### PR TITLE
[codex] add native macOS app dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ tokdash serve
 
 Open: `http://localhost:55423`
 
+### macOS app
+
+Tokdash can generate a local native `Tokdash.app` dashboard for macOS:
+
+```bash
+pip install tokdash
+tokdash macos-app --output ~/Applications --force
+open ~/Applications/Tokdash.app
+```
+
+The app opens its own macOS window and reads Tokdash usage data directly from local session files. It does not start the HTTP server and does not open a browser.
+
+When Xcode's Swift compiler is available, Tokdash builds a SwiftUI app that uses system material effects and adopts Liquid Glass on macOS 26+. If Swift is unavailable, it falls back to a lightweight Tk-based native window.
+
+The generated app uses the Python environment that created it. If you upgrade or move that Python environment, regenerate the app with `tokdash macos-app --force`.
+
 ### Run (from source)
 
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -57,6 +57,22 @@ tokdash serve
 
 打开：`http://localhost:55423`
 
+### macOS App
+
+Tokdash 可以生成一个本地原生 `Tokdash.app` 仪表盘：
+
+```bash
+pip install tokdash
+tokdash macos-app --output ~/Applications --force
+open ~/Applications/Tokdash.app
+```
+
+这个 App 会打开自己的 macOS 窗口，并直接从本地 session 文件读取 Tokdash 用量数据。它不会启动 HTTP 服务，也不会打开浏览器。
+
+如果系统里有 Xcode 的 Swift 编译器，Tokdash 会生成 SwiftUI App，并在 macOS 26+ 上采用系统 Liquid Glass 效果。如果没有 Swift 编译器，则回退到轻量的 Tk 原生窗口。
+
+生成的 App 会使用创建它时的 Python 环境。如果你升级或移动了该 Python 环境，请重新运行 `tokdash macos-app --force` 生成 App。
+
 ### 从源码运行
 
 ```bash

--- a/src/tokdash/cli.py
+++ b/src/tokdash/cli.py
@@ -9,6 +9,7 @@ import uvicorn
 
 from .api import app
 from .compute import compute_usage
+from .macos_app import create_macos_app_bundle
 
 
 def _port_type(value: str) -> int:
@@ -37,7 +38,7 @@ def build_parser(prog: str) -> argparse.ArgumentParser:
         "command",
         nargs="?",
         default="serve",
-        choices=["serve", "export"],
+        choices=["serve", "export", "macos-app"],
         help="Command (default: serve)",
     )
 
@@ -80,7 +81,17 @@ def build_parser(prog: str) -> argparse.ArgumentParser:
     parser.add_argument(
         "--output",
         type=str,
-        help="Write output to a file instead of stdout",
+        help="Export: write JSON to a file. macos-app: output .app path or parent directory.",
+    )
+    parser.add_argument(
+        "--app-name",
+        default="Tokdash",
+        help='macos-app: app bundle name (default: "Tokdash")',
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="macos-app: replace an existing app bundle",
     )
 
     return parser
@@ -102,6 +113,12 @@ def export(period: str, pretty: bool, output: str | None) -> None:
         print(payload)
 
 
+def macos_app(output: str | None, app_name: str, force: bool) -> None:
+    path = create_macos_app_bundle(output, app_name=app_name, force=force)
+    print(f"Created macOS app: {path}")
+    print(f"Open it with: open {path}")
+
+
 def cli(argv: list[str] | None = None, prog: str = "tokdash") -> int:
     parser = build_parser(prog=prog)
     args = parser.parse_args(argv)
@@ -113,6 +130,10 @@ def cli(argv: list[str] | None = None, prog: str = "tokdash") -> int:
 
     if args.command == "export":
         export(args.period, args.pretty, args.output)
+        return 0
+
+    if args.command == "macos-app":
+        macos_app(args.output, args.app_name, args.force)
         return 0
 
     parser.error(f"Unknown command: {args.command}")

--- a/src/tokdash/compute.py
+++ b/src/tokdash/compute.py
@@ -426,10 +426,9 @@ def _compute_previous_period_range(period: str) -> tuple[datetime, datetime]:
     current_since, current_until = _current_period_range(period)
     if period == "month":
         prev_until = current_since
-        prev_until_local = prev_until.astimezone()
-        prev_month_anchor = prev_until_local - timedelta(days=1)
-        prev_since_local = prev_month_anchor.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-        return prev_since_local.astimezone(timezone.utc), prev_until
+        prev_month_anchor = prev_until - timedelta(microseconds=1)
+        prev_since = prev_month_anchor.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        return prev_since, prev_until
 
     if period_to_days(period) == 1:
         prev_since = current_since - timedelta(days=1)

--- a/src/tokdash/macos_app.py
+++ b/src/tokdash/macos_app.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import os
+import plistlib
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+DEFAULT_APP_NAME = "Tokdash"
+DEFAULT_BUNDLE_ID = "io.github.jingbiaomei.tokdash.native"
+
+
+def _write_icon(resources_dir: Path) -> str | None:
+    icon_png = Path(__file__).resolve().parent / "static" / "icons" / "icon-512.png"
+    if not icon_png.exists():
+        return None
+
+    iconset = resources_dir / "Tokdash.iconset"
+    iconset.mkdir(parents=True, exist_ok=True)
+    sizes = [
+        (16, "icon_16x16.png"),
+        (32, "icon_16x16@2x.png"),
+        (32, "icon_32x32.png"),
+        (64, "icon_32x32@2x.png"),
+        (128, "icon_128x128.png"),
+        (256, "icon_128x128@2x.png"),
+        (256, "icon_256x256.png"),
+        (512, "icon_256x256@2x.png"),
+        (512, "icon_512x512.png"),
+    ]
+
+    try:
+        for size, name in sizes:
+            subprocess.run(
+                ["sips", "-z", str(size), str(size), str(icon_png), "--out", str(iconset / name)],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        subprocess.run(
+            ["iconutil", "-c", "icns", str(iconset), "-o", str(resources_dir / "Tokdash.icns")],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        shutil.copy2(icon_png, resources_dir / "icon-512.png")
+        shutil.rmtree(iconset, ignore_errors=True)
+        return None
+
+    shutil.rmtree(iconset, ignore_errors=True)
+    return "Tokdash.icns"
+
+
+def _write_info_plist(contents_dir: Path, app_name: str, executable_name: str, icon_file: str | None) -> None:
+    info = {
+        "CFBundleDevelopmentRegion": "en",
+        "CFBundleDisplayName": app_name,
+        "CFBundleExecutable": executable_name,
+        "CFBundleIdentifier": DEFAULT_BUNDLE_ID,
+        "CFBundleInfoDictionaryVersion": "6.0",
+        "CFBundleName": app_name,
+        "CFBundlePackageType": "APPL",
+        "CFBundleShortVersionString": "1.0",
+        "CFBundleVersion": "1",
+        "LSMinimumSystemVersion": "10.15",
+        "NSHighResolutionCapable": True,
+    }
+    if icon_file:
+        info["CFBundleIconFile"] = icon_file
+    with (contents_dir / "Info.plist").open("wb") as handle:
+        plistlib.dump(info, handle)
+
+
+def _copy_python_resources(resources_dir: Path) -> Path:
+    bundled_python_dir = resources_dir / "python"
+    bundled_python_dir.mkdir(parents=True)
+    shutil.copytree(
+        Path(__file__).resolve().parent,
+        bundled_python_dir / "tokdash",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+    return bundled_python_dir
+
+
+def _swift_source(app_name: str, python_executable: str) -> str:
+    return f"""
+import SwiftUI
+import Foundation
+
+struct Metric: Decodable, Identifiable {{
+    var id: String {{ label }}
+    let label: String
+    let value: String
+    let delta: String
+}}
+
+struct AppRow: Decodable, Identifiable {{
+    var id: String {{ name }}
+    let name: String
+    let tokens: String
+    let tokens_raw: Int
+    let cost: String
+    let messages: String
+}}
+
+struct ModelRow: Decodable, Identifiable {{
+    var id: String {{ name }}
+    let name: String
+    let tokens: String
+    let tokens_raw: Int
+    let input: String
+    let output: String
+    let cache: String
+    let cost: String
+}}
+
+struct DashboardData: Decodable {{
+    let period: String
+    let refreshed: String
+    let range_label: String
+    let date_from: String
+    let date_to: String
+    let metrics: [Metric]
+    let breakdown: [AppRow]
+    let models: [ModelRow]
+}}
+
+@main
+struct {app_name}App: App {{
+    var body: some Scene {{
+        WindowGroup {{
+            DashboardView()
+                .frame(minWidth: 920, minHeight: 640)
+        }}
+        .windowStyle(.hiddenTitleBar)
+    }}
+}}
+
+struct DashboardView: View {{
+    @State private var selectedPeriod = "today"
+    @State private var dashboard: DashboardData?
+    @State private var errorMessage: String?
+    @State private var isLoading = false
+
+    private let periods = [("Today", "today"), ("Last 7 Days", "week"), ("This Month", "month")]
+
+    var body: some View {{
+        ZStack {{
+            MeshGradient(width: 3, height: 3, points: [
+                [0.0, 0.0], [0.5, 0.0], [1.0, 0.0],
+                [0.0, 0.5], [0.55, 0.45], [1.0, 0.55],
+                [0.0, 1.0], [0.5, 1.0], [1.0, 1.0]
+            ], colors: [
+                Color(red: 0.92, green: 0.96, blue: 0.93),
+                Color(red: 0.98, green: 0.91, blue: 0.78),
+                Color(red: 0.82, green: 0.91, blue: 0.95),
+                Color(red: 0.95, green: 0.97, blue: 0.92),
+                Color(red: 1.00, green: 0.98, blue: 0.90),
+                Color(red: 0.88, green: 0.94, blue: 0.91),
+                Color(red: 0.90, green: 0.88, blue: 0.82),
+                Color(red: 0.77, green: 0.88, blue: 0.83),
+                Color(red: 0.96, green: 0.93, blue: 0.86)
+            ])
+            .ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 22) {{
+                header
+                if let dashboard {{
+                    metricGrid(dashboard)
+                    HStack(alignment: .top, spacing: 18) {{
+                        modelPanel(dashboard)
+                        appPanel(dashboard)
+                    }}
+                    footer(dashboard)
+                }} else {{
+                    ContentUnavailableView("No usage data", systemImage: "chart.bar.xaxis")
+                        .tokdashGlass(cornerRadius: 28)
+                }}
+            }}
+            .padding(28)
+        }}
+        .task {{ load() }}
+    }}
+
+    private var header: some View {{
+        HStack(alignment: .top) {{
+            VStack(alignment: .leading, spacing: 4) {{
+                Text("Tokdash")
+                    .font(.system(size: 34, weight: .bold, design: .rounded))
+                Text("Local AI coding usage")
+                    .foregroundStyle(.secondary)
+            }}
+            Spacer()
+            Picker("Range", selection: $selectedPeriod) {{
+                ForEach(periods, id: \\.1) {{ label, value in
+                    Text(label).tag(value)
+                }}
+            }}
+            .pickerStyle(.segmented)
+            .frame(width: 330)
+            .onChange(of: selectedPeriod) {{ _, _ in load() }}
+
+            Button {{ load() }} label: {{
+                Label(isLoading ? "Refreshing" : "Refresh", systemImage: "arrow.clockwise")
+            }}
+            .buttonStyle(.borderedProminent)
+        }}
+    }}
+
+    private func metricGrid(_ data: DashboardData) -> some View {{
+        HStack(spacing: 14) {{
+            ForEach(data.metrics) {{ metric in
+                VStack(alignment: .leading, spacing: 8) {{
+                    Text(metric.label.uppercased())
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(metric.value)
+                        .font(.system(size: 34, weight: .bold, design: .rounded))
+                        .contentTransition(.numericText())
+                    Text(metric.delta)
+                        .font(.caption)
+                        .foregroundStyle(metric.delta.hasPrefix("+") ? .green : .secondary)
+                }}
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(18)
+                .tokdashGlass(cornerRadius: 26)
+            }}
+        }}
+    }}
+
+    private func modelPanel(_ data: DashboardData) -> some View {{
+        VStack(alignment: .leading, spacing: 14) {{
+            Text("Model Flow")
+                .font(.title3.bold())
+            ForEach(data.models.prefix(8)) {{ model in
+                modelBar(model, maxTokens: maxModelTokens(data.models))
+            }}
+        }}
+        .padding(18)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .tokdashGlass(cornerRadius: 30)
+    }}
+
+    private func modelBar(_ model: ModelRow, maxTokens: Int) -> some View {{
+        VStack(alignment: .leading, spacing: 6) {{
+            HStack {{
+                Text(model.name)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+                Spacer()
+                Text(model.tokens)
+                    .font(.subheadline.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }}
+            GeometryReader {{ proxy in
+                ZStack(alignment: .leading) {{
+                    Capsule().fill(.white.opacity(0.34))
+                    Capsule()
+                        .fill(LinearGradient(colors: [.green.opacity(0.75), .teal.opacity(0.78)], startPoint: .leading, endPoint: .trailing))
+                        .frame(width: max(8, proxy.size.width * CGFloat(Double(model.tokens_raw) / Double(max(maxTokens, 1)))))
+                }}
+            }}
+            .frame(height: 12)
+            HStack(spacing: 12) {{
+                Text("In \\(model.input)")
+                Text("Out \\(model.output)")
+                Text("Cache \\(model.cache)")
+                Spacer()
+                Text(model.cost)
+            }}
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }}
+    }}
+
+    private func appPanel(_ data: DashboardData) -> some View {{
+        VStack(alignment: .leading, spacing: 14) {{
+            Text("Apps")
+                .font(.title3.bold())
+            ForEach(data.breakdown.prefix(8)) {{ app in
+                HStack(spacing: 12) {{
+                    Circle()
+                        .fill(.teal.opacity(0.64))
+                        .frame(width: 10, height: 10)
+                    VStack(alignment: .leading, spacing: 2) {{
+                        Text(app.name)
+                            .font(.subheadline.weight(.semibold))
+                        Text("\\(app.messages) messages")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }}
+                    Spacer()
+                    VStack(alignment: .trailing, spacing: 2) {{
+                        Text(app.tokens)
+                            .font(.subheadline.monospacedDigit())
+                        Text(app.cost)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }}
+                }}
+                Divider().opacity(0.35)
+            }}
+        }}
+        .padding(18)
+        .frame(minWidth: 300, idealWidth: 300, maxWidth: 300, maxHeight: .infinity, alignment: .topLeading)
+        .tokdashGlass(cornerRadius: 30)
+    }}
+
+    private func footer(_ data: DashboardData) -> some View {{
+        HStack {{
+            Text("\\(data.range_label) · \\(data.date_from) to \\(data.date_to)")
+            Spacer()
+            if let errorMessage {{
+                Text(errorMessage).foregroundStyle(.red)
+            }} else {{
+                Text("Updated \\(data.refreshed)")
+            }}
+        }}
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }}
+
+    private func maxModelTokens(_ models: [ModelRow]) -> Int {{
+        max(models.map(\\.tokens_raw).max() ?? 1, 1)
+    }}
+
+    private func load() {{
+        let period = selectedPeriod
+        isLoading = true
+        errorMessage = nil
+        Task.detached {{
+            do {{
+                let data = try loadDashboardData(period: period)
+                await MainActor.run {{
+                    withAnimation(.smooth(duration: 0.32)) {{
+                        dashboard = data
+                        isLoading = false
+                    }}
+                }}
+            }} catch {{
+                await MainActor.run {{
+                    errorMessage = error.localizedDescription
+                    isLoading = false
+                }}
+            }}
+        }}
+    }}
+
+    nonisolated private func loadDashboardData(period: String) throws -> DashboardData {{
+        guard let resourcePath = Bundle.main.resourcePath else {{
+            throw NSError(domain: "Tokdash", code: 1, userInfo: [NSLocalizedDescriptionKey: "Missing app resources"])
+        }}
+        let pythonRoot = URL(fileURLWithPath: resourcePath).appendingPathComponent("python").path
+        let code = "import sys; sys.path.insert(0, '\\(pythonRoot)'); from tokdash.macos_native_app import json_main; raise SystemExit(json_main())"
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "{python_executable}")
+        process.arguments = ["-c", code, period]
+        let pipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = errorPipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        if process.terminationStatus != 0 {{
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            let message = String(data: errorData, encoding: .utf8) ?? "Python helper failed"
+            throw NSError(domain: "Tokdash", code: Int(process.terminationStatus), userInfo: [NSLocalizedDescriptionKey: message])
+        }}
+        return try JSONDecoder().decode(DashboardData.self, from: data)
+    }}
+}}
+
+extension View {{
+    @ViewBuilder
+    func tokdashGlass(cornerRadius: CGFloat) -> some View {{
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        if #available(macOS 26.0, *) {{
+            self.glassEffect(.regular.interactive(), in: shape)
+        }} else {{
+            self.background(.regularMaterial, in: shape)
+                .overlay(shape.stroke(.white.opacity(0.34), lineWidth: 1))
+        }}
+    }}
+}}
+"""
+
+
+def _create_swiftui_app(output_path: Path, app_name: str, python_executable: str) -> bool:
+    swiftc = shutil.which("swiftc")
+    if not swiftc:
+        return False
+
+    contents_dir = output_path / "Contents"
+    macos_dir = contents_dir / "MacOS"
+    resources_dir = contents_dir / "Resources"
+    macos_dir.mkdir(parents=True)
+    resources_dir.mkdir(parents=True)
+    _copy_python_resources(resources_dir)
+    icon_file = _write_icon(resources_dir)
+    _write_info_plist(contents_dir, app_name, app_name, icon_file)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        source = Path(tmp) / f"{app_name}.swift"
+        source.write_text(_swift_source(app_name, python_executable), encoding="utf-8")
+        try:
+            subprocess.run([swiftc, "-parse-as-library", str(source), "-o", str(macos_dir / app_name)], check=True)
+        except Exception:
+            return False
+    return True
+
+
+def _create_shell_script_app(output_path: Path, app_name: str) -> None:
+    contents_dir = output_path / "Contents"
+    macos_dir = contents_dir / "MacOS"
+    resources_dir = contents_dir / "Resources"
+    macos_dir.mkdir(parents=True)
+    resources_dir.mkdir(parents=True)
+    _copy_python_resources(resources_dir)
+
+    icon_file = _write_icon(resources_dir)
+    _write_info_plist(contents_dir, app_name, app_name, icon_file)
+
+    executable = macos_dir / app_name
+    import_root = contents_dir / "Resources" / "python"
+    launcher_code = (
+        "import sys; "
+        f"sys.path.insert(0, {str(import_root)!r}); "
+        "from tokdash.macos_native_app import main; "
+        "raise SystemExit(main())"
+    )
+    executable.write_text(
+        f"""#!/bin/sh
+exec "{sys.executable}" -c "{launcher_code}" "$@" >>/tmp/tokdash-native-app.log 2>&1
+""",
+        encoding="utf-8",
+    )
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def create_macos_app_bundle(
+    output: str | os.PathLike[str] | None = None,
+    *,
+    app_name: str = DEFAULT_APP_NAME,
+    force: bool = False,
+) -> Path:
+    output_path = Path(output).expanduser() if output else Path.cwd() / f"{app_name}.app"
+    output_path = output_path.resolve()
+    if output_path.suffix != ".app":
+        output_path = output_path / f"{app_name}.app"
+
+    if output_path.exists():
+        if not force:
+            raise FileExistsError(f"{output_path} already exists. Use --force to replace it.")
+        shutil.rmtree(output_path)
+
+    if not _create_swiftui_app(output_path, app_name, sys.executable):
+        if output_path.exists():
+            shutil.rmtree(output_path)
+        _create_shell_script_app(output_path, app_name)
+    return output_path

--- a/src/tokdash/macos_native_app.py
+++ b/src/tokdash/macos_native_app.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from datetime import timedelta
+from typing import Any
+
+from .compute import compute_usage_with_comparison
+
+
+PERIODS = {
+    "Today": "today",
+    "Last 7 Days": "week",
+    "This Month": "month",
+}
+
+
+def _int_value(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except Exception:
+        return 0
+
+
+def _float_value(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except Exception:
+        return 0.0
+
+
+def format_tokens(value: Any) -> str:
+    number = _int_value(value)
+    if number >= 1_000_000:
+        return f"{number / 1_000_000:.2f}M"
+    if number >= 1_000:
+        return f"{number / 1_000:.1f}K"
+    return f"{number:,}"
+
+
+def format_money(value: Any) -> str:
+    return f"${_float_value(value):,.2f}"
+
+
+def format_delta(value: Any) -> str:
+    if value is None:
+        return "No previous data"
+    number = _float_value(value)
+    sign = "+" if number > 0 else ""
+    return f"{sign}{number:.1f}% vs previous"
+
+
+def _date_range_for_period(period: str) -> tuple[str, str, str]:
+    today = datetime.now().astimezone().date()
+    if period == "week":
+        start = today - timedelta(days=6)
+        return start.isoformat(), today.isoformat(), "Last 7 days"
+    if period == "month":
+        start = today.replace(day=1)
+        return start.isoformat(), today.isoformat(), "This month"
+    return today.isoformat(), today.isoformat(), "Today"
+
+
+def compute_native_dashboard_data(period: str) -> dict[str, Any]:
+    date_from, date_to, range_label = _date_range_for_period(period)
+    data = compute_usage_with_comparison(period, date_from, date_to)
+    view_model = build_dashboard_view_model(data)
+    view_model["date_from"] = date_from
+    view_model["date_to"] = date_to
+    view_model["range_label"] = range_label
+    return view_model
+
+
+def build_dashboard_view_model(data: dict[str, Any]) -> dict[str, Any]:
+    models = data.get("combined_models") or data.get("top_models") or []
+    apps = data.get("apps") or {}
+    comparison = data.get("comparison") or {}
+    timestamp = data.get("timestamp")
+    refreshed = "Just now"
+    if timestamp:
+        try:
+            refreshed = datetime.fromisoformat(timestamp).strftime("%H:%M")
+        except ValueError:
+            refreshed = str(timestamp)
+
+    return {
+        "period": data.get("period", "today"),
+        "refreshed": refreshed,
+        "metrics": [
+            {
+                "label": "Total tokens",
+                "value": format_tokens(data.get("total_tokens")),
+                "delta": format_delta(comparison.get("tokens_pct")),
+            },
+            {
+                "label": "Estimated cost",
+                "value": format_money(data.get("total_cost")),
+                "delta": format_delta(comparison.get("cost_pct")),
+            },
+            {
+                "label": "Messages",
+                "value": f"{_int_value(data.get('total_messages')):,}",
+                "delta": format_delta(comparison.get("messages_pct")),
+            },
+        ],
+        "breakdown": [
+            {
+                "name": name,
+                "tokens": format_tokens(row.get("tokens")),
+                "tokens_raw": _int_value(row.get("tokens")),
+                "cost": format_money(row.get("cost")),
+                "messages": f"{_int_value(row.get('messages')):,}",
+            }
+            for name, row in sorted(apps.items(), key=lambda item: _int_value(item[1].get("tokens")), reverse=True)
+        ],
+        "models": [
+            {
+                "name": row.get("name", "unknown"),
+                "tokens": format_tokens(row.get("tokens")),
+                "tokens_raw": _int_value(row.get("tokens")),
+                "input": format_tokens(row.get("tokens_in")),
+                "output": format_tokens(row.get("tokens_out")),
+                "cache": format_tokens(row.get("tokens_cache")),
+                "cost": format_money(row.get("cost")),
+            }
+            for row in models[:12]
+        ],
+    }
+
+
+class TokdashNativeApp:
+    def __init__(self, root: Any):
+        import tkinter as tk
+        from tkinter import ttk
+
+        self.tk = tk
+        self.ttk = ttk
+        self.root = root
+        self.period = "today"
+        self.colors = {
+            "bg": "#f6f3ee",
+            "panel": "#fffaf2",
+            "ink": "#221f1a",
+            "muted": "#766f64",
+            "line": "#ddd2c2",
+            "accent": "#2f6f5e",
+            "accent_weak": "#d9ebe3",
+            "warn": "#a45f2b",
+        }
+        self.period_buttons: dict[str, Any] = {}
+        self.metric_value_labels: list[Any] = []
+        self.metric_delta_labels: list[Any] = []
+        self.status_var = tk.StringVar(value="Loading")
+        self.error_var = tk.StringVar(value="")
+        self.metric_title_labels: list[Any] = []
+
+        self.root.title("Tokdash")
+        self.root.geometry("980x680")
+        self.root.minsize(760, 560)
+        self.root.configure(bg=self.colors["bg"])
+        self._configure_styles()
+        self._build_layout()
+        self.refresh()
+
+    def _configure_styles(self) -> None:
+        style = self.ttk.Style()
+        style.theme_use("clam")
+        style.configure("Treeview", background=self.colors["panel"], fieldbackground=self.colors["panel"], rowheight=28)
+        style.configure("Treeview.Heading", background=self.colors["bg"], foreground=self.colors["muted"], relief="flat")
+        style.map("Treeview", background=[("selected", self.colors["accent_weak"])], foreground=[("selected", self.colors["ink"])])
+
+    def _frame(self, parent: Any, **kwargs: Any) -> Any:
+        return self.tk.Frame(parent, bg=kwargs.pop("bg", self.colors["bg"]), **kwargs)
+
+    def _label(self, parent: Any, text: str = "", **kwargs: Any) -> Any:
+        return self.tk.Label(parent, text=text, bg=kwargs.pop("bg", self.colors["bg"]), fg=kwargs.pop("fg", self.colors["ink"]), **kwargs)
+
+    def _build_layout(self) -> None:
+        shell = self._frame(self.root, padx=28, pady=24)
+        shell.pack(fill="both", expand=True)
+
+        header = self._frame(shell)
+        header.pack(fill="x")
+        title_stack = self._frame(header)
+        title_stack.pack(side="left", fill="x", expand=True)
+        self._label(title_stack, "Tokdash", font=("Avenir Next", 30, "bold")).pack(anchor="w")
+        self._label(
+            title_stack,
+            "Local AI coding usage",
+            fg=self.colors["muted"],
+            font=("Avenir Next", 13),
+        ).pack(anchor="w", pady=(2, 0))
+
+        controls = self._frame(header)
+        controls.pack(side="right", anchor="n")
+        for label, value in PERIODS.items():
+            btn = self.tk.Button(
+                controls,
+                text=label,
+                command=lambda period=value: self.set_period(period),
+                bd=0,
+                padx=14,
+                pady=8,
+                cursor="pointinghand",
+                font=("Avenir Next", 12, "bold"),
+            )
+            btn.pack(side="left", padx=(0, 6))
+            self.period_buttons[value] = btn
+        self.tk.Button(
+            controls,
+            text="Refresh",
+            command=self.refresh,
+            bg=self.colors["ink"],
+            fg=self.colors["panel"],
+            activebackground=self.colors["accent"],
+            activeforeground=self.colors["panel"],
+            bd=0,
+            padx=16,
+            pady=8,
+            cursor="pointinghand",
+            font=("Avenir Next", 12, "bold"),
+        ).pack(side="left")
+
+        metrics = self._frame(shell)
+        metrics.pack(fill="x", pady=(30, 22))
+        for index in range(3):
+            panel = self._frame(metrics, bg=self.colors["panel"], padx=18, pady=16, highlightbackground=self.colors["line"], highlightthickness=1)
+            panel.pack(side="left", fill="x", expand=True, padx=(0 if index == 0 else 10, 0))
+            title = self._label(panel, "", bg=self.colors["panel"], fg=self.colors["muted"], font=("Avenir Next", 12, "bold"))
+            title.pack(anchor="w")
+            value = self._label(panel, "0", bg=self.colors["panel"], font=("Avenir Next", 28, "bold"))
+            value.pack(anchor="w", pady=(8, 4))
+            delta = self._label(panel, "", bg=self.colors["panel"], fg=self.colors["muted"], font=("Avenir Next", 11))
+            delta.pack(anchor="w")
+            self.metric_title_labels.append(title)
+            self.metric_value_labels.append(value)
+            self.metric_delta_labels.append(delta)
+
+        body = self._frame(shell)
+        body.pack(fill="both", expand=True)
+
+        left = self._frame(body)
+        left.pack(side="left", fill="both", expand=True, padx=(0, 14))
+        right = self._frame(body)
+        right.pack(side="right", fill="both", expand=True)
+
+        self._label(left, "Models", font=("Avenir Next", 16, "bold")).pack(anchor="w", pady=(0, 8))
+        self.models_tree = self.ttk.Treeview(left, columns=("model", "tokens", "input", "output", "cache", "cost"), show="headings")
+        self._setup_tree(
+            self.models_tree,
+            [("model", "Model"), ("tokens", "Tokens"), ("input", "Input"), ("output", "Output"), ("cache", "Cache"), ("cost", "Cost")],
+        )
+        self.models_tree.pack(fill="both", expand=True)
+
+        self._label(right, "Apps", font=("Avenir Next", 16, "bold")).pack(anchor="w", pady=(0, 8))
+        self.apps_tree = self.ttk.Treeview(right, columns=("app", "tokens", "cost", "messages"), show="headings", height=8)
+        self._setup_tree(self.apps_tree, [("app", "App"), ("tokens", "Tokens"), ("cost", "Cost"), ("messages", "Messages")])
+        self.apps_tree.pack(fill="both", expand=True)
+
+        footer = self._frame(shell)
+        footer.pack(fill="x", pady=(14, 0))
+        self._label(footer, textvariable=self.status_var, fg=self.colors["muted"], font=("Avenir Next", 11)).pack(side="left")
+        self._label(footer, textvariable=self.error_var, fg=self.colors["warn"], font=("Avenir Next", 11)).pack(side="right")
+
+    def _setup_tree(self, tree: Any, columns: list[tuple[str, str]]) -> None:
+        for key, label in columns:
+            tree.heading(key, text=label)
+            anchor = "w" if key in {"model", "app"} else "e"
+            width = 220 if key == "model" else 110
+            tree.column(key, width=width, anchor=anchor, stretch=True)
+
+    def _update_period_buttons(self) -> None:
+        for period, button in self.period_buttons.items():
+            selected = period == self.period
+            button.configure(
+                bg=self.colors["accent"] if selected else self.colors["accent_weak"],
+                fg=self.colors["panel"] if selected else self.colors["ink"],
+                activebackground=self.colors["accent"],
+                activeforeground=self.colors["panel"],
+            )
+
+    def set_period(self, period: str) -> None:
+        self.period = period
+        self.refresh()
+
+    def refresh(self) -> None:
+        self._update_period_buttons()
+        self.status_var.set("Refreshing")
+        self.error_var.set("")
+        self.root.update_idletasks()
+        try:
+            view_model = compute_native_dashboard_data(self.period)
+        except Exception as exc:
+            self.error_var.set(str(exc))
+            self.status_var.set("Refresh failed")
+            return
+
+        for index, metric in enumerate(view_model["metrics"]):
+            self.metric_title_labels[index].configure(text=metric["label"])
+            self.metric_value_labels[index].configure(text=metric["value"])
+            self.metric_delta_labels[index].configure(text=metric["delta"])
+
+        self._replace_tree_rows(
+            self.models_tree,
+            [
+                (row["name"], row["tokens"], row["input"], row["output"], row["cache"], row["cost"])
+                for row in view_model["models"]
+            ],
+        )
+        self._replace_tree_rows(
+            self.apps_tree,
+            [(row["name"], row["tokens"], row["cost"], row["messages"]) for row in view_model["breakdown"]],
+        )
+        self.status_var.set(f"{view_model['range_label']} · Updated {view_model['refreshed']}")
+
+    def _replace_tree_rows(self, tree: Any, rows: list[tuple[Any, ...]]) -> None:
+        tree.delete(*tree.get_children())
+        for row in rows:
+            if not row:
+                continue
+            tree.insert("", "end", values=tuple(row))
+
+
+def main() -> int:
+    import tkinter as tk
+
+    root = tk.Tk()
+    TokdashNativeApp(root)
+    root.mainloop()
+    return 0
+
+
+def json_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Emit native Tokdash dashboard data as JSON")
+    parser.add_argument("period", nargs="?", default="today", choices=["today", "week", "month"])
+    args = parser.parse_args(argv)
+    print(json.dumps(compute_native_dashboard_data(args.period)))
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    if "--json" in sys.argv:
+        sys.argv.remove("--json")
+        raise SystemExit(json_main())
+    raise SystemExit(main())

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -1,0 +1,69 @@
+import plistlib
+
+from tokdash.macos_native_app import build_dashboard_view_model
+from tokdash.macos_app import create_macos_app_bundle
+
+
+def test_create_macos_app_bundle(tmp_path):
+    app_path = create_macos_app_bundle(tmp_path, force=True)
+
+    assert app_path.name == "Tokdash.app"
+    assert (app_path / "Contents" / "Info.plist").exists()
+
+    info = plistlib.loads((app_path / "Contents" / "Info.plist").read_bytes())
+    assert info["CFBundleName"] == "Tokdash"
+    assert info["CFBundlePackageType"] == "APPL"
+
+    executable = app_path / "Contents" / "MacOS" / info["CFBundleExecutable"]
+    assert executable.exists()
+    assert executable.stat().st_mode & 0o111
+    assert (app_path / "Contents" / "Resources" / "python" / "tokdash" / "macos_native_app.py").exists()
+
+
+def test_build_dashboard_view_model_formats_usage_data():
+    view_model = build_dashboard_view_model(
+        {
+            "period": "today",
+            "total_tokens": 1234567,
+            "total_cost": 3.2,
+            "total_messages": 42,
+            "timestamp": "2026-05-06T10:30:00",
+            "comparison": {"tokens_pct": 12.5, "cost_pct": -4.0, "messages_pct": None},
+            "apps": {
+                "codex": {"tokens": 1200000, "cost": 3.1, "messages": 40},
+                "claude": {"tokens": 34567, "cost": 0.1, "messages": 2},
+            },
+            "combined_models": [
+                {
+                    "name": "gpt-5.5",
+                    "tokens": 1234567,
+                    "tokens_in": 200000,
+                    "tokens_out": 34567,
+                    "tokens_cache": 1000000,
+                    "cost": 3.2,
+                }
+            ],
+        }
+    )
+
+    assert view_model["metrics"][0] == {
+        "label": "Total tokens",
+        "value": "1.23M",
+        "delta": "+12.5% vs previous",
+    }
+    assert view_model["metrics"][1] == {
+        "label": "Estimated cost",
+        "value": "$3.20",
+        "delta": "-4.0% vs previous",
+    }
+    assert view_model["metrics"][2] == {"label": "Messages", "value": "42", "delta": "No previous data"}
+    assert view_model["breakdown"][0]["name"] == "codex"
+    assert view_model["models"][0] == {
+        "name": "gpt-5.5",
+        "tokens": "1.23M",
+        "tokens_raw": 1234567,
+        "input": "200.0K",
+        "output": "34.6K",
+        "cache": "1.00M",
+        "cost": "$3.20",
+    }


### PR DESCRIPTION
## Summary

- add `tokdash macos-app` to generate a native macOS `Tokdash.app`
- prefer a compiled SwiftUI app when `swiftc` is available, using system material and `glassEffect` on macOS 26+
- fall back to a lightweight Tk native dashboard when Swift is unavailable
- read usage directly from local session files through Tokdash compute helpers, without starting the HTTP server or opening a browser
- use explicit local date ranges for Today / Last 7 Days / This Month so the native app matches the web dashboard quick-range semantics
- add visual model bars and app breakdown rows in the native dashboard
- document the macOS app flow in English and Chinese READMEs
- fix the previous-month period calculation so the existing month semantics test passes consistently

## Validation

- `PYTHONPATH=src /Users/oreo/miniconda3/bin/python -m pytest -q`
- `PYTHONPATH=src /Users/oreo/miniconda3/bin/python -m pytest tests/test_macos_app.py tests/test_package_metadata.py tests/test_period_semantics.py -q`
- `PYTHONPATH=src /Users/oreo/miniconda3/bin/python -m tokdash.macos_native_app --json today`
- generated `dist/Tokdash.app` with `tokdash macos-app --output ./dist --force`
- confirmed the generated app is a Mach-O SwiftUI executable when Xcode Swift is available
- launched the generated app with `open dist/Tokdash.app` and confirmed it starts `Contents/MacOS/Tokdash` without opening a browser or starting the localhost server
