### PR TITLE
[codex] Add native Windows support seams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10", "3.12"]
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Nothing is uploaded; nothing is read from your machine.
 
 - **Linux (including WSL2):** supported
 - **macOS:** experimental
+- **Windows (native):** in progress — foreground `tokdash serve` support and a Windows Task Scheduler backend for `tokdash setup` are implemented in this branch, but still need real-Windows validation before release. Until then, prefer WSL2 for fully verified support, or treat native Windows as experimental. See [`docs/WINDOWS_SUPPORT_PLAN.md`](docs/WINDOWS_SUPPORT_PLAN.md) for the tiered rollout and current status.
 
 ## Quick start
 
@@ -224,6 +225,13 @@ serve other tools there. After Serve succeeds, setup prints the exact
 Tailscale Serve is read-only for mutating dashboard/API actions because proxied requests fail
 Tokdash's loopback write gate. Use SSH forwarding when you need trusted remote writes.
 
+**Tailscale on Windows:** the Windows Tailscale client installs both a GUI and a `tailscale`
+CLI, and `tailscale serve` works the same way from PowerShell/cmd once the client is
+running. This has not yet been verified against Tokdash's native Windows support
+(implemented in this branch but not real-Windows validated — see
+[Platform support](#platform-support)), so treat it as experimental
+until confirmed.
+
 Binding Tokdash directly to `0.0.0.0` is possible but not recommended because the local API is
 not an internet-facing authenticated service.
 
@@ -273,8 +281,9 @@ The local API can power a statusline item in your coding agent (Claude Code, etc
 
 - [`statusline-minimal.sh`](docs/examples/statusline/statusline-minimal.sh) → one line: `[Claude Sonnet 4.6] 📁 myproject | 📊 12.3M ($4.56) today`
 - [`statusline-full.sh`](docs/examples/statusline/statusline-full.sh) → a four-row dashboard with today + week totals and a top-3 per-tool breakdown
+- [`statusline.ps1`](docs/examples/statusline/statusline.ps1) → the same one-line output as the minimal template, for Claude Code running natively on Windows (PowerShell, no `curl`/`jq` needed)
 
-Both are read-only, localhost-only, and fail silently if Tokdash isn't running. See the [folder README](docs/examples/statusline/README.md) for install/config and [`docs/API.md`](docs/API.md) for the endpoint reference.
+All are read-only, localhost-only, and fail silently if Tokdash isn't running. See the [folder README](docs/examples/statusline/README.md) for install/config and [`docs/API.md`](docs/API.md) for the endpoint reference.
 
 Prefer to roll your own? Hand your agent this prompt and point it at [`docs/API.md`](docs/API.md):
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -101,6 +101,10 @@ Demo 源码：[tokdash/tokdash.github.io](https://github.com/tokdash/tokdash.git
 
 - **Linux（含 WSL2）**：支持
 - **macOS**：实验性支持
+- **Windows（原生）**：进行中 —— 前台 `tokdash serve` 支持和 `tokdash setup` 的 Windows
+  任务计划程序（Task Scheduler）后台服务已在本分支实现，但发布前仍需要真实 Windows 环境验证。
+  在此之前，完整验证过的 Windows 体验仍建议使用 WSL2；原生 Windows 请按实验性支持看待。分阶段计划与当前状态见
+  [`docs/WINDOWS_SUPPORT_PLAN.md`](docs/WINDOWS_SUPPORT_PLAN.md)（英文）。
 
 ## 快速开始
 
@@ -216,6 +220,11 @@ Serve 配置，交互式向导会提示是否运行一次性的 `sudo tailscale 
 Tailscale Serve 下的写接口会因 Tokdash 的回环写入保护而保持只读；如果你需要可信的远程写入，
 请使用 SSH 转发作为认证层。
 
+**Windows 上的 Tailscale：** Windows 版 Tailscale 客户端会同时安装图形界面和 `tailscale`
+命令行工具，客户端运行后，在 PowerShell/cmd 下使用 `tailscale serve` 的方式与其他平台相同。
+这一点尚未针对 Tokdash 的原生 Windows 支持（本分支已实现但尚未真实 Windows 验证——见[平台支持](#平台支持)）做过验证，
+请视为实验性功能，等待确认后再依赖它。
+
 可以直接绑定到 `0.0.0.0`，但不推荐：Tokdash 的本地 API 不是面向公网的认证服务。
 
 ### 前台运行备用方式
@@ -263,8 +272,9 @@ curl -s https://raw.githubusercontent.com/JingbiaoMei/Tokdash/main/docs/agents/o
 
 - [`statusline-minimal.sh`](docs/examples/statusline/statusline-minimal.sh) → 单行：`[Claude Sonnet 4.6] 📁 myproject | 📊 12.3M ($4.56) today`
 - [`statusline-full.sh`](docs/examples/statusline/statusline-full.sh) → 四行面板，含今日 + 本周合计，以及按工具的 Top-3 明细
+- [`statusline.ps1`](docs/examples/statusline/statusline.ps1) → 输出与 minimal 模板相同的单行，供在原生 Windows 上运行 Claude Code 的用户使用（PowerShell 原生实现，无需 `curl`/`jq`）
 
-两者均为只读、仅本地访问，Tokdash 未运行时会静默隐藏 📊 段。安装与配置见[该目录的 README](docs/examples/statusline/README.md)，端点细节见 [`docs/API.md`](docs/API.md)。
+三者均为只读、仅本地访问，Tokdash 未运行时会静默隐藏 📊 段。安装与配置见[该目录的 README](docs/examples/statusline/README.md)，端点细节见 [`docs/API.md`](docs/API.md)。
 
 想自己定制？把下面这段提示词发给你的 Agent，并把 [`docs/API.md`](docs/API.md) 一起给它：
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+## 1.0.5 - 2026-07-01
+
+### Added
+- Added native Windows support seams and CI coverage, including Windows-aware client path resolution, `msvcrt` file locking, Task Scheduler onboarding support, Windows venv path handling, and PowerShell statusline documentation.
+- Added Windows-focused tests for file locking, client path discovery, service selection, and Task Scheduler rendering.
+
 ## 1.0.4 - 2026-06-22
 
 ### Added

--- a/docs/WINDOWS_CLIENT_PATHS.md
+++ b/docs/WINDOWS_CLIENT_PATHS.md
@@ -1,0 +1,136 @@
+# Windows Client Data Paths (research for the Windows-support pass)
+
+**Status:** research backing the Windows-support branch. The resulting code keeps the portable dotfile paths for
+clients that use them on Windows and implements the one verified Windows-native branch: Hermes defaults to
+`%LOCALAPPDATA%\hermes`. This doc records, with citations, where each supported client stores its session/usage
+data on **native Windows** (not WSL), so future `clientpaths.py` changes can stay anchored to verified facts.
+
+**Last researched:** 2026-07-01. Findings come from each tool's primary source (GitHub source code, official docs,
+or — for Amp — strings pulled from the shipped Windows binary). Every non-obvious claim is cited below.
+
+**Method note on `os.homedir()` / `Path.home()`:** For Node.js tools, `os.homedir()` returns `%USERPROFILE%`
+(e.g. `C:\Users\<user>`) on native Windows. For Python tools, `pathlib.Path.home()` resolves the same via
+`USERPROFILE`. So any tool that simply joins the home dir with a `.<name>` dotfile is automatically "portable" —
+its Windows path is just `%USERPROFILE%\.<name>\...` with no code branch needed. The interesting cases below are
+the ones that do NOT do this (Hermes) or that use a Linux-only convention on Windows anyway (OpenCode).
+
+---
+
+## Summary table
+
+| Client | POSIX path (tokdash today) | Windows path | Confidence | Source URL(s) |
+|---|---|---|---|---|
+| **OpenCode** | `~/.local/share/opencode/storage/message` and `~/.local/share/opencode/opencode.db` | `%USERPROFILE%\.local\share\opencode\storage\message` and `%USERPROFILE%\.local\share\opencode\opencode.db` (Linux-style `.local\share` layout is used on Windows too — NO `%APPDATA%`/`%LOCALAPPDATA%` branch). Honors `XDG_DATA_HOME` even on Windows. | **Verified** | [global.ts](https://github.com/anomalyco/opencode/blob/472d0f376e654fbbf573c84aec70aaf821d78a58/packages/core/src/global.ts) · [database.ts](https://github.com/anomalyco/opencode/blob/472d0f376e654fbbf573c84aec70aaf821d78a58/packages/core/src/database/database.ts) · [xdg-basedir index.js](https://github.com/sindresorhus/xdg-basedir/blob/main/index.js) · [issue #8235](https://github.com/anomalyco/opencode/issues/8235) |
+| **GitHub Copilot CLI** | `~/.copilot/otel`, `~/.copilot/session-state/*/events.jsonl` | `%USERPROFILE%\.copilot\otel\*.jsonl`, `%USERPROFILE%\.copilot\session-state\*\events.jsonl` (portable dotfile). `COPILOT_HOME` relocates whole tree; `COPILOT_OTEL_FILE_EXPORTER_PATH` honored. Separate **cache** dir is `%LOCALAPPDATA%\copilot` (not session data). | **Verified** (dir); `events.jsonl` filename detail **Uncertain** | [cli-config-dir-reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference) · [configure-copilot-cli](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/configure-copilot-cli) · [install-copilot-cli](https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli) |
+| **Gemini CLI** | `~/.gemini/tmp/*/chats/session-*.json(l)` | `%USERPROFILE%\.gemini\tmp\*\chats\session-*.json(l)` (portable dotfile via Node `os.homedir()`, no XDG redirect). | **Verified** | [storage.ts](https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/core/src/config/storage.ts) · [configuration docs](https://google-gemini.github.io/gemini-cli/docs/get-started/configuration.html) · [issue #23622](https://github.com/google-gemini/gemini-cli/issues/23622) |
+| **Codex** | `~/.codex/sessions`, `~/.codex/state_5.sqlite` | `%USERPROFILE%\.codex\sessions`, `%USERPROFILE%\.codex\state_5.sqlite` (portable dotfile via Rust `dirs::home_dir()`). `CODEX_HOME` overrides whole tree cross-platform. | **Verified** | [home-dir/src/lib.rs](https://github.com/openai/codex/blob/main/codex-rs/utils/home-dir/src/lib.rs) · [Codex on Windows](https://developers.openai.com/codex/windows) |
+| **Claude Code** | `~/.claude*/projects/` | `%USERPROFILE%\.claude*\projects\` (portable dotfile; docs say so verbatim). `CLAUDE_CONFIG_DIR` overrides cross-platform. NOTE: `%APPDATA%\Claude` is the Claude **Desktop** app, not Claude Code. | **Verified** | [claude-directory docs](https://code.claude.com/docs/en/claude-directory) · [env-vars docs](https://code.claude.com/docs/en/env-vars) |
+| **Kimi CLI** | `~/.kimi` (env `KIMI_SHARE_DIR`) | `%USERPROFILE%\.kimi` (portable dotfile via Python `Path.home()`; `KIMI_SHARE_DIR` honored). | **Verified** (path logic); native-Windows support **Uncertain** | [share.py](https://raw.githubusercontent.com/MoonshotAI/kimi-cli/main/src/kimi_cli/share.py) · [kimi-cli repo](https://github.com/MoonshotAI/kimi-cli) |
+| **Pi** | `~/.pi/agent/sessions` (tokdash assumes env `PI_AGENT_DIR`, comma-separated) | `%USERPROFILE%\.pi\agent\sessions` (portable dotfile via Node `os.homedir()`). **Env-var mismatch (see note):** live var is `PI_CODING_AGENT_DIR` / `PI_CODING_AGENT_SESSION_DIR`, single path, no comma-list. | **Verified** (path logic); env-var name/comma-list premise **contradicted** | [config.ts](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/config.ts) · [docs/windows.md](https://github.com/earendil-works/pi/blob/main/docs/windows.md) · [settings docs](https://github.com/earendil-works/pi/blob/main/docs/settings.md) |
+| **Hermes** | `~/.hermes` (env `HERMES_HOME`, comma-separated) | **`%LOCALAPPDATA%\hermes`** (state.db at `%LOCALAPPDATA%\hermes\state.db`) — **this tool DOES branch to a Windows-native dir.** Installer sets `HERMES_HOME=%LOCALAPPDATA%\hermes`. **No comma-list support** (single path; "profiles" is the multi-instance mechanism). | **Verified** | [hermes-agent repo](https://github.com/NousResearch/hermes-agent) (`hermes_constants.py`, `hermes_state.py`) · [Windows Native guide](https://hermes-agent.nousresearch.com/docs/user-guide/windows-native) · [configuration docs](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) |
+| **Amp** | `~/.amp` | `%USERPROFILE%\.amp` (portable dotfile; env var is `AMP_HOME`, not `AMP_DATA_HOME`). | **Verified** (via shipped Windows binary strings) | [ampcode.com/manual](https://ampcode.com/manual) · [@ampcode/cli-win32-x64](https://www.npmjs.com/package/@ampcode/cli-win32-x64) |
+
+---
+
+## Per-client recommended `clientpaths.py` branch
+
+### OpenCode — HIGHEST priority; result is the surprising one
+- **Do NOT branch to `%APPDATA%`/`%LOCALAPPDATA%`.** OpenCode imports `xdgData` unconditionally from the npm
+  `xdg-basedir` package (`xdg-basedir` = `env.XDG_DATA_HOME || join(os.homedir(), '.local', 'share')`) with **no**
+  `process.platform === 'win32'` branch anywhere. So on Windows the data root is literally
+  `%USERPROFILE%\.local\share\opencode\` — the same `.local\share` layout as Linux.
+- **Recommended branch:** keep the current logic essentially as-is, but resolve `XDG_DATA_HOME` first, then fall
+  back to `Path.home() / ".local/share/opencode/..."`. On Windows `Path.home()` already yields `%USERPROFILE%`, so
+  `Path.home() / ".local/share/opencode/storage/message"` and `.../opencode.db` are correct **without an OS branch**.
+  The only Windows override that redirects these is `XDG_DATA_HOME`.
+- Corroboration: [issue #8235](https://github.com/anomalyco/opencode/issues/8235) ("Config and Data directories
+  follow the Linux XDG standard even on windows") documents exactly this; it was stale-bot-closed, not fixed, and
+  current `dev`-branch source still has no Windows branch. (Repo note: `github.com/sst/opencode` now redirects to
+  `github.com/anomalyco/opencode` — same project, renamed org.)
+
+### GitHub Copilot CLI
+- **Keep `Path.home() / ".copilot" / "otel"` and the `~/.copilot/session-state/*/events.jsonl` glob** — the dotfile
+  is portable; docs confirm `~/.copilot/` on Windows (`$HOME/.copilot/...` examples). `COPILOT_OTEL_FILE_EXPORTER_PATH`
+  and `COPILOT_HOME` are honored cross-platform (tokdash already reads the former).
+- Watch-out: the Windows **cache** dir is `%LOCALAPPDATA%\copilot` (override `COPILOT_CACHE_HOME`) — that is NOT
+  session/otel data; do not point the parser there.
+
+### Gemini CLI
+- **Keep `Path.home() / ".gemini"`** — portable dotfile. `getGlobalGeminiDir()` = `join(os.homedir(), '.gemini')`
+  with no OS branch and no XDG redirect. No per-user `.gemini` relocation env var exists today
+  (`GEMINI_CLI_HOME` changes the home *base*; system-level `C:\ProgramData\gemini-cli\` config is separate and not
+  what tokdash parses).
+
+### Codex
+- **Keep `Path.home() / ".codex"`** — portable dotfile via the Rust `dirs` crate. For robustness, resolve
+  `CODEX_HOME` first (works identically on Windows, any absolute path), then fall back to `Path.home()/".codex"`.
+- Windows is natively supported (sandbox modes in `config.toml`); the in-repo `docs/install.md` "WSL2 only" line is
+  stale — the live docs site supersedes it.
+
+### Claude Code
+- **Keep the `Path.home().glob(".claude*")` + `/projects` logic** — docs state verbatim that on Windows `~/.claude`
+  resolves to `%USERPROFILE%\.claude`. Optionally resolve `CLAUDE_CONFIG_DIR` first (cross-platform).
+- Do not confuse with `%APPDATA%\Claude\` (that's Claude Desktop, a different product).
+
+### Kimi CLI
+- **Keep `Path.home() / ".kimi"`** with the existing `KIMI_SHARE_DIR` override — resolver is
+  `Path(os.getenv("KIMI_SHARE_DIR")) or Path.home()/".kimi"`, and Python `Path.home()` yields `%USERPROFILE%` on
+  Windows. Path logic is portable as-is. (Caveat: no docs/CI evidence that Kimi CLI is actually *tested* on native
+  Windows — the path math is right, but Windows support is otherwise undocumented.)
+
+### Pi
+- **Keep `Path.home() / ".pi" / "agent" / "sessions"`** for the default — portable dotfile via Node `os.homedir()`,
+  and native Windows is officially supported (Git Bash required for the shell tool).
+- **Env-var discrepancy to resolve (not a path issue but affects the override branch):** tokdash's
+  `pi_agent_search_dirs()` reads `PI_AGENT_DIR` as a **comma-separated** list. In current upstream source, the live
+  runtime var is **`PI_CODING_AGENT_DIR`** (and `PI_CODING_AGENT_SESSION_DIR` for the session dir specifically), a
+  **single** path — `PI_AGENT_DIR` only appears as a test constant / one-off migration script, and no comma-split
+  logic exists anywhere upstream. This is orthogonal to Windows but should be reconciled against whichever Pi
+  version tokdash targets before writing the branch. (If the comma-list override is kept, note Windows drive-letter
+  paths like `D:\...` don't contain commas, so splitting on `,` is still safe.)
+
+### Hermes — the one genuine Windows branch
+- **DO branch on Windows.** On POSIX the DB is `~/.hermes/state.db`; on native Windows Hermes uses
+  `%LOCALAPPDATA%\hermes\state.db` (the installer sets `HERMES_HOME=%LOCALAPPDATA%\hermes`, and source branches
+  `if sys.platform == "win32": base = %LOCALAPPDATA% (or ~/AppData/Local); return base/"hermes"`).
+- **Recommended branch:** resolve `HERMES_HOME` first (already done); when unset, on Windows return
+  `Path(os.environ.get("LOCALAPPDATA") or Path.home()/"AppData"/"Local") / "hermes"`, else `Path.home()/".hermes"`.
+- **Also reconcile the comma-list:** upstream `HERMES_HOME` is read as a single `Path(val)` — no comma-separated
+  multi-dir support (multi-instance is done via "profiles", not comma-lists). tokdash's `hermes_search_dirs()`
+  comma-split is a tokdash-specific convenience; keep it if desired, but it does not mirror upstream behavior.
+
+### Amp
+- **Keep `Path.home() / ".amp"`** — portable dotfile; the shipped Windows binary literally does
+  `if (process.env.AMP_HOME) return process.env.AMP_HOME; ... return join(homedir(), ".amp")` and embeds
+  `%USERPROFILE%\.amp\bin\amp.bat`. If an override is ever added to tokdash, the env var is **`AMP_HOME`** (not
+  `AMP_DATA_HOME`). Note Amp's *settings* file lives separately at `%USERPROFILE%\.config\amp\settings.json`, which
+  tokdash's `.amp`-rooted parser does not currently need.
+
+---
+
+## Still unverified — needs a real Windows box to confirm
+
+These are honest gaps. Do NOT hardcode any of the below as if verified:
+
+1. **Copilot CLI `events.jsonl` filename convention on Windows.** The docs confirm the `%USERPROFILE%\.copilot\session-state\`
+   *directory* exists on Windows, but the exact per-session `*/events.jsonl` file layout was confirmed only on POSIX
+   and inferred by analogy. Also note current builds (v0.0.342+) use `session-state/`; older builds used
+   `history-session-state/` — verify which exists on a real Windows install. (Source:
+   [cli-config-dir-reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference).)
+
+2. **Kimi CLI actually running on native Windows.** The path-construction code is portable (`Path.home()/".kimi"`),
+   but there are no Windows install instructions, docs, or CI evidence that Kimi CLI is supported/exercised on native
+   Windows. The `%USERPROFILE%\.kimi\sessions\<userId>\<sessionId>\wire.jsonl` layout is inferred to hold on Windows
+   but was not observed on a Windows box.
+
+3. **OpenCode: no default-state Windows observation.** The `%USERPROFILE%\.local\share\opencode\` conclusion is from
+   source (strong), but the one public `opencode debug paths` Windows dump found had a customized `XDG_CONFIG_HOME`,
+   so it isn't clean default-state proof. A `opencode debug paths` run on a stock Windows install would confirm.
+
+4. **Pi env-var reconciliation.** Whether tokdash should read `PI_CODING_AGENT_DIR`/`PI_CODING_AGENT_SESSION_DIR`
+   (upstream-current) vs the `PI_AGENT_DIR` it reads today depends on the Pi version tokdash targets — needs a
+   decision, not a Windows box, but flagged here because it affects the override branch.
+
+5. **Hermes comma-list vs single path.** The `%LOCALAPPDATA%\hermes` default is verified; the divergence between
+   tokdash's comma-separated `HERMES_HOME` handling and upstream's single-path reading should be reconciled against
+   the Hermes version tokdash targets.

--- a/docs/WINDOWS_SUPPORT_PLAN.md
+++ b/docs/WINDOWS_SUPPORT_PLAN.md
@@ -1,0 +1,228 @@
+# Windows support plan
+
+Status: implemented in this branch through Tier 3, but not yet validated on a real
+Windows machine. This document records the agreed approach, the concrete gaps, and
+the tiered rollout; checkboxes marked complete indicate code/docs/tests present in
+the working tree, not released support.
+
+## 1. Goal & scope
+
+Add native Windows support to tokdash so all three usage tiers work the same way they
+do on Linux/WSL/macOS today:
+
+1. **Foreground**: `tokdash serve` runs correctly on a stock Windows Python install.
+2. **Background/autostart**: a managed background service equivalent to the
+   `onboard/systemd.py` (Linux) / `onboard/launchd.py` (macOS) backends, so
+   `tokdash setup` can offer a real "starts on login" option on Windows instead of the
+   current foreground-only fallback.
+3. **Polish**: statusline integration, docs, and CI parity so Windows is a first-class,
+   tested platform rather than an unsupported afterthought.
+
+WSL is already covered (`onboard/detect.py:os_kind()` returns `"wsl"` and treats it as
+Linux for systemd purposes). This plan is about **native Windows** (`sys.platform ==
+"win32"`, i.e. `os_kind() == "windows"`).
+
+## 2. Architecture decision: one package, not `tokdash-win`
+
+**Decision: ship Windows support inside the existing `tokdash` package. Do not create a
+separate `tokdash-win` package.**
+
+Reasoning:
+
+- tokdash is pure Python + `subprocess` calls to OS CLIs (`systemctl`, `launchctl`,
+  `tailscale`). There are no compiled extensions or OS-only library dependencies that
+  would force a split.
+- Roughly 90% of the codebase (parsers, `compute.py`, `pricing.py`, the FastAPI app,
+  the static dashboard) is already platform-agnostic and runs unmodified on Windows
+  today.
+- A second package would mean two release pipelines, two version numbers to keep in
+  sync, and a real risk of version skew between `tokdash` and `tokdash-win` — exactly
+  the kind of multi-package maintenance burden the project's release rules
+  (`AGENTS.md` → *Release rules*) are designed to avoid for a single package.
+  It would also break the simple `pip install tokdash` story documented in `README.md`.
+
+Instead, reusability comes from clean **internal seams** within the one package,
+following the pattern the repo already uses for OS-specific backends:
+`onboard/systemd.py` (Linux) and `onboard/launchd.py` (macOS), selected by
+`onboard/detect.py:os_kind()`. Windows support is "more of the same pattern," not a new
+distribution model.
+
+### Implemented module layout
+
+New, flat top-level modules under `src/tokdash/`, matching the repo's existing mostly-flat
+module style (see the `Architecture overview` table in `AGENTS.md`):
+
+| Module | Purpose | Replaces / centralizes |
+| --- | --- | --- |
+| `src/tokdash/osinfo.py` | Centralized OS detection: `os_kind()` → `linux \| wsl \| macos \| windows`, plus `is_windows()` / `is_macos()` / `is_wsl()` helpers. | The logic currently embedded in `onboard/detect.py:os_kind()` / `is_wsl()` (`src/tokdash/onboard/detect.py:28-47`), which today is onboarding-only even though other modules need the same answer. |
+| `src/tokdash/clientpaths.py` | Per-OS path resolution for **every** supported client (OpenCode, Codex, Claude Code, Gemini CLI, OpenClaw, Kimi CLI, Pi, Copilot CLI, Hermes, Amp) plus tokdash's own data dir. | The scattered `Path.home() / ".local/share/opencode/..."`-style literals in `src/tokdash/sources/coding_tools.py` and `src/tokdash/sessions.py` (see the gap table below). This is the single biggest maintainability win — it's also where every Windows-specific path branch will live. |
+| `src/tokdash/filelock.py` | Cross-platform advisory file lock: `fcntl.flock` on POSIX, `msvcrt.locking` on Windows, behind one context manager. | The direct `import fcntl` / Windows no-op in `src/tokdash/usage_store.py:14-17,41-56`. |
+| `src/tokdash/onboard/service_base.py` | A `ServiceBackend` protocol, backend registry, and `select_service()` factory. `plan._resolve_service()` delegates service selection through this seam, while backend-specific lifecycle calls stay in `engine.py`. | The ad hoc dispatch in `src/tokdash/onboard/plan.py:_resolve_service()` (`plan.py:224-270`). |
+
+Optional dependency to evaluate: [`platformdirs`](https://pypi.org/project/platformdirs/)
+for OS-convention data/cache/config directories. **Caveat to keep in mind**: several
+clients use a literal `~/.<client>` dotfile regardless of OS convention (e.g. `.codex`,
+`.claude`, `.gemini`, `.copilot`, `.hermes`), which `platformdirs` would get wrong if
+applied uniformly. `platformdirs` is a helper for tokdash's *own* data dir and any
+client that does follow OS convention (OpenCode is the one known XDG-style case) — not a
+silver bullet. Each client's real Windows layout must still be verified empirically
+(see §6).
+
+## 3. Original gap analysis
+
+These were the gaps identified before the Windows-support branch. Some have now
+been closed in this working tree; they remain here as the rationale for the tiered
+plan and for the remaining real-Windows validation work.
+
+| # | Gap | Where | Impact on Windows today |
+| --- | --- | --- | --- |
+| 1 | File locking uses POSIX-only `fcntl` | `src/tokdash/usage_store.py:14-17` (`import fcntl` guarded by `except ImportError`), `usage_store.py:41-56` (`usage_db_process_lock`) | `fcntl` is `None` on Windows, so the lock silently no-ops (`if fcntl is None: yield; return`). Cross-process serialization between `tokdash serve` and `tokdash db watch`/resync is lost — a real correctness gap, not just a warning. |
+| 2 | No Windows background-service backend | `src/tokdash/onboard/systemd.py` (Linux only), `src/tokdash/onboard/launchd.py` (macOS only); dispatch in `src/tokdash/onboard/plan.py:_resolve_service()` | `plan.py:265-270` already has the explicit fallback branch: *"Other (e.g. native Windows): no managed service yet"* — `--service systemd`/`--service launchd` are blocked, and the default path appends the note `"Background service setup for {os_kind} is not available yet; use `tokdash serve`."` Native Windows users get foreground-only today, by design. |
+| 3 | OpenCode data path hardcoded to XDG layout | `src/tokdash/sources/coding_tools.py:202-203` (`OpenCodeParser.__init__`: `Path.home() / ".local/share/opencode/storage/message"` and `.../opencode.db`); duplicated in `src/tokdash/sessions.py:369` (codex), `sessions.py:680` (`_opencode_db_signature`: same `~/.local/share/opencode/opencode.db` literal) | `~/.local/share/...` is an XDG/Linux convention. OpenCode does not necessarily store data there on Windows (likely `%LOCALAPPDATA%\opencode\` or similar — unverified, see §6). Until confirmed and branched, OpenCode usage will not be discovered on native Windows. |
+| 4 | venv interpreter path assumes `bin/python` | `src/tokdash/onboard/paths.py:70-72` (`managed_venv_python()`, with the existing comment *"Windows venvs put the interpreter under Scripts/, but Phase 1 targets POSIX"*); `src/tokdash/onboard/detect.py:188-189` (`pipx_tokdash_python()` candidate paths end in `.../venvs/tokdash/bin/python`); consumed by `src/tokdash/onboard/runtime.py:resolve()`/`create_managed_venv()` | On Windows, `python -m venv` creates `Scripts\python.exe`, not `bin/python`. Both the managed-venv runtime and pipx-detection candidates need an OS branch before `tokdash setup --runtime venv` or `--runtime pipx` can work natively on Windows. |
+| 5 | Other client paths need a Windows verification pass | `src/tokdash/sources/coding_tools.py`: Codex `:306` (`~/.codex/sessions`), Claude Code `:406` (`Path.home().glob(".claude*")`), Gemini CLI `:584` (`~/.gemini`), Amp `:690` (`~/.amp`), Kimi CLI `:746` (`~/.kimi`, override via env), Pi `:888-891` (`~/.pi/agent/sessions`, override via `PI_AGENT_DIR`), Copilot CLI `:1071-1072` (`~/.copilot/otel`, `~/.copilot/session-state/*/events.jsonl` — glob built via `str(Path.home() / ...)`), Hermes `:1518-1520` (`~/.hermes`, override via `HERMES_HOME`) | `~/.<client>` dotfiles resolve fine via `Path.home()` on Windows (`pathlib` handles `%USERPROFILE%`), so these are *probably* OK as-is — but each one needs an explicit verification pass against the real Windows install of that client, not an assumption. The Copilot CLI glob built with `str(Path / ... / "*" / "events.jsonl")` should also be checked for backslash-vs-glob interaction on Windows. |
+| 6 | `uvloop` is POSIX-only | `pyproject.toml` dependency `uvicorn[standard]>=0.32.0`; consumed at `src/tokdash/cli.py:256` (`uvicorn.run(...)`) | Confirm-only, not a blocker: `uvicorn[standard]`'s `uvloop` extra is not installable on Windows, and uvicorn already falls back to the stdlib `asyncio` event loop there. No code change expected; verify under CI once `windows-latest` is added (Tier 1). |
+| 7 | Headless/browser-open detection | `src/tokdash/cli.py:_has_display()` (`cli.py:193-214`) | Already OK — note only. The Linux branch gates on `DISPLAY`/`WAYLAND_DISPLAY`; for any non-Linux platform (`sys.platform.startswith("linux")` is `False`) it already returns `True` (`cli.py:212-214`), which is the right behavior for Windows desktop sessions. No change needed. |
+| 8 | Statusline templates are bash-only | `docs/examples/statusline/statusline-minimal.sh`, `docs/examples/statusline/statusline-full.sh` (both `curl`+`jq`, `#!/usr/bin/env bash`) | Claude Code on Windows can still run a bash script under WSL/Git Bash, but a native PowerShell statusline template is missing for users running Claude Code natively on Windows. |
+| 9 | CI is Ubuntu-only | `.github/workflows/ci.yml` (`runs-on: ubuntu-latest`, matrix `python-version: ["3.10", "3.12"]`) | No automated signal at all for Windows regressions; every gap above can silently break without CI catching it. |
+| 10 | Tests assume POSIX/systemd/launchd | `tests/test_onboard.py` (monkeypatches `systemd`/`launchd` modules directly), `tests/test_usage_store.py` (locking behavior assumes `fcntl` semantics), plus any test that builds paths assuming POSIX separators | Needs skip-markers for backend-specific tests (e.g. `@pytest.mark.skipif(os_kind() != "windows", ...)` for a future `winsched` backend) and new Windows-specific tests once Tier 1/2 land. |
+| 11 | Docs/metadata don't mention Windows | `README.md:102-105` (`## Platform support` lists only Linux/WSL2 = supported, macOS = experimental); `pyproject.toml` `classifiers` (no `Operating System ::` classifier at all today) | Cosmetic but user-facing: nothing currently tells a Windows user whether tokdash works for them, and PyPI's classifier list doesn't advertise Windows support once it exists. |
+
+## 4. Tiered plan
+
+### Tier 0 — Seams refactor (no behavior change)
+
+Goal: extract the seams so later tiers are additive, without changing behavior on any
+currently-supported platform. This tier should be invisible to existing Linux/macOS
+users — it is pure refactoring with test coverage to prove parity.
+
+- [x] Add `src/tokdash/osinfo.py` with `os_kind()` / `is_windows()` / `is_macos()` /
+      `is_wsl()`; re-implement `onboard/detect.py:os_kind()` and `is_wsl()` as thin
+      wrappers (or have `detect.py` import from `osinfo.py`) so there is exactly one
+      source of truth.
+- [x] Add `src/tokdash/clientpaths.py` and move every client path literal listed in gap
+      #3/#5 into named functions (e.g. `opencode_data_dir()`, `codex_sessions_dir()`,
+      `claude_project_dirs()`, …). Update `sources/coding_tools.py` and `sessions.py`
+      to call these functions instead of inlining `Path.home() / ...`. Behavior must be
+      byte-for-byte identical on Linux/macOS — this tier only relocates the literals,
+      it does not add Windows branches yet.
+- [x] Add `src/tokdash/filelock.py` with a single `process_lock(path)` context manager;
+      port the POSIX `fcntl` implementation from `usage_store.py:41-56` into it
+      unchanged. `usage_store.py` calls the new module instead of importing `fcntl`
+      directly. The Windows (`msvcrt`) branch is a stub/`NotImplementedError`-free no-op
+      in this tier — implementing real Windows locking is Tier 1 (see below).
+- [x] Define `onboard/service_base.py`: a `ServiceBackend` protocol, registry, and
+      `select_service()` factory. Update `onboard/plan.py:_resolve_service()` to delegate
+      through it instead of carrying the inline `if os_kind == "macos" / ...` chain.
+- [x] Full test suite green with no behavior change; this is the gate for starting
+      Tier 1.
+
+**Completed after Tier 0**: the real `msvcrt`-based lock implementation and the
+verified Hermes Windows path branch landed in later tiers. Remaining Windows behavior
+still needs real-machine validation before release.
+
+### Tier 1 — Native Windows foreground
+
+Goal: `tokdash serve` (and `tokdash export`, `tokdash db ...`) work correctly when run
+directly with a stock Windows Python install (no managed service yet).
+
+- [x] Implement the `msvcrt.locking()` branch in `filelock.py` so
+      `usage_db_process_lock`-equivalent locking is real (not a no-op) on Windows.
+- [x] Add OS-aware branches in `clientpaths.py` where empirically needed. Research found
+      OpenCode keeps its Linux-style `.local/share` layout on Windows; Hermes was the only
+      client requiring a Windows-native `%LOCALAPPDATA%\hermes` branch.
+- [x] Audit and, where needed, branch the remaining client paths from gap #5
+      (Codex, Claude Code, Gemini CLI, Amp, Kimi CLI, Pi, Copilot CLI, Hermes) for
+      Windows; most are expected to need no change (`Path.home()` resolves
+      `%USERPROFILE%` correctly), but each must be confirmed against a real install,
+      not assumed.
+- [ ] Smoke-test `tokdash serve` end-to-end on Windows (`python -m tokdash serve` and
+      the packaged `tokdash` console script).
+- [x] Add `windows-latest` to `.github/workflows/ci.yml`'s matrix; add
+      `skipif`/`xfail` markers to the POSIX-only tests identified in gap #10, and add
+      new Windows-specific tests (lock behavior, path resolution).
+- [x] Update `README.md` `## Platform support` (gap #11) to add a Windows row, and add
+      `"Operating System :: Microsoft :: Windows"` to `pyproject.toml` classifiers.
+      Keep `README_CN.md` in sync per `AGENTS.md`'s release rules.
+
+### Tier 2 — Background-service parity
+
+Goal: `tokdash setup` offers a real managed background service on Windows, matching
+what systemd/launchd already provide on Linux/macOS.
+
+- [x] Add `src/tokdash/onboard/winsched.py`: a Task Scheduler backend backed by
+      Windows Task Scheduler, registering an `ONLOGON` trigger that runs
+      `pythonw -m tokdash serve` (using `pythonw` rather than `python` to avoid a
+      console window, mirroring how `systemd.py`/`launchd.py` run detached).
+- [x] Carry the same ownership-marker discipline systemd/launchd use today (see
+      `onboard/systemd.py`'s `MARKER_COMMENT` / `onboard/manifest.py`'s
+      `marker_token()`) so `tokdash uninstall` can prove a task is setup-owned before
+      removing it — the same safety property `plan.py:_plan_service_removal()` already
+      enforces for systemd/launchd units.
+- [x] Fix the Windows venv interpreter path (gap #4): branch
+      `onboard/paths.py:managed_venv_python()` to return `Scripts\python.exe` on
+      Windows, and extend `onboard/detect.py:pipx_tokdash_python()`'s candidate list
+      accordingly.
+- [x] Wire `tokdash setup` / `tokdash doctor` / `tokdash uninstall` additively for the
+      `winsched` service type, including manifest read/write.
+- [x] New tests covering the winsched backend (rendering, ownership marker detection,
+      install/uninstall planning) mirroring `tests/test_onboard.py`'s systemd/launchd
+      coverage.
+
+### Tier 3 — Polish
+
+- [x] Add a PowerShell statusline template alongside
+      `docs/examples/statusline/statusline-minimal.sh` /
+      `statusline-full.sh` (gap #8), plus the matching Windows `settings.json`
+      `statusLine` snippet for Claude Code.
+- [x] Document Tailscale-on-Windows notes for remote access (the existing
+      `onboard/tailscale.py` flow assumes a CLI on `PATH`; confirm behavior with the
+      Windows Tailscale client and document any differences).
+
+## 5. Testing & CI strategy
+
+Canonical local commands (unchanged from today, per `AGENTS.md`):
+
+```bash
+PYTHONPATH=src python3 -m pytest -q
+python -m compileall -q src/tokdash main.py
+```
+
+CI (`.github/workflows/ci.yml`) changes:
+
+- Add `windows-latest` to the `runs-on` matrix (currently `ubuntu-latest` only,
+  `python-version: ["3.10", "3.12"]`).
+- Keep the existing `Compile` step (`python -m compileall -q src/tokdash main.py
+  docs/agents/openclaw_reporting/openclaw_cron_job.py`) and `Test` step (`pytest -q`)
+  unchanged in shape; they should run as-is on `windows-latest` once Tier 1's
+  skip-markers are in place.
+- Tests that exercise systemd/launchd-specific monkeypatching (`tests/test_onboard.py`)
+  need `skipif(os_kind() == "windows")` guards until the Tier 2 `winsched` backend has
+  its own equivalent coverage.
+- New Windows-only tests (file locking, client path resolution, winsched rendering)
+  should be guarded the other way — `skipif(os_kind() != "windows")` — so the suite
+  stays meaningful and fast on every platform rather than every test running everywhere.
+
+## 6. Open items / research needed before Tier 1
+
+The single biggest risk in this plan is **guessing** a Windows path instead of
+verifying it. Before Tier 1 path branches are written, confirm empirically (real
+Windows install, not documentation alone) where each of these actually stores data:
+
+- **OpenCode** — currently assumed XDG-style (`~/.local/share/opencode/...`,
+  `sources/coding_tools.py:202-203`); Windows is plausibly
+  `%LOCALAPPDATA%\opencode\` but this is unverified.
+- **GitHub Copilot CLI** — currently `~/.copilot/otel` and
+  `~/.copilot/session-state/*/events.jsonl` (`sources/coding_tools.py:1071-1072`);
+  confirm whether the Windows install uses the same dotfile-style home directory or a
+  `%APPDATA%`/`%LOCALAPPDATA%` convention instead.
+- **Gemini CLI** — currently `~/.gemini` (`sources/coding_tools.py:584`); confirm same
+  question.
+- Lower-priority but worth a pass during Tier 1's broader audit: Kimi CLI, Pi, Hermes,
+  Amp, Codex, Claude Code — all currently simple `~/.<client>` dotfiles that *should*
+  resolve correctly via `pathlib.Path.home()` on Windows, but each should still get a
+  one-time empirical check rather than being assumed correct by analogy.
+
+`platformdirs` (see §2) can help once the real per-client convention is known, but it
+cannot substitute for checking each client's actual behavior — several of them
+deliberately ignore OS convention in favor of a portable dotfile.

--- a/docs/examples/statusline/README.md
+++ b/docs/examples/statusline/README.md
@@ -6,10 +6,11 @@ Drop-in [Claude Code statusline](https://docs.claude.com/en/docs/claude-code/sta
 |---|---|---|
 | [`statusline-minimal.sh`](statusline-minimal.sh) | `[Claude Sonnet 4.6] 📁 myproject \| 📊 12.3M ($4.56) today` | You just want today's total on one line. Best starting point. |
 | [`statusline-full.sh`](statusline-full.sh) | Four rows: model/branch/effort · context bar/session cost · dir/env/**tokdash today+week**/git · clock/rate-limits/**top-3 tools** | You want a full dashboard in the status bar. The tokdash parts are fenced in a clearly marked block you can keep or delete. |
+| [`statusline.ps1`](statusline.ps1) | Same one-liner as `statusline-minimal.sh`: `[Claude Sonnet 4.6] 📁 myproject \| 📊 12.3M ($4.56) today` | You're running Claude Code natively on Windows and want the minimal template without installing `curl`/`jq`. See [Windows](#windows) below. |
 
 ## Requirements
 
-- [`jq`](https://jqlang.github.io/jq/) and `curl` on your `PATH`.
+- [`jq`](https://jqlang.github.io/jq/) and `curl` on your `PATH` (bash templates). On native Windows, `statusline.ps1` only needs PowerShell 5.1+ — `Invoke-RestMethod`/`ConvertFrom-Json` ship in the box, no extra install. See [Windows](#windows).
 - Tokdash running locally (`tokdash serve`, or a `tokdash setup` background service).
 - Claude Code **2.1.97+** for `refreshInterval` (older versions only repaint the statusline on each turn).
 
@@ -35,9 +36,61 @@ chmod +x ~/.claude/scripts/statusline.sh
 
 `refreshInterval` re-runs the script every N seconds so the totals stay live even while you're idle. Keep it ≥ Tokdash's cache TTL behavior in mind — every 30s is comfortable.
 
+## Windows
+
+Running Claude Code natively on Windows (not under WSL/Git Bash)? Use
+[`statusline.ps1`](statusline.ps1) instead of the bash templates — it renders the same
+minimal one-liner as `statusline-minimal.sh` using `Invoke-RestMethod` /
+`ConvertFrom-Json`, which ship with PowerShell, so there's nothing extra to install.
+
+### Install
+
+```powershell
+# 1. Copy the template into place
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.claude\scripts" | Out-Null
+Copy-Item statusline.ps1 "$env:USERPROFILE\.claude\scripts\statusline.ps1"
+```
+
+```jsonc
+// 2. Add this to %USERPROFILE%\.claude\settings.json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "powershell -NoProfile -ExecutionPolicy Bypass -File \"%USERPROFILE%\\.claude\\scripts\\statusline.ps1\"",
+    "refreshInterval": 30
+  }
+}
+```
+
+`-NoProfile` skips your PowerShell profile for a faster, cleaner start; `-ExecutionPolicy
+Bypass` lets this one invocation run regardless of your machine's script execution
+policy without changing that policy globally. If you use PowerShell 7+, `pwsh` works the
+same way in place of `powershell`.
+
+The same environment variables as the bash templates apply — set them with `$env:` instead
+of `export`, e.g. in your PowerShell profile (`$PROFILE`):
+
+```powershell
+$env:TOKDASH_URL = "http://127.0.0.1:55423"
+$env:TOKDASH_STATUSLINE_PERIOD = "today"
+```
+
+`statusline.ps1` is read-only, localhost-only, and fails silently (drops the 📊 segment)
+if Tokdash isn't running or unreachable — the same fail-silent behavior as the bash
+templates.
+
+> Native Windows support for Tokdash itself (foreground `tokdash serve` and the
+> Task Scheduler background service) is implemented in this branch but still awaiting
+> real-Windows validation — see
+> [Platform support](../../../README.md#platform-support) in the main README. This
+> statusline template targets Claude Code running on Windows independently of that
+> rollout; it only needs a reachable Tokdash `/api/usage` endpoint, wherever Tokdash is
+> actually running.
+
 ## Configuration
 
-Both scripts honor environment variables (set them in your shell profile, e.g. `~/.bashrc`):
+All templates honor the same environment variables (set them in your shell profile, e.g.
+`~/.bashrc`; on Windows, via `$env:` — see [Windows](#windows) above):
 
 | Variable | Default | Meaning |
 |---|---|---|
@@ -87,5 +140,6 @@ curl -s 'http://127.0.0.1:55423/api/usage?period=today' | jq '{total_tokens, tot
 | Statusline is blank / errors | `jq` not installed, or the script isn't executable. Run `bash ~/.claude/scripts/statusline.sh < /dev/null` to see errors. |
 | Totals look frozen | Bump or add `refreshInterval`; without it the bar only repaints when Claude Code produces output. |
 | Brief stalls when restarting Tokdash | Expected and bounded — each `curl -m 1` call waits at most 1s. The minimal template makes one Tokdash request; the full template makes two. |
+| (Windows) Statusline blank / "cannot be loaded" error | Script execution policy blocked it — make sure the `command` in `settings.json` includes `-ExecutionPolicy Bypass` exactly as shown in [Windows](#windows). Run `powershell -NoProfile -ExecutionPolicy Bypass -File "%USERPROFILE%\.claude\scripts\statusline.ps1"` directly (with no piped stdin) to see the raw error. |
 
 > These scripts are read-only and localhost-only. They never send your usage data anywhere — they just render what your local Tokdash already computed.

--- a/docs/examples/statusline/statusline.ps1
+++ b/docs/examples/statusline/statusline.ps1
@@ -1,0 +1,73 @@
+# Tokdash -> Claude Code statusline (PowerShell / native Windows starter)
+# -------------------------------------------------------------------------------
+# Renders one line, e.g.:   [Claude Sonnet 4.6] 📁 myproject | 📊 12.3M ($4.56) today
+#
+# Requires: PowerShell 5.1+ (Invoke-RestMethod / ConvertFrom-Json are built in --
+# no curl or jq needed). Fails silently (drops the 📊 segment) if tokdash isn't
+# running. This script only ever issues GET requests, so the write-protection
+# gate never blocks it.
+#
+# Install:
+#   1. copy statusline.ps1 to %USERPROFILE%\.claude\scripts\statusline.ps1
+#   2. add the Windows "statusLine" block from this folder's README.md to
+#      %USERPROFILE%\.claude\settings.json
+#
+# If you changed TOKDASH_HOST / TOKDASH_PORT, point the script at your endpoint,
+# e.g. in your PowerShell profile:
+#   $env:TOKDASH_URL = "http://127.0.0.1:55423"
+#
+# This is the PowerShell counterpart of statusline-minimal.sh -- keep the two in
+# sync if you change one.
+
+$TokdashUrl = if ($env:TOKDASH_URL) { $env:TOKDASH_URL } else { "http://127.0.0.1:55423" }
+$Period = if ($env:TOKDASH_STATUSLINE_PERIOD) { $env:TOKDASH_STATUSLINE_PERIOD } else { "today" }   # today | 3days | week | 14days | month | year | all
+
+# Claude Code feeds the statusline a JSON blob on stdin.
+$stdinText = [Console]::In.ReadToEnd()
+$Model = "?"
+$Dir = ""
+try {
+    $inputJson = $stdinText | ConvertFrom-Json -ErrorAction Stop
+    if ($inputJson.model.display_name) { $Model = $inputJson.model.display_name }
+    if ($inputJson.workspace.current_dir) { $Dir = [string]$inputJson.workspace.current_dir }
+} catch {
+    # Missing/malformed stdin (e.g. a manual test run) -- keep the "?" fallback,
+    # same as the bash template's `jq -r '.model.display_name // "?"'`.
+}
+$DirName = if ($Dir) { Split-Path -Leaf $Dir } else { "" }
+
+# Compact a raw token count to B / M / k (mirrors fmt_tok() in statusline-minimal.sh).
+# Formats with InvariantCulture so the separator is always "." regardless of the
+# machine's regional settings (some locales default to "," for decimals).
+function Format-TokenCount {
+    param([double]$Count)
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    if ($Count -ge 1000000000) {
+        return ($Count / 1000000000).ToString("F1", $inv) + "B"
+    } elseif ($Count -ge 1000000) {
+        return ($Count / 1000000).ToString("F1", $inv) + "M"
+    } elseif ($Count -ge 1000) {
+        $rounded = [Math]::Round($Count / 1000, 0, [MidpointRounding]::AwayFromZero)
+        return "$([int64]$rounded)k"
+    } else {
+        return "$([int64]$Count)"
+    }
+}
+
+# Fetch the period totals. -TimeoutSec 1 keeps the bar responsive if tokdash is
+# mid-restart -- the same purpose as the bash template's `curl -m 1`.
+$TokdashSegment = ""
+try {
+    $usage = Invoke-RestMethod -Uri "$TokdashUrl/api/usage?period=$Period" -TimeoutSec 1 -ErrorAction Stop
+    $tokens = if ($null -ne $usage.total_tokens) { [double]$usage.total_tokens } else { 0 }
+    $cost = if ($null -ne $usage.total_cost) { [double]$usage.total_cost } else { 0 }
+    if ($tokens -ne 0) {
+        $costText = $cost.ToString("F2", [System.Globalization.CultureInfo]::InvariantCulture)
+        $TokdashSegment = " | 📊 $(Format-TokenCount $tokens) (`$$costText) $Period"
+    }
+} catch {
+    # Tokdash isn't running / unreachable -- fail silently, same as the bash
+    # template's empty-JSON check.
+}
+
+Write-Output "[$Model] 📁 $DirName$TokdashSegment"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tokdash"
-version = "1.0.4"
+version = "1.0.5"
 description = "Local token & cost dashboard for AI coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: MacOS",
   "Topic :: Software Development :: Libraries",
   "Topic :: Utilities",
 ]

--- a/src/tokdash/__init__.py
+++ b/src/tokdash/__init__.py
@@ -1,3 +1,3 @@
 """Tokdash package."""
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/src/tokdash/cli.py
+++ b/src/tokdash/cli.py
@@ -159,7 +159,7 @@ def build_parser(prog: str) -> argparse.ArgumentParser:
     )
     lifecycle.add_argument(
         "--service",
-        choices=["auto", "systemd", "launchd", "none"],
+        choices=["auto", "systemd", "launchd", "winsched", "none"],
         default="auto",
         help="Background service type (default: auto)",
     )

--- a/src/tokdash/clientpaths.py
+++ b/src/tokdash/clientpaths.py
@@ -1,0 +1,150 @@
+"""Centralized per-client + data-dir path resolution (Tier 0 seams refactor).
+
+Every coding-tool log location and env-var override that ``sources/coding_tools.py``
+and ``sessions.py`` need lives here, in one place, so a later Windows-support pass
+(Tier 1) only has to branch on OS in this module instead of at every call site.
+
+This module is intentionally a pure centralization: it computes EXACTLY what the
+call sites computed inline before (same env vars, same ``Path.home()`` lookups,
+same defaults). No Windows-specific branches are added here yet.
+
+Paths are resolved fresh on every call (``Path.home()`` / ``os.environ`` are read
+at call time, never cached at import time) so that tests which monkeypatch
+``Path.home`` or set env vars before constructing a parser keep working unchanged.
+
+Note: the Tokdash data dir (``TOKDASH_DATA_DIR``) also has an independent copy in
+``onboard/paths.py::data_dir()`` for the setup engine. That copy is left untouched
+by this refactor (see module docstring there for why) — only ``usage_store.py``
+and the coding-tool sources/sessions call sites are centralized here.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Optional
+
+from . import osinfo
+
+
+# --- OpenCode ---------------------------------------------------------------
+
+
+def opencode_messages_dir() -> Path:
+    return Path.home() / ".local/share/opencode/storage/message"
+
+
+def opencode_db_path() -> Path:
+    return Path.home() / ".local/share/opencode/opencode.db"
+
+
+# --- Codex --------------------------------------------------------------------
+
+
+def codex_sessions_dir() -> Path:
+    return Path.home() / ".codex/sessions"
+
+
+def codex_state_db_path() -> Path:
+    return Path.home() / ".codex" / "state_5.sqlite"
+
+
+# --- Claude Code ----------------------------------------------------------------
+
+
+def claude_project_dirs() -> List[Path]:
+    """``projects/`` dir under every ``~/.claude*`` install (base + variants)."""
+    return [p / "projects" for p in sorted(Path.home().glob(".claude*")) if (p / "projects").is_dir()]
+
+
+# --- Gemini CLI -----------------------------------------------------------------
+
+
+def gemini_root() -> Path:
+    return Path.home() / ".gemini"
+
+
+def gemini_chats_json_glob(root: Optional[Path] = None) -> str:
+    root = root if root is not None else gemini_root()
+    return str(root / "tmp" / "*" / "chats" / "session-*.json")
+
+
+def gemini_chats_jsonl_glob(root: Optional[Path] = None) -> str:
+    root = root if root is not None else gemini_root()
+    return str(root / "tmp" / "*" / "chats" / "session-*.jsonl")
+
+
+# --- Amp --------------------------------------------------------------------
+
+
+def amp_root() -> Path:
+    return Path.home() / ".amp"
+
+
+# --- Kimi CLI ---------------------------------------------------------------
+
+
+def kimi_root() -> Path:
+    """``$KIMI_SHARE_DIR`` if set, else ``~/.kimi``."""
+    kimi_share_dir = os.environ.get("KIMI_SHARE_DIR", "").strip()
+    return Path(kimi_share_dir).expanduser() if kimi_share_dir else (Path.home() / ".kimi")
+
+
+# --- Pi Agent -----------------------------------------------------------------
+
+
+def pi_agent_search_dirs() -> List[Path]:
+    """``$PI_AGENT_DIR`` (comma-separated) if set, else ``~/.pi/agent/sessions``."""
+    pi_dir_env = os.environ.get("PI_AGENT_DIR", "").strip()
+    if pi_dir_env:
+        return [Path(d.strip()).expanduser() for d in pi_dir_env.split(",") if d.strip()]
+    return [Path.home() / ".pi" / "agent" / "sessions"]
+
+
+# --- GitHub Copilot CLI -----------------------------------------------------------
+
+
+def copilot_otel_dir() -> Path:
+    return Path.home() / ".copilot" / "otel"
+
+
+def copilot_events_glob() -> str:
+    return str(Path.home() / ".copilot" / "session-state" / "*" / "events.jsonl")
+
+
+def copilot_otel_exporter_path() -> str:
+    """``$COPILOT_OTEL_FILE_EXPORTER_PATH``, stripped; empty string when unset."""
+    return os.environ.get("COPILOT_OTEL_FILE_EXPORTER_PATH", "").strip()
+
+
+# --- Hermes -------------------------------------------------------------------
+
+
+def hermes_search_dirs() -> List[Path]:
+    """``$HERMES_HOME`` (comma-separated) if set, else ``~/.hermes`` (``%LOCALAPPDATA%\\hermes`` on Windows)."""
+    hermes_home_env = os.environ.get("HERMES_HOME", "").strip()
+    if hermes_home_env:
+        return [Path(d.strip()).expanduser() for d in hermes_home_env.split(",") if d.strip()]
+    if osinfo.is_windows():
+        base = os.environ.get("LOCALAPPDATA") or (Path.home() / "AppData" / "Local")
+        return [Path(base) / "hermes"]
+    return [Path.home() / ".hermes"]
+
+
+# --- Tokdash data dir / usage DB -------------------------------------------------
+#
+# Mirrors onboard/paths.py::data_dir() (kept as a separate, untouched copy there —
+# see this module's docstring). Centralized here only for usage_store.py and the
+# sources/sessions call sites.
+
+
+def tokdash_data_dir() -> Path:
+    """Resolved Tokdash data dir: ``$TOKDASH_DATA_DIR`` if set, else ``~/.tokdash``."""
+    return Path(os.environ.get("TOKDASH_DATA_DIR", "~/.tokdash")).expanduser()
+
+
+def usage_db_path() -> Path:
+    """``$TOKDASH_USAGE_DB_PATH`` if set, else ``<data dir>/usage.sqlite3``."""
+    explicit = os.environ.get("TOKDASH_USAGE_DB_PATH", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    return tokdash_data_dir() / "usage.sqlite3"

--- a/src/tokdash/filelock.py
+++ b/src/tokdash/filelock.py
@@ -1,0 +1,135 @@
+"""Cross-platform advisory file lock seam (Tier 0 seams refactor; Tier 1 Windows support).
+
+Extracted from ``usage_store.usage_db_process_lock``. ``process_lock()`` is the
+single place that knows how to take an advisory, exclusive, blocking lock on a
+sidecar lock file. POSIX uses ``fcntl.flock``; when ``fcntl`` is unavailable
+(e.g. not implemented on the platform) the lock degrades to a no-op, exactly as
+today's ``usage_store`` behavior did before this extraction.
+
+Windows (Tier 1) uses ``msvcrt.locking`` on an ``os.name == "nt"`` branch. This
+is intentionally kept separate from the POSIX branch rather than unified: the
+two OS locking primitives have different semantics (see caveat below), and the
+POSIX path must stay byte-identical for Linux/macOS. If ``msvcrt`` is ever
+unavailable on a "nt" platform, or the lock cannot be acquired even after
+retrying, this degrades to the same no-op fallback as the POSIX
+"fcntl unavailable" case — a locking failure must never crash a caller.
+
+Caveat (Windows vs POSIX locking semantics): ``msvcrt.locking`` locks a
+byte-range of the *open file* and is enforced by the OS as a *mandatory*
+(not just advisory) lock on Windows, whereas POSIX ``flock`` is purely
+advisory and locks the whole file via the inode. ``msvcrt.locking(LK_LOCK, ...)``
+is also not truly blocking: internally it retries acquisition roughly 10 times
+over ~1 second and then raises ``OSError`` if it still can't get the lock. To
+approximate ``flock``'s indefinite blocking behavior, the Windows branch below
+wraps that call in its own bounded retry loop. This is best-effort, not a
+perfect emulation of POSIX advisory semantics.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+import os
+import time
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows fallback
+    fcntl = None  # type: ignore[assignment]
+
+
+# How long the Windows branch will keep retrying ``msvcrt.locking`` after it
+# raises ``OSError`` (each internal msvcrt attempt already spends ~1s retrying
+# before raising), before giving up and degrading to the no-op fallback.
+_WINDOWS_LOCK_TIMEOUT_SECONDS = 30.0
+_WINDOWS_LOCK_RETRY_DELAY_SECONDS = 0.05
+
+
+@contextmanager
+def process_lock(lock_path: Path) -> Iterator[None]:
+    """Take an advisory, exclusive, blocking lock on ``lock_path`` for the ``with`` block.
+
+    Creates ``lock_path``'s parent directory if needed. When the platform has no
+    locking support (``fcntl`` unavailable on POSIX, ``msvcrt`` unavailable or
+    non-functional on Windows), this is a no-op — callers still get the rest of
+    their concurrency story (e.g. an in-process lock) but not cross-process
+    exclusion. Preserves the exact behavior of the original
+    ``usage_store.usage_db_process_lock`` POSIX/no-op fallback.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if os.name == "nt":
+        with _windows_process_lock(lock_path):
+            yield
+        return
+
+    if fcntl is None:
+        yield
+        return
+    with lock_path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _windows_process_lock(lock_path: Path) -> Iterator[bool]:
+    """``os.name == "nt"`` locking implementation using ``msvcrt.locking``.
+
+    Imported lazily because ``msvcrt`` does not exist on POSIX. Any failure to
+    import or use it (module missing, attribute missing, or the bounded retry
+    loop below exhausting its budget) degrades to a no-op, exactly like the
+    POSIX ``fcntl is None`` fallback — locking is a best-effort convenience,
+    never a hard dependency for callers.
+    """
+    try:
+        import msvcrt
+    except ImportError:  # pragma: no cover - exercised via injected fake on non-Windows
+        yield False
+        return
+
+    try:
+        handle = lock_path.open("a+b")
+    except OSError:
+        yield False
+        return
+
+    with handle:
+        try:
+            fd = handle.fileno()
+        except (OSError, ValueError):
+            yield False
+            return
+
+        locked = _acquire_windows_lock(msvcrt, fd)
+        try:
+            yield locked
+        finally:
+            if locked:
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+
+
+def _acquire_windows_lock(msvcrt, fd: int) -> bool:
+    """Retry ``msvcrt.locking(LK_LOCK)`` to approximate blocking ``flock(LOCK_EX)``.
+
+    ``msvcrt.locking(fd, LK_LOCK, 1)`` already retries internally (~10 times
+    over ~1 second) before raising ``OSError`` if the region is still locked.
+    We wrap that in an outer bounded loop so a lock held by another process for
+    longer than msvcrt's internal retry window doesn't immediately give up.
+    After ``_WINDOWS_LOCK_TIMEOUT_SECONDS`` of total retrying we give up and
+    return ``False`` (no-op degrade) rather than block forever or raise.
+    """
+    deadline = time.monotonic() + _WINDOWS_LOCK_TIMEOUT_SECONDS
+    while True:
+        try:
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            return True
+        except OSError:
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(_WINDOWS_LOCK_RETRY_DELAY_SECONDS)

--- a/src/tokdash/onboard/detect.py
+++ b/src/tokdash/onboard/detect.py
@@ -9,42 +9,33 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
-import platform
 import shutil
 import socket
 import subprocess
 import sys
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
+from .. import osinfo
 from . import manifest, paths
 
 MIN_PYTHON = (3, 10)
 
 # --- OS / session ---------------------------------------------------------------
+#
+# Canonical implementation lives in ``tokdash.osinfo`` (Tier 0 seams refactor).
+# These wrappers exist so existing callers of ``detect.os_kind()`` / ``detect.is_wsl()``
+# (and tests that ``monkeypatch.setattr(detect, "os_kind", ...)``) keep working unchanged.
 
 
 def is_wsl() -> bool:
-    if sys.platform != "linux":
-        return False
-    if "microsoft" in platform.release().lower():
-        return True
-    try:
-        return "microsoft" in Path("/proc/version").read_text(encoding="utf-8").lower()
-    except OSError:
-        return False
+    return osinfo.is_wsl()
 
 
 def os_kind() -> str:
     """One of ``linux`` | ``wsl`` | ``macos`` | ``windows``."""
-    if sys.platform == "darwin":
-        return "macos"
-    if sys.platform.startswith("win"):
-        return "windows"
-    if is_wsl():
-        return "wsl"
-    return "linux"
+    return osinfo.os_kind()
 
 
 def is_tty() -> bool:
@@ -169,6 +160,11 @@ def launchd_available() -> bool:
     return os_kind() == "macos" and shutil.which("launchctl") is not None
 
 
+def winsched_available() -> bool:
+    """Whether a per-user Windows Task Scheduler task can be managed (Windows only)."""
+    return os_kind() == "windows" and shutil.which("schtasks") is not None
+
+
 def tailscale_available() -> bool:
     """Whether the `tailscale` CLI is present (for wizard-run Tailscale Serve)."""
     return shutil.which("tailscale") is not None
@@ -188,9 +184,17 @@ def pipx_tokdash_python() -> Optional[str]:
         home / ".local" / "pipx" / "venvs" / "tokdash" / "bin" / "python",
         home / ".local" / "share" / "pipx" / "venvs" / "tokdash" / "bin" / "python",
     ]
+    if os_kind() == "windows":
+        # pipx's default Windows venv layout puts the interpreter under Scripts/, same as
+        # any other Windows venv (paths.managed_venv_python() makes the same swap).
+        local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+        if local_appdata:
+            candidates.insert(0, Path(local_appdata).expanduser() / "pipx" / "venvs" / "tokdash" / "Scripts" / "python.exe")
+        candidates.append(home / "pipx" / "venvs" / "tokdash" / "Scripts" / "python.exe")
     pipx_home = os.environ.get("PIPX_HOME", "").strip()
     if pipx_home:
-        candidates.insert(0, Path(pipx_home).expanduser() / "venvs" / "tokdash" / "bin" / "python")
+        suffix = ("Scripts", "python.exe") if os_kind() == "windows" else ("bin", "python")
+        candidates.insert(0, Path(pipx_home).expanduser() / "venvs" / "tokdash" / suffix[0] / suffix[1])
     for c in candidates:
         if c.is_file():
             return str(c)
@@ -228,9 +232,11 @@ def existing_service() -> Dict[str, Any]:
     """Report any service file present (setup-written or manual)."""
     unit = paths.systemd_unit_path()
     plist = paths.launchd_plist_path()
+    task = paths.winsched_task_path() if os_kind() == "windows" else None
     return {
         "systemd_unit": str(unit) if unit.is_file() else None,
         "launchd_plist": str(plist) if plist.is_file() else None,
+        "winsched_task": str(task) if task and task.is_file() else None,
     }
 
 
@@ -296,6 +302,7 @@ def detect_all(port: int) -> Dict[str, Any]:
         "tty": is_tty(),
         "systemd_user": systemd_user_available(),
         "launchd": launchd_available(),
+        "winsched": winsched_available(),
         "tailscale": tailscale_available(),
         "python": python_fitness(),
         "pipx": find_pipx(),

--- a/src/tokdash/onboard/engine.py
+++ b/src/tokdash/onboard/engine.py
@@ -21,7 +21,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from . import detect, launchd, manifest, paths, plan, runtime, systemd, tailscale, updatecheck
+from . import detect, launchd, manifest, paths, plan, runtime, systemd, tailscale, updatecheck, winsched
 from .plan import DEFAULT_PORT, Options
 
 EXIT_OK = 0
@@ -108,7 +108,7 @@ def cmd_setup(opts: Options) -> int:
         and not opts.yes
         and detection["tty"]
         and detection.get("tailscale")
-        and result.get("service", {}).get("type") in {"systemd-user", "launchd"}
+        and result.get("service", {}).get("type") in {"systemd-user", "launchd", "winsched"}
         and plan._is_loopback(result.get("bind", ""))
     ):
         _offer_tailscale(result)
@@ -409,6 +409,43 @@ def _apply_setup(p: Dict[str, Any], opts: Options) -> Dict[str, Any]:
             "created_by_setup": True, "marker": manifest.marker_token(marker_id),
         }
         changed.append("service:launchd")
+    elif svc_type == "winsched":
+        task_text = winsched.render_task(
+            rt["command"], p["bind"], p["port"], marker_id=marker_id, env_data_dir=p["env_data_dir"]
+        )
+        task_path = winsched.write_task(task_text)
+        winsched_errors: List[str] = []
+        try:
+            # Non-zero is benign only in that `/F` already forces a clean replace; a genuine
+            # failure here means the task never got registered at all.
+            proc = winsched.create(task_path)
+            if proc.returncode != 0:
+                return {
+                    "ok": False, "action": "setup",
+                    "error": f"schtasks /Create failed: {_proc_failure_detail(proc, f'exit {proc.returncode}')}",
+                }
+        except subprocess.TimeoutExpired as exc:
+            return {"ok": False, "action": "setup", "error": _timeout_detail("schtasks /Create", exc)}
+        except Exception as exc:  # pragma: no cover - environment dependent
+            return {"ok": False, "action": "setup", "error": f"failed to register Task Scheduler task: {exc}"}
+        try:
+            run_proc = winsched.run_now()
+            if run_proc.returncode != 0:
+                winsched_errors.append(
+                    "schtasks /Run: " + _proc_failure_detail(run_proc, f"exit {run_proc.returncode}")
+                )
+        except subprocess.TimeoutExpired as exc:
+            winsched_errors.append(_timeout_detail("schtasks /Run", exc))
+        except Exception as exc:  # pragma: no cover - environment dependent
+            return {"ok": False, "action": "setup", "error": f"failed to start Task Scheduler task: {exc}"}
+        service_status = winsched.status()
+        if winsched_errors:
+            service_status["start_error"] = "; ".join(winsched_errors)
+        service_block = {
+            "type": "winsched", "unit": str(task_path), "name": winsched.TASK_NAME,
+            "created_by_setup": True, "marker": manifest.marker_token(marker_id),
+        }
+        changed.append("service:winsched")
 
     # 3. Record the manifest (the revert contract).
     fit = detect.python_fitness(rt.get("python"))
@@ -454,7 +491,7 @@ def _apply_setup(p: Dict[str, Any], opts: Options) -> Dict[str, Any]:
                 ),
             })
             return result
-    if svc_type in {"systemd-user", "launchd"}:
+    if svc_type in {"systemd-user", "launchd", "winsched"}:
         readiness = _wait_for_service_ready(p["bind"], p["port"])
         result["readiness"] = readiness
         if not readiness.get("ok"):
@@ -496,6 +533,7 @@ def cmd_doctor(opts: Options) -> int:
         "python": {"version": fit.get("version"), "fit": fit.get("fit"), "reason": fit.get("reason")},
         "systemd_user": detection["systemd_user"],
         "launchd": detection.get("launchd"),
+        "winsched": detection.get("winsched"),
         "data_dir": detection["data_dir"],
         "manifest_present": man is not None,
         "install_method": (man or {}).get("install_method"),
@@ -516,7 +554,12 @@ def cmd_doctor(opts: Options) -> int:
 def _doctor_service(man: Optional[Dict[str, Any]], detection: Dict[str, Any]) -> Dict[str, Any]:
     service = (man or {}).get("service") or {}
     existing = detection["existing_service"]
-    unit = service.get("unit") or existing.get("systemd_unit") or existing.get("launchd_plist")
+    unit = (
+        service.get("unit")
+        or existing.get("systemd_unit")
+        or existing.get("launchd_plist")
+        or existing.get("winsched_task")
+    )
     stype = service.get("type")
     info: Dict[str, Any] = {"type": stype, "unit": unit, "present": bool(unit and Path(unit).is_file())}
     if stype == "systemd-user" and detection["systemd_user"]:
@@ -530,6 +573,9 @@ def _doctor_service(man: Optional[Dict[str, Any]], detection: Dict[str, Any]) ->
     elif stype == "launchd" and detection.get("launchd"):
         loaded = launchd.is_loaded()
         info.update({"enabled": loaded, "active": loaded})
+    elif stype == "winsched" and detection.get("winsched"):
+        registered = winsched.is_registered()
+        info.update({"enabled": registered, "active": winsched.is_running() if registered else False})
     return info
 
 
@@ -554,7 +600,7 @@ def _append_service_issues(issues: List[str], man: Optional[Dict[str, Any]], ser
             )
         return
     stype = service.get("type")
-    if stype not in {"systemd-user", "launchd"}:
+    if stype not in {"systemd-user", "launchd", "winsched"}:
         return
     if not service.get("present"):
         issues.append(f"{stype} service unit is recorded in the manifest but the file is missing: {service.get('unit')}")
@@ -568,6 +614,9 @@ def _append_service_issues(issues: List[str], man: Optional[Dict[str, Any]], ser
             issues.append(
                 f"systemd service name resolves to {loaded}, not the manifest unit {service.get('unit')}."
             )
+    elif stype == "winsched" and not detection.get("winsched"):
+        issues.append("Task Scheduler (schtasks) is unavailable, but the manifest records a winsched service.")
+        return
     if "active" in service and not service.get("active"):
         issues.append(f"{stype} service is not active.")
     port = detection.get("port") or {}
@@ -625,12 +674,17 @@ def cmd_update(opts: Options) -> int:
         )
 
     service_type = service.get("type")
-    restart_managed = service_type in {"systemd-user", "launchd"}
+    restart_managed = service_type in {"systemd-user", "launchd", "winsched"}
     # Fallback must be service-type aware: the launchd label is com.tokdash.tokdash, not
     # "tokdash" — a literal-"tokdash" fallback would print a remediation command targeting a
     # non-existent agent. `or` (not dict.get default) so a manifest with name present-but-None
     # (hand-edited/corrupt) also degrades to the safe default instead of "...restart None".
-    default_name = launchd.LABEL if service_type == "launchd" else systemd.SERVICE_NAME
+    if service_type == "launchd":
+        default_name = launchd.LABEL
+    elif service_type == "winsched":
+        default_name = winsched.TASK_NAME
+    else:
+        default_name = systemd.SERVICE_NAME
     service_name = service.get("name") or default_name
 
     if opts.dry_run:
@@ -645,6 +699,8 @@ def cmd_update(opts: Options) -> int:
             if restart_managed:
                 if service_type == "launchd":
                     print(f"Would restart: launchctl kickstart -k gui/$(id -u)/{service_name}")
+                elif service_type == "winsched":
+                    print(f"Would restart: schtasks /End /TN {service_name} & schtasks /Run /TN {service_name}")
                 else:
                     print(f"Would restart: systemctl --user restart {service_name}")
         return EXIT_OK
@@ -696,6 +752,17 @@ def cmd_update(opts: Options) -> int:
                 restart_failed = not restarted
             else:
                 restart_failed = True  # managed agent exists but launchctl is unreachable
+        elif service_type == "winsched":
+            if detect.winsched_available():
+                # Mirrors the launchd arm: any failure (including a hung/missing schtasks)
+                # is a failed restart, never a raw traceback.
+                try:
+                    restarted = winsched.restart(service_name).returncode == 0
+                except Exception:
+                    restarted = False
+                restart_failed = not restarted
+            else:
+                restart_failed = True  # managed task exists but schtasks is unreachable
         elif detect.systemd_user_available():
             try:
                 restarted = systemd.restart(service_name).returncode == 0
@@ -780,6 +847,8 @@ def _emit_update_result(opts: Options, result: Dict[str, Any]) -> int:
         name = result.get("service_name", "tokdash")
         if result.get("service_type") == "launchd":
             cmd = f"launchctl kickstart -k gui/$(id -u)/{name}"
+        elif result.get("service_type") == "winsched":
+            cmd = f"schtasks /End /TN {name} & schtasks /Run /TN {name}"
         else:
             cmd = f"systemctl --user restart {name}"
         before = result.get("version_before")
@@ -905,6 +974,29 @@ def _apply_uninstall(p: Dict[str, Any], opts: Options) -> Dict[str, Any]:
                                 detail = (proc.stderr or proc.stdout or "").strip()
                                 raise OSError(
                                     "launchctl bootout failed and the agent is still loaded "
+                                    f"(or its state could not be confirmed): {detail}"
+                                )
+                    unit = Path(step["unit"])
+                    if unit.is_file():
+                        unit.unlink()
+                elif step.get("service_type") == "winsched":
+                    if detect.winsched_available():
+                        # `schtasks /Delete` returns non-zero when the task simply isn't
+                        # registered (benign — nothing to remove), so treat it as a failure
+                        # ONLY if the task is STILL registered afterwards. A genuine
+                        # "couldn't delete it" must abort BEFORE we unlink our recorded XML
+                        # (so a retry can still find it) and surface as an error — mirroring
+                        # the launchd arm above.
+                        proc = winsched.delete(name)
+                        if proc.returncode != 0:
+                            try:
+                                still_registered = winsched.is_registered_strict(name)
+                            except Exception:
+                                still_registered = True
+                            if still_registered:
+                                detail = (proc.stderr or proc.stdout or "").strip()
+                                raise OSError(
+                                    "schtasks /Delete failed and the task is still registered "
                                     f"(or its state could not be confirmed): {detail}"
                                 )
                     unit = Path(step["unit"])
@@ -1117,14 +1209,21 @@ def _print_setup_result(r: Dict[str, Any]) -> None:
         print(f"    Status:   systemctl --user status {svc['name']} --no-pager")
         print(f"    Logs:     journalctl --user -u {svc['name']} -f")
         print(f"    Restart:  systemctl --user restart {svc['name']}")
-        print(f"    Remove:   tokdash uninstall")
+        print("    Remove:   tokdash uninstall")
     elif svc.get("type") == "launchd":
         print(_ok(_bold("Tokdash is running as a launchd user agent.")) + "\n")
         _print_open_targets(r["url"], tailnet_url)
         print(f"\n  {_bold('Manage:')}")
         print(f"    Status:   launchctl print gui/$(id -u)/{svc['name']}")
         print(f"    Restart:  launchctl kickstart -k gui/$(id -u)/{svc['name']}")
-        print(f"    Remove:   tokdash uninstall")
+        print("    Remove:   tokdash uninstall")
+    elif svc.get("type") == "winsched":
+        print(_ok(_bold("Tokdash is running as a Windows Task Scheduler task.")) + "\n")
+        _print_open_targets(r["url"], tailnet_url)
+        print(f"\n  {_bold('Manage:')}")
+        print(f"    Status:   schtasks /Query /TN {svc['name']} /V")
+        print(f"    Restart:  schtasks /End /TN {svc['name']} & schtasks /Run /TN {svc['name']}")
+        print("    Remove:   tokdash uninstall")
     else:
         # Match the recorded port/bind exactly — setup may have auto-picked a free port,
         # so a bare `tokdash serve` (which defaults to 55423) would bind elsewhere.
@@ -1192,6 +1291,8 @@ def _print_doctor_human(r: Dict[str, Any]) -> None:
     print(f"  Python:       {py['version']} ({'fit' if py['fit'] else 'UNFIT: ' + str(py['reason'])})")
     if r["os"] == "macos":
         print(f"  launchd:      {'available' if r.get('launchd') else 'unavailable'}")
+    elif r["os"] == "windows":
+        print(f"  Task Scheduler: {'available' if r.get('winsched') else 'unavailable'}")
     else:
         print(f"  systemd user: {'available' if r['systemd_user'] else 'unavailable'}")
     print(f"  Data dir:     {r['data_dir']}")

--- a/src/tokdash/onboard/paths.py
+++ b/src/tokdash/onboard/paths.py
@@ -67,8 +67,24 @@ def managed_venv_dir() -> Path:
     return runtime_dir() / "python-venv"
 
 
+def _windows_venv_layout() -> bool:
+    """Whether the managed venv uses the Windows ``Scripts/`` layout (Tier 2).
+
+    A tiny monkeypatchable seam around ``os.name`` (not ``detect.os_kind()``, so this stays
+    free of the detect<->paths dependency) — tests simulate the Windows branch by
+    monkeypatching *this* function rather than the real ``os.name``, because pathlib's
+    ``Path()`` constructor itself reads ``os.name`` to pick ``WindowsPath``/``PosixPath``;
+    mutating the real global would make every other fresh ``Path(...)`` call in the process
+    (including ones this module makes internally) try to build an unusable ``WindowsPath`` on
+    a non-Windows test host.
+    """
+    return os.name == "nt"
+
+
 def managed_venv_python() -> Path:
-    # Windows venvs put the interpreter under Scripts/, but Phase 1 targets POSIX.
+    # Windows venvs put the interpreter under Scripts/ (Tier 2); POSIX stays under bin/.
+    if _windows_venv_layout():
+        return managed_venv_dir() / "Scripts" / "python.exe"
     return managed_venv_dir() / "bin" / "python"
 
 
@@ -96,3 +112,17 @@ def systemd_unit_path(name: str = "tokdash") -> Path:
 def launchd_plist_path() -> Path:
     """macOS LaunchAgent path (Phase 4; defined here so doctor can report it)."""
     return Path("~/Library/LaunchAgents/com.tokdash.tokdash.plist").expanduser()
+
+
+def winsched_task_path() -> Path:
+    """Windows Task Scheduler task-definition source path (Tier 2; defined here so doctor
+    can report it, mirroring :func:`launchd_plist_path`).
+
+    ``schtasks`` keeps the live task registration in its own store, not this file — this is
+    where setup keeps its own copy of the last XML it registered, so the ownership-marker
+    check (``winsched.task_is_managed``) and the ``unit_path.is_file()`` gate work the same
+    way here as they do for the systemd/launchd backends.
+    """
+    base = os.environ.get("LOCALAPPDATA", "").strip()
+    root = Path(base).expanduser() if base else Path("~/AppData/Local").expanduser()
+    return root / "Tokdash" / "Tokdash.xml"

--- a/src/tokdash/onboard/plan.py
+++ b/src/tokdash/onboard/plan.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from . import detect, launchd, manifest, paths, runtime, systemd, tailscale
+from . import detect, launchd, manifest, paths, runtime, service_base, systemd, tailscale, winsched
 
 DEFAULT_PORT = 55423
 LOOPBACK = {"127.0.0.1", "::1", "localhost"}
@@ -174,6 +174,28 @@ def build_setup_plan(opts: Options, detection: Dict[str, Any]) -> Dict[str, Any]
             "created_by_setup": True,
             "marker": manifest.marker_token(marker_id),
         }
+    elif service["type"] == "winsched" and rt["command"]:
+        # Same overwrite guard as systemd/launchd: refuse an unmarked, hand-installed task.
+        existing_task = detection["existing_service"].get("winsched_task")
+        if existing_task and not winsched.task_is_managed(Path(existing_task)) and not opts.force:
+            blockers.append(
+                f"{existing_task} already exists and was not created by tokdash setup; refusing to "
+                "overwrite it. Re-run with --force to replace it, or remove it first."
+            )
+        marker_id = manifest.new_marker_id()
+        unit_text = winsched.render_task(
+            rt["command"], bind, port, marker_id=marker_id, env_data_dir=env_data_dir
+        )
+        task_path = paths.winsched_task_path()
+        changes.append(f"write {task_path}")
+        changes.append("register + start the Windows Task Scheduler task")
+        service_block = {
+            "type": "winsched",
+            "unit": str(task_path),
+            "name": winsched.TASK_NAME,
+            "created_by_setup": True,
+            "marker": manifest.marker_token(marker_id),
+        }
     elif service["type"] == "none":
         notes.append("No background service will be created; start Tokdash with `tokdash serve` (see the URL above for the bind/port).")
 
@@ -222,52 +244,26 @@ def build_setup_plan(opts: Options, detection: Dict[str, Any]) -> Dict[str, Any]
 
 
 def _resolve_service(opts: Options, detection: Dict[str, Any], blockers: List[str], notes: List[str]) -> Dict[str, Any]:
-    if opts.no_service or opts.service == "none":
-        return {"type": "none", "reason": "requested"}
-    want = opts.service
-    os_kind = detection["os"]
+    """Decide the service backend; delegates to :func:`service_base.select_service`.
 
-    # macOS -> launchd.
-    if os_kind == "macos":
-        if want in {"auto", "launchd"}:
-            if detection.get("launchd"):
-                return {"type": "launchd", "reason": None}
-            reason = "launchctl is unavailable"
-            if want == "launchd":
-                blockers.append(reason + "; re-run with --no-service or run `tokdash serve` yourself.")
-            else:
-                notes.append(reason + "; falling back to foreground guidance.")
-            return {"type": "none", "reason": reason}
-        if want == "systemd":
-            blockers.append("--service systemd is not supported on macOS; use --service launchd.")
-            return {"type": "none", "reason": "unsupported"}
-        return {"type": "none", "reason": "unknown"}
-
-    # Linux / WSL -> systemd user service.
-    if os_kind in {"linux", "wsl"}:
-        if want in {"auto", "systemd"}:
-            if detection.get("systemd_user"):
-                return {"type": "systemd-user", "reason": None}
-            reason = (
-                "systemd user services are unavailable"
-                + (" (enable WSL systemd in /etc/wsl.conf)" if os_kind == "wsl" else "")
-            )
-            if want == "systemd":
-                blockers.append(reason + "; re-run without --service systemd or use --no-service.")
-            else:
-                notes.append(reason + "; falling back to foreground guidance.")
-            return {"type": "none", "reason": reason}
-        if want == "launchd":
-            blockers.append("--service launchd is only supported on macOS.")
-            return {"type": "none", "reason": "unsupported"}
-        return {"type": "none", "reason": "unknown"}
-
-    # Other (e.g. native Windows): no managed service yet.
-    if want in {"systemd", "launchd"}:
-        blockers.append(f"--service {want} is not supported on {os_kind}.")
-        return {"type": "none", "reason": "unsupported"}
-    notes.append(f"Background service setup for {os_kind} is not available yet; use `tokdash serve`.")
-    return {"type": "none", "reason": "deferred"}
+    Kept as a thin adapter (extract primitives from ``opts``/``detection``, call the
+    centralized selection factory, thread its blockers/notes back into the caller's
+    accumulating lists) so this function's name/signature — and therefore its single
+    caller in :func:`build_setup_plan` plus any external import of it — stays unchanged.
+    The actual branch logic and every message string now live in
+    :mod:`.service_base` (moved verbatim; see that module's docstring).
+    """
+    sel = service_base.select_service(
+        opts.service,
+        detection["os"],
+        no_service=opts.no_service,
+        systemd_available=bool(detection.get("systemd_user")),
+        launchd_available=bool(detection.get("launchd")),
+        winsched_available=bool(detection.get("winsched")),
+    )
+    blockers.extend(sel.blockers)
+    notes.extend(sel.notes)
+    return sel.result
 
 
 # --- uninstall ------------------------------------------------------------------
@@ -285,6 +281,8 @@ def _plan_service_removal(
     file_exists = unit_path.is_file()
     if service_type == "launchd":
         is_ours = launchd.plist_is_managed(unit_path, marker_id) if file_exists else False
+    elif service_type == "winsched":
+        is_ours = winsched.task_is_managed(unit_path, marker_id) if file_exists else False
     else:
         is_ours = systemd.unit_is_managed(unit_path, marker_id) if file_exists else False
     step = {"kind": "service", "unit": str(unit_path), "name": name, "service_type": service_type}
@@ -344,7 +342,7 @@ def build_uninstall_plan(opts: Options, detection: Dict[str, Any]) -> Dict[str, 
         _plan_service_removal(
             steps, removed, blockers, opts,
             unit_path=Path(manifest_unit), service_type=manifest_type, marker_id=marker_id,
-            name=service.get("name", launchd.LABEL if manifest_type == "launchd" else "tokdash"),
+            name=service.get("name", _default_service_name(manifest_type)),
             have_manifest=have_manifest, created_by_setup=service.get("created_by_setup"),
             block_unmarked=True,  # a recorded-but-replaced unit must warn, not be deleted
         )
@@ -355,13 +353,17 @@ def build_uninstall_plan(opts: Options, detection: Dict[str, Any]) -> Dict[str, 
         # disk and remove only marker-carrying (provably ours) units, so a single uninstall
         # truly removes the service it owns instead of leaving it running and lying.
         es = detection["existing_service"]
-        for stype, ustr in (("systemd-user", es.get("systemd_unit")), ("launchd", es.get("launchd_plist"))):
+        for stype, ustr in (
+            ("systemd-user", es.get("systemd_unit")),
+            ("launchd", es.get("launchd_plist")),
+            ("winsched", es.get("winsched_task")),
+        ):
             if not ustr:
                 continue
             _plan_service_removal(
                 steps, removed, blockers, opts,
                 unit_path=Path(ustr), service_type=stype, marker_id=None,
-                name=launchd.LABEL if stype == "launchd" else "tokdash",
+                name=_default_service_name(stype),
                 have_manifest=have_manifest, created_by_setup=False,
                 # Only the truly-unknown (no-manifest) case blocks an unmarked unit. When the
                 # manifest says we created no service, an unmarked unit is provably NOT ours —
@@ -433,3 +435,12 @@ def _marker_id_from(marker: Optional[str]) -> Optional[str]:
         if token.startswith("id="):
             return token[3:]
     return None
+
+
+def _default_service_name(service_type: Optional[str]) -> str:
+    """Fallback service ``name`` when a (possibly hand-edited/legacy) manifest omits it."""
+    if service_type == "launchd":
+        return launchd.LABEL
+    if service_type == "winsched":
+        return winsched.TASK_NAME
+    return "tokdash"

--- a/src/tokdash/onboard/runtime.py
+++ b/src/tokdash/onboard/runtime.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 from . import detect, paths

--- a/src/tokdash/onboard/service_base.py
+++ b/src/tokdash/onboard/service_base.py
@@ -1,0 +1,199 @@
+"""Service-backend seam: the extension point the ``winsched`` module plugs into.
+
+``systemd.py``, ``launchd.py`` and ``winsched.py`` are the three backends today, all plain
+modules (not classes) exposing a small, overlapping surface: render the unit/plist/task
+text, write it to disk, check whether an on-disk unit carries setup's ownership marker, and
+report status. This module formalizes that surface as a :class:`typing.Protocol`
+(documentation/typing only — it does not rewrite ``systemd``/``launchd``/``winsched`` into
+classes), provides a registry mapping a resolved ``service_type`` string to its backend
+module, and centralizes the *selection* decision (:func:`select_service`) that used to live
+inline in ``plan._resolve_service``.
+
+Tier 2 (native Windows Task Scheduler support) registers ``winsched`` here and extends
+``select_service`` with a dedicated ``windows`` branch (mirroring the macOS/linux branches
+below); every other OS kind still resolves exactly as before this seams refactor.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import ModuleType
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+from . import launchd, systemd, winsched
+
+
+@runtime_checkable
+class ServiceBackend(Protocol):
+    """Structural contract a per-user service backend module should satisfy.
+
+    ``systemd``, ``launchd`` and ``winsched`` already implement this shape, each under its
+    own backend-specific names — this Protocol is the generic vocabulary they can be checked
+    against. It is intentionally *not* applied via ``isinstance()``/type annotations to the
+    real ``systemd``/``launchd``/``winsched`` modules anywhere in this codebase (their public
+    functions are named ``render_unit``/``render_plist``/``render_task``,
+    ``write_unit``/``write_plist``/``write_task``, ``unit_is_managed``/``plist_is_managed``/
+    ``task_is_managed``, and they additionally expose backend-specific lifecycle verbs —
+    ``daemon_reload``/``enable_now``/``disable_now``/``restart`` for systemd,
+    ``bootstrap``/``bootout``/``kickstart`` for launchd, ``create``/``delete``/``query`` for
+    winsched — that have no shared name across backends and so are deliberately left out of
+    this Protocol). Concrete mapping today:
+
+    =============== ================== =================== ===================
+    concept          systemd.py         launchd.py           winsched.py
+    =============== ================== =================== ===================
+    name/label       SERVICE_NAME       LABEL                TASK_NAME
+    marker comment   MARKER_COMMENT     MARKER_COMMENT       MARKER_COMMENT
+    render(...)      render_unit(...)   render_plist(...)    render_task(...)
+    write(text)      write_unit(text)   write_plist(text)    write_task(text)
+    is_managed(...)  unit_is_managed    plist_is_managed     task_is_managed
+    status()         status()          status()             status()
+    =============== ================== =================== ===================
+    """
+
+    MARKER_COMMENT: str
+
+    def render(self, *args: Any, **kwargs: Any) -> str:
+        """Render the unit/plist/task text for a given runtime command/bind/port."""
+        ...
+
+    def write(self, text: str, *args: Any, **kwargs: Any) -> Any:
+        """Persist rendered text to its on-disk path; returns the path written."""
+        ...
+
+    def is_managed(self, path: Any, marker_id: Optional[str] = None) -> bool:
+        """Does the on-disk unit carry setup's ownership marker (optionally a specific id)?"""
+        ...
+
+    def status(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        """Current enabled/active snapshot as a dict."""
+        ...
+
+
+# Registry: resolved ``service_type`` string -> backend module. Tier 2 registers the
+# native Windows Task Scheduler backend here (alongside its select_service() branch and
+# the apply/uninstall dispatch in engine.py); this is the same extension point a further
+# future backend would use.
+SERVICE_BACKENDS: Dict[str, ModuleType] = {
+    "systemd-user": systemd,
+    "launchd": launchd,
+    "winsched": winsched,
+}
+
+
+def backend_for(service_type: str) -> Optional[ModuleType]:
+    """Look up the backend module for a resolved ``service_type``.
+
+    Returns ``None`` for ``"none"`` and any unregistered/unknown type — matching current
+    semantics where no backend module is dispatched to in that case.
+    """
+    return SERVICE_BACKENDS.get(service_type)
+
+
+@dataclass
+class ServiceSelection:
+    """Outcome of :func:`select_service`.
+
+    ``result`` is the ``{"type", "reason"}`` dict returned by (what used to be, and still
+    is, externally) ``plan._resolve_service``. ``blockers``/``notes`` are the messages
+    that call site must append to its own accumulating lists, in order, so the overall
+    plan output is unchanged.
+    """
+
+    result: Dict[str, Any]
+    blockers: List[str] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
+
+
+def select_service(
+    want: str,
+    os_kind: str,
+    *,
+    no_service: bool,
+    systemd_available: bool,
+    launchd_available: bool,
+    winsched_available: bool = False,
+) -> ServiceSelection:
+    """Decide which service backend (if any) setup should configure.
+
+    The macOS/linux/wsl/"other" branches are copied verbatim (branch logic and every message
+    string) from the pre-refactor ``plan._resolve_service`` body and are UNCHANGED by Tier 2;
+    ``opts``/``detection`` lookups are primitive parameters so this module has no dependency
+    on :mod:`.plan` (avoiding a circular import). ``plan._resolve_service`` delegates here and
+    threads ``result``/``blockers``/``notes`` back into its own arguments, so the externally
+    observable behavior for every non-windows OS kind — the returned dict and every
+    blocker/note string, verbatim, in the same order — is unchanged.
+
+    ``windows`` gets its own dedicated branch (mirroring the macOS/linux-wsl shape): ``auto``
+    or an explicit ``--service winsched`` resolves to the ``winsched`` backend when Task
+    Scheduler is available, else falls back with a note (auto) or a blocker (explicit),
+    exactly like launchd's "launchctl is unavailable" shape. An explicit
+    ``--service systemd``/``--service launchd`` on Windows keeps the same
+    ``f"--service {want} is not supported on {os_kind}."`` blocker as before. Any other
+    (non-windows, non-macOS/linux/wsl) OS kind still resolves to ``{"type": "none", ...}``
+    ("unsupported" for an explicit --service request, "deferred" for auto) — unchanged.
+    ``winsched_available`` defaults to ``False`` so every pre-existing call site (which never
+    passes it) is unaffected.
+    """
+    blockers: List[str] = []
+    notes: List[str] = []
+
+    if no_service or want == "none":
+        return ServiceSelection({"type": "none", "reason": "requested"}, blockers, notes)
+
+    # macOS -> launchd.
+    if os_kind == "macos":
+        if want in {"auto", "launchd"}:
+            if launchd_available:
+                return ServiceSelection({"type": "launchd", "reason": None}, blockers, notes)
+            reason = "launchctl is unavailable"
+            if want == "launchd":
+                blockers.append(reason + "; re-run with --no-service or run `tokdash serve` yourself.")
+            else:
+                notes.append(reason + "; falling back to foreground guidance.")
+            return ServiceSelection({"type": "none", "reason": reason}, blockers, notes)
+        if want == "systemd":
+            blockers.append("--service systemd is not supported on macOS; use --service launchd.")
+            return ServiceSelection({"type": "none", "reason": "unsupported"}, blockers, notes)
+        return ServiceSelection({"type": "none", "reason": "unknown"}, blockers, notes)
+
+    # Linux / WSL -> systemd user service.
+    if os_kind in {"linux", "wsl"}:
+        if want in {"auto", "systemd"}:
+            if systemd_available:
+                return ServiceSelection({"type": "systemd-user", "reason": None}, blockers, notes)
+            reason = (
+                "systemd user services are unavailable"
+                + (" (enable WSL systemd in /etc/wsl.conf)" if os_kind == "wsl" else "")
+            )
+            if want == "systemd":
+                blockers.append(reason + "; re-run without --service systemd or use --no-service.")
+            else:
+                notes.append(reason + "; falling back to foreground guidance.")
+            return ServiceSelection({"type": "none", "reason": reason}, blockers, notes)
+        if want == "launchd":
+            blockers.append("--service launchd is only supported on macOS.")
+            return ServiceSelection({"type": "none", "reason": "unsupported"}, blockers, notes)
+        return ServiceSelection({"type": "none", "reason": "unknown"}, blockers, notes)
+
+    # Native Windows -> Task Scheduler.
+    if os_kind == "windows":
+        if want in {"auto", "winsched"}:
+            if winsched_available:
+                return ServiceSelection({"type": "winsched", "reason": None}, blockers, notes)
+            reason = "Task Scheduler (schtasks) is unavailable"
+            if want == "winsched":
+                blockers.append(reason + "; re-run with --no-service or run `tokdash serve` yourself.")
+            else:
+                notes.append(reason + "; falling back to foreground guidance.")
+            return ServiceSelection({"type": "none", "reason": reason}, blockers, notes)
+        if want in {"systemd", "launchd"}:
+            blockers.append(f"--service {want} is not supported on {os_kind}.")
+            return ServiceSelection({"type": "none", "reason": "unsupported"}, blockers, notes)
+        return ServiceSelection({"type": "none", "reason": "unknown"}, blockers, notes)
+
+    # Other (unrecognized OS kind): no managed service yet.
+    if want in {"systemd", "launchd", "winsched"}:
+        blockers.append(f"--service {want} is not supported on {os_kind}.")
+        return ServiceSelection({"type": "none", "reason": "unsupported"}, blockers, notes)
+    notes.append(f"Background service setup for {os_kind} is not available yet; use `tokdash serve`.")
+    return ServiceSelection({"type": "none", "reason": "deferred"}, blockers, notes)

--- a/src/tokdash/onboard/winsched.py
+++ b/src/tokdash/onboard/winsched.py
@@ -1,0 +1,268 @@
+"""Windows Task Scheduler *per-user* task generation and lifecycle (Tier 2).
+
+The Windows analogue of :mod:`.systemd` (Linux/WSL) and :mod:`.launchd` (macOS). A task
+named :data:`TASK_NAME` carries the same ownership marker so ``uninstall`` can prove setup
+wrote it before removing it (mirrors §12.3 for the other two backends). All lifecycle calls
+go through per-user ``schtasks`` only — never an elevated/system task, never ``runas``.
+
+Task Scheduler has no single "unit file" the way systemd/launchd do; ``schtasks`` keeps the
+live registration in its own store. To keep the same on-disk "does this file carry our
+marker" gate the other two backends use (:func:`task_is_managed`, mirroring
+``unit_is_managed``/``plist_is_managed``), setup keeps its own copy of the last XML it
+registered at :func:`paths.winsched_task_path`; :func:`task_is_managed` also accepts a bare
+task name, in which case it asks ``schtasks`` for the live definition instead of reading a
+file (useful when only the name, not a source file, is known).
+
+Task Scheduler's XML schema has no first-class per-action environment variable slot (unlike
+systemd's ``Environment=`` or launchd's ``EnvironmentVariables`` dict) and the task always
+runs ``pythonw.exe`` (never ``python.exe``) so it never flashes a console window — the
+Windows analogue of how systemd/launchd detach the service from any controlling terminal.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path, PureWindowsPath
+from typing import Any, Dict, List, Optional, Union
+from xml.sax.saxutils import escape
+
+from . import manifest, paths
+
+TASK_NAME = "Tokdash"
+MARKER_COMMENT = "Managed-by: tokdash-setup"
+LIFECYCLE_TIMEOUT = 120
+
+def _pythonw_for(python_exe: str) -> str:
+    """Best-effort swap of a ``python.exe`` interpreter path for its windowless ``pythonw.exe`` twin.
+
+    Task Scheduler runs this task in the triggering user's interactive session (LogonTrigger +
+    InteractiveToken — mirroring launchd's ``gui/<uid>`` domain / systemd's ``--user`` scope,
+    never a SYSTEM/elevated task), where a console-subsystem executable like ``python.exe``
+    would flash a console window. ``pythonw.exe`` is the GUI-subsystem twin Windows never
+    allocates a console for. Falls back to the given path unchanged if it does not look like a
+    plain ``python.exe`` (e.g. an unexpected runtime), so this never invents a nonexistent binary.
+    """
+    p = PureWindowsPath(python_exe)
+    if p.name.lower() == "python.exe":
+        return str(p.with_name("pythonw.exe"))
+    return python_exe
+
+
+def _module_args(runtime_command: List[str], bind: str, port: int) -> List[str]:
+    """Args after the interpreter: ``<runtime_command[1:]> serve --bind <bind> --port <port> --no-open``."""
+    return list(runtime_command[1:]) + ["serve", "--bind", bind, "--port", str(port), "--no-open"]
+
+
+def _tokdash_argv(module_args: List[str]) -> List[str]:
+    """``sys.argv`` for a ``runpy.run_module('tokdash')`` trampoline.
+
+    ``runtime_command`` is normally ``[python, "-m", "tokdash"]``. The direct task path
+    needs those ``-m tokdash`` interpreter arguments, but the ``-c`` trampoline has already
+    chosen the module via ``runpy.run_module('tokdash', ...)``; leaving ``-m tokdash`` in
+    ``sys.argv`` would make Tokdash's CLI parse ``-m`` as the command.
+    """
+    if len(module_args) >= 2 and module_args[:2] == ["-m", "tokdash"]:
+        return ["tokdash"] + module_args[2:]
+    return ["tokdash"] + module_args
+
+
+def render_task(
+    runtime_command: List[str],
+    bind: str,
+    port: int,
+    *,
+    marker_id: str,
+    env_data_dir: Optional[str] = None,
+) -> str:
+    """Render the Task Scheduler task definition text (``schtasks /Create /XML`` shape).
+
+    ``<Command>`` is always :func:`_pythonw_for` of ``runtime_command[0]`` so the task never
+    flashes a console window. When the data dir is non-default, since Task Scheduler has no
+    per-action environment slot, ``env_data_dir`` is threaded in via a small self-contained
+    ``-c`` snippet that sets ``os.environ`` before dispatching into ``tokdash`` — still just
+    one ``pythonw.exe`` process, no shell/console wrapper (mirror of §10.1's env line).
+    """
+    python_exe = runtime_command[0] if runtime_command else ""
+    command = _pythonw_for(python_exe)
+    module_args = _module_args(runtime_command, bind, port)
+
+    if env_data_dir:
+        argv_literal = repr(_tokdash_argv(module_args))
+        snippet = (
+            "import os,runpy,sys;"
+            f"os.environ['TOKDASH_DATA_DIR']={env_data_dir!r};"
+            f"sys.argv={argv_literal};"
+            "runpy.run_module('tokdash', run_name='__main__')"
+        )
+        arguments = subprocess.list2cmdline(["-c", snippet])
+    else:
+        arguments = subprocess.list2cmdline(module_args)
+
+    description = f"{MARKER_COMMENT}&#10;{escape(manifest.marker_token(marker_id))}"
+
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">',
+        "  <RegistrationInfo>",
+        f"    <Description>{description}</Description>",
+        "  </RegistrationInfo>",
+        "  <Triggers>",
+        "    <LogonTrigger>",
+        "      <Enabled>true</Enabled>",
+        "    </LogonTrigger>",
+        "  </Triggers>",
+        "  <Principals>",
+        '    <Principal id="Author">',
+        "      <LogonType>InteractiveToken</LogonType>",
+        "      <RunLevel>LeastPrivilege</RunLevel>",
+        "    </Principal>",
+        "  </Principals>",
+        "  <Settings>",
+        "    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>",
+        "    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>",
+        "    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>",
+        "    <StartWhenAvailable>true</StartWhenAvailable>",
+        "    <RestartOnFailure>",
+        "      <Interval>PT1M</Interval>",
+        "      <Count>3</Count>",
+        "    </RestartOnFailure>",
+        "  </Settings>",
+        '  <Actions Context="Author">',
+        "    <Exec>",
+        f"      <Command>{escape(command)}</Command>",
+        f"      <Arguments>{escape(arguments)}</Arguments>",
+        "    </Exec>",
+        "  </Actions>",
+        "</Task>",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _read_definition_text(path_or_name: Union[Path, str]) -> Optional[str]:
+    if isinstance(path_or_name, Path):
+        try:
+            return path_or_name.read_text(encoding="utf-8")
+        except OSError:
+            return None
+    # A bare task name: ask Task Scheduler for the live XML definition it holds today.
+    try:
+        proc = _run(["/Query", "/TN", str(path_or_name), "/XML"], timeout=10)
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def task_is_managed(path_or_name: Union[Path, str], marker_id: Optional[str] = None) -> bool:
+    """Does this task (by source-file path, or by live name) carry setup's ownership marker?"""
+    text = _read_definition_text(path_or_name)
+    if text is None:
+        return False
+    if "X-Tokdash-Managed" not in text:
+        return False
+    if marker_id is not None:
+        return f"id={marker_id}" in text
+    return True
+
+
+def write_task(text: str) -> Path:
+    path = paths.winsched_task_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _run(args: List[str], timeout: int = 20) -> subprocess.CompletedProcess:
+    return subprocess.run(["schtasks", *args], capture_output=True, text=True, timeout=timeout)
+
+
+def create(task_path: Path, name: str = TASK_NAME) -> subprocess.CompletedProcess:
+    """Register (or replace, ``/F``) the task from the XML file written by :func:`write_task`."""
+    return _run(["/Create", "/TN", name, "/XML", str(task_path), "/F"], timeout=LIFECYCLE_TIMEOUT)
+
+
+def delete(name: str = TASK_NAME) -> subprocess.CompletedProcess:
+    return _run(["/Delete", "/TN", name, "/F"], timeout=LIFECYCLE_TIMEOUT)
+
+
+def run_now(name: str = TASK_NAME) -> subprocess.CompletedProcess:
+    return _run(["/Run", "/TN", name], timeout=LIFECYCLE_TIMEOUT)
+
+
+def end_task(name: str = TASK_NAME) -> subprocess.CompletedProcess:
+    return _run(["/End", "/TN", name], timeout=LIFECYCLE_TIMEOUT)
+
+
+def restart(name: str = TASK_NAME) -> subprocess.CompletedProcess:
+    """``/End`` (best-effort; benign if not currently running) then ``/Run``.
+
+    Task Scheduler has no single "restart" verb — this is the Windows analogue of launchd's
+    ``kickstart -k`` / systemd's ``restart``.
+    """
+    try:
+        end_task(name)
+    except Exception:
+        pass
+    return run_now(name)
+
+
+def register(text: str, name: str = TASK_NAME) -> Path:
+    """Write the rendered definition to disk, then register it with Task Scheduler.
+
+    A one-shot convenience combining :func:`write_task` + :func:`create`, analogous to
+    ``write_unit``+``enable_now`` / ``write_plist``+``bootstrap`` being called together.
+    """
+    path = write_task(text)
+    create(path, name)
+    return path
+
+
+def query(name: str = TASK_NAME) -> subprocess.CompletedProcess:
+    return _run(["/Query", "/TN", name, "/FO", "LIST", "/V"], timeout=10)
+
+
+def _status_field(text: str) -> Optional[str]:
+    for line in text.splitlines():
+        if line.strip().lower().startswith("status:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def is_registered(name: str = TASK_NAME) -> bool:
+    try:
+        return query(name).returncode == 0
+    except Exception:
+        return False
+
+
+def is_registered_strict(name: str = TASK_NAME) -> bool:
+    """Like :func:`is_registered` but does NOT swallow errors/timeouts.
+
+    ``is_registered()`` returns False both for "confirmed not registered" and "could not
+    determine". The uninstall teardown must tell those apart so it can fail CLOSED when it
+    cannot confirm the task was removed — it calls this variant and treats a raised error
+    (e.g. a hung ``schtasks``) as "state unknown -> assume still registered".
+    """
+    return query(name).returncode == 0
+
+
+def is_running(name: str = TASK_NAME) -> bool:
+    """Best-effort ``Running`` state parsed from ``schtasks /Query ... /V`` text output."""
+    try:
+        proc = query(name)
+    except Exception:
+        return False
+    if proc.returncode != 0:
+        return False
+    return _status_field(proc.stdout) == "Running"
+
+
+def status(name: str = TASK_NAME) -> Dict[str, Any]:
+    registered = is_registered(name)
+    return {
+        "type": "winsched",
+        "name": name,
+        "enabled": registered,
+        "active": is_running(name) if registered else False,
+    }

--- a/src/tokdash/osinfo.py
+++ b/src/tokdash/osinfo.py
@@ -1,0 +1,54 @@
+"""Centralized OS detection (Tier 0 seams refactor).
+
+This is the canonical home for OS-kind detection. ``onboard/detect.py``
+historically owned ``os_kind()``/``is_wsl()`` for the setup engine; those now
+delegate here so there is exactly one implementation, while every existing
+caller of ``detect.os_kind()`` (or anything reading ``detection["os"]``)
+keeps working unchanged.
+
+Each probe fails safe: detection must never raise, and an unknown answer is
+treated conservatively by callers.
+"""
+from __future__ import annotations
+
+import platform
+import sys
+from pathlib import Path
+
+
+def is_wsl() -> bool:
+    """True when running on Linux under Windows Subsystem for Linux."""
+    if sys.platform != "linux":
+        return False
+    if "microsoft" in platform.release().lower():
+        return True
+    try:
+        return "microsoft" in Path("/proc/version").read_text(encoding="utf-8").lower()
+    except OSError:
+        return False
+
+
+def os_kind() -> str:
+    """One of ``linux`` | ``wsl`` | ``macos`` | ``windows``."""
+    if sys.platform == "darwin":
+        return "macos"
+    if sys.platform.startswith("win"):
+        return "windows"
+    if is_wsl():
+        return "wsl"
+    return "linux"
+
+
+def is_windows() -> bool:
+    """True when ``os_kind()`` is ``windows``."""
+    return os_kind() == "windows"
+
+
+def is_macos() -> bool:
+    """True when ``os_kind()`` is ``macos``."""
+    return os_kind() == "macos"
+
+
+def is_linux() -> bool:
+    """True when ``os_kind()`` is ``linux`` (native Linux, not WSL)."""
+    return os_kind() == "linux"

--- a/src/tokdash/sessions.py
+++ b/src/tokdash/sessions.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
+from . import clientpaths
 from .compute import cache_hit_rate, period_to_days
 from .dateutil import parse_date_range
 from .pricing import PricingDatabase
@@ -366,7 +367,7 @@ def _pricing_signature() -> tuple:
 
 
 def _codex_state_db_path() -> Path:
-    return Path.home() / ".codex" / "state_5.sqlite"
+    return clientpaths.codex_state_db_path()
 
 
 def _codex_state_signature() -> tuple:
@@ -534,7 +535,7 @@ def _load_codex_sessions(signature: tuple[tuple[str, int, int], ...], pricing_si
 
 
 def _codex_sessions() -> Dict[str, Dict[str, Any]]:
-    root = Path.home() / ".codex" / "sessions"
+    root = clientpaths.codex_sessions_dir()
     return _apply_codex_title_map(_load_codex_sessions(_iter_file_signatures(root), _pricing_signature()))
 
 
@@ -668,16 +669,14 @@ def _load_claude_sessions(signature: tuple[tuple[str, int, int], ...], pricing_s
 
 def _claude_sessions() -> Dict[str, Dict[str, Any]]:
     all_sigs: list[tuple[str, int, int]] = []
-    for claude_dir in sorted(Path.home().glob(".claude*")):
-        projects_dir = claude_dir / "projects"
-        if projects_dir.is_dir():
-            all_sigs.extend(_iter_file_signatures(projects_dir))
+    for projects_dir in clientpaths.claude_project_dirs():
+        all_sigs.extend(_iter_file_signatures(projects_dir))
     all_sigs.sort(key=lambda item: item[0])
     return _load_claude_sessions(tuple(all_sigs), _pricing_signature())
 
 
 def _opencode_db_signature() -> tuple[tuple[str, int, int], ...]:
-    db_path = Path.home() / ".local/share/opencode/opencode.db"
+    db_path = clientpaths.opencode_db_path()
     if not db_path.exists():
         return ()
     signatures: list[tuple[str, int, int]] = []
@@ -978,10 +977,7 @@ def _opencode_sessions(since_ms: Optional[int] = None, until_ms: Optional[int] =
 
 
 def _pi_session_roots() -> list[Path]:
-    raw = os.environ.get("PI_AGENT_DIR", "").strip()
-    if raw:
-        return [Path(item.strip()).expanduser() for item in raw.split(",") if item.strip()]
-    return [Path.home() / ".pi" / "agent" / "sessions"]
+    return clientpaths.pi_agent_search_dirs()
 
 
 def _pi_session_signatures() -> tuple[tuple[str, int, int], ...]:
@@ -1218,7 +1214,7 @@ def _session_records_to_raw_sessions(tool: str, records: Iterable[Dict[str, Any]
 def _stored_sessions_for_tool(tool: str) -> Dict[str, Dict[str, Any]]:
     store = UsageEntryStore()
     if tool == "codex":
-        root = Path.home() / ".codex" / "sessions"
+        root = clientpaths.codex_sessions_dir()
         signatures = _iter_file_signatures(root)
         parser_sig = {"parser": parser_code_signature(_parse_codex_session_file), "pricing": _pricing_signature()}
         pricing_sig = _pricing_signature()
@@ -1230,10 +1226,8 @@ def _stored_sessions_for_tool(tool: str) -> Dict[str, Dict[str, Any]]:
         )
     elif tool == "claude":
         all_sigs: list[tuple[str, int, int]] = []
-        for claude_dir in sorted(Path.home().glob(".claude*")):
-            projects_dir = claude_dir / "projects"
-            if projects_dir.is_dir():
-                all_sigs.extend(_iter_file_signatures(projects_dir))
+        for projects_dir in clientpaths.claude_project_dirs():
+            all_sigs.extend(_iter_file_signatures(projects_dir))
         all_sigs.sort(key=lambda item: item[0])
         parser_sig = {"parser": parser_code_signature(_parse_claude_session_file), "pricing": _pricing_signature()}
         pricing_sig = _pricing_signature()

--- a/src/tokdash/sources/coding_tools.py
+++ b/src/tokdash/sources/coding_tools.py
@@ -19,9 +19,11 @@ from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
 
 try:
+    from .. import clientpaths
     from ..pricing import PricingDatabase
 except ImportError:  # pragma: no cover
     # Allow running as a script by file path.
+    import clientpaths
     from pricing import PricingDatabase
 
 
@@ -199,8 +201,8 @@ class OpenCodeParser(BaseParser):
 
     def __init__(self, pricing_db: PricingDatabase):
         super().__init__(pricing_db)
-        self.messages_dir = Path.home() / ".local/share/opencode/storage/message"
-        self.db_path = Path.home() / ".local/share/opencode/opencode.db"
+        self.messages_dir = clientpaths.opencode_messages_dir()
+        self.db_path = clientpaths.opencode_db_path()
 
     def _build_entry(self, model: str, provider: str, tokens: Dict[str, Any], ts_ms: int) -> Dict[str, Any]:
         cache = tokens.get("cache") if isinstance(tokens.get("cache"), dict) else {}
@@ -303,7 +305,7 @@ class CodexParser(BaseParser):
 
     def __init__(self, pricing_db: PricingDatabase):
         super().__init__(pricing_db)
-        self.sessions_dir = Path.home() / ".codex/sessions"
+        self.sessions_dir = clientpaths.codex_sessions_dir()
 
     @staticmethod
     def _infer_provider(model: str, fallback: str = "openai") -> str:
@@ -401,11 +403,7 @@ class ClaudeParser(BaseParser):
 
     def __init__(self, pricing_db: PricingDatabase):
         super().__init__(pricing_db)
-        self.projects_dirs = [
-            p / "projects"
-            for p in sorted(Path.home().glob(".claude*"))
-            if (p / "projects").is_dir()
-        ]
+        self.projects_dirs = clientpaths.claude_project_dirs()
 
     @staticmethod
     def _infer_provider(model: str) -> str:
@@ -581,7 +579,7 @@ class GeminiCLIParser(BaseParser):
 
     def __init__(self, pricing_db: PricingDatabase):
         super().__init__(pricing_db)
-        self.gemini_root = Path.home() / ".gemini"
+        self.gemini_root = clientpaths.gemini_root()
 
     def _build_entry(self, model: str, tokens: Dict[str, Any], ts_ms: int) -> Dict[str, Any]:
         raw_input = self._i(tokens.get("input"))
@@ -612,8 +610,8 @@ class GeminiCLIParser(BaseParser):
 
     def _file_signatures(self) -> tuple:
         def scan() -> tuple:
-            json_pattern = str(self.gemini_root / "tmp" / "*" / "chats" / "session-*.json")
-            jsonl_pattern = str(self.gemini_root / "tmp" / "*" / "chats" / "session-*.jsonl")
+            json_pattern = clientpaths.gemini_chats_json_glob(self.gemini_root)
+            jsonl_pattern = clientpaths.gemini_chats_jsonl_glob(self.gemini_root)
             return tuple(sorted(_glob_sigs(json_pattern) + _glob_sigs(jsonl_pattern)))
 
         return _timed_sigs(f"gemini:{self.gemini_root}", scan)
@@ -687,7 +685,7 @@ class AmpParser(BaseParser):
 
     def __init__(self, pricing_db: PricingDatabase):
         super().__init__(pricing_db)
-        self.amp_root = Path.home() / ".amp"
+        self.amp_root = clientpaths.amp_root()
 
     def _parse_all(self) -> List[Dict[str, Any]]:
         # TODO(coding_tools): Amp parser placeholder.
@@ -742,8 +740,7 @@ class KimiParser(BaseParser):
 
     def __init__(self, pricing_db: PricingDatabase):
         super().__init__(pricing_db)
-        kimi_share_dir = os.environ.get("KIMI_SHARE_DIR", "").strip()
-        self.kimi_root = Path(kimi_share_dir).expanduser() if kimi_share_dir else (Path.home() / ".kimi")
+        self.kimi_root = clientpaths.kimi_root()
 
     @staticmethod
     def _default_model_for_timestamp(ts: datetime) -> str:
@@ -883,13 +880,8 @@ class PiAgentParser(BaseParser):
 
     def __init__(self, pricing_db: PricingDatabase):
         super().__init__(pricing_db)
-        pi_dir_env = os.environ.get("PI_AGENT_DIR", "").strip()
-        if pi_dir_env:
-            self.search_dirs = [Path(d.strip()).expanduser() for d in pi_dir_env.split(",") if d.strip()]
-            self.use_rglob = True
-        else:
-            self.search_dirs = [Path.home() / ".pi" / "agent" / "sessions"]
-            self.use_rglob = True
+        self.search_dirs = clientpaths.pi_agent_search_dirs()
+        self.use_rglob = True
 
     @staticmethod
     def _infer_provider(model: str, fallback: str = "") -> str:
@@ -1068,8 +1060,8 @@ class CopilotCLIParser(BaseParser):
 
     def __init__(self, pricing_db: PricingDatabase):
         super().__init__(pricing_db)
-        self.otel_dir = Path.home() / ".copilot" / "otel"
-        self.events_glob = str(Path.home() / ".copilot" / "session-state" / "*" / "events.jsonl")
+        self.otel_dir = clientpaths.copilot_otel_dir()
+        self.events_glob = clientpaths.copilot_events_glob()
 
     @staticmethod
     def _infer_provider(model: str) -> str:
@@ -1085,7 +1077,7 @@ class CopilotCLIParser(BaseParser):
     def _file_signatures(self) -> tuple:
         def scan() -> tuple:
             sigs = list(_rglob_sigs(self.otel_dir, "*.jsonl"))
-            otel_env = os.environ.get("COPILOT_OTEL_FILE_EXPORTER_PATH", "").strip()
+            otel_env = clientpaths.copilot_otel_exporter_path()
             if otel_env:
                 try:
                     s = os.stat(otel_env)
@@ -1381,7 +1373,7 @@ class CopilotCLIParser(BaseParser):
         otel_paths: List[str] = []
         for path_str, _, _ in _rglob_sigs(self.otel_dir, "*.jsonl"):
             otel_paths.append(path_str)
-        otel_env = os.environ.get("COPILOT_OTEL_FILE_EXPORTER_PATH", "").strip()
+        otel_env = clientpaths.copilot_otel_exporter_path()
         if otel_env and otel_env not in otel_paths:
             if os.path.isfile(otel_env):
                 otel_paths.append(otel_env)
@@ -1513,11 +1505,7 @@ class HermesParser(BaseParser):
 
     def __init__(self, pricing_db: PricingDatabase):
         super().__init__(pricing_db)
-        hermes_home_env = os.environ.get("HERMES_HOME", "").strip()
-        if hermes_home_env:
-            self.search_dirs = [Path(d.strip()).expanduser() for d in hermes_home_env.split(",") if d.strip()]
-        else:
-            self.search_dirs = [Path.home() / ".hermes"]
+        self.search_dirs = clientpaths.hermes_search_dirs()
 
     @staticmethod
     def _infer_provider(model: str) -> str:

--- a/src/tokdash/usage_store.py
+++ b/src/tokdash/usage_store.py
@@ -11,10 +11,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional
 
-try:
-    import fcntl
-except ImportError:  # pragma: no cover - Windows fallback
-    fcntl = None  # type: ignore[assignment]
+from . import clientpaths
+from .filelock import process_lock
 
 
 SCHEMA_VERSION = 4
@@ -31,29 +29,22 @@ def persistent_usage_db_enabled() -> bool:
 
 
 def usage_db_path() -> Path:
-    explicit = os.environ.get("TOKDASH_USAGE_DB_PATH", "").strip()
-    if explicit:
-        return Path(explicit).expanduser()
-    data_dir = Path(os.environ.get("TOKDASH_DATA_DIR", "~/.tokdash")).expanduser()
-    return data_dir / "usage.sqlite3"
+    """Delegates to :func:`tokdash.clientpaths.usage_db_path` (Tier 0 seams refactor)."""
+    return clientpaths.usage_db_path()
 
 
 @contextmanager
 def usage_db_process_lock(db_path: Optional[Path] = None):
-    """Serialize DB writes/resyncs across Tokdash processes when supported."""
+    """Serialize DB writes/resyncs across Tokdash processes when supported.
+
+    Thin wrapper delegating to :func:`tokdash.filelock.process_lock` (Tier 0 seams
+    refactor) so this module's lock contract — and the additional process-local
+    ``_WRITE_LOCK`` serialization below — stays exactly as it was for callers.
+    """
     path = db_path or usage_db_path()
-    lock_path = Path(str(path) + ".lock")
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
     with _WRITE_LOCK:
-        if fcntl is None:
+        with process_lock(Path(str(path) + ".lock")):
             yield
-            return
-        with lock_path.open("a+", encoding="utf-8") as handle:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 def durable_usage_db_enabled() -> bool:

--- a/tests/test_clientpaths_windows.py
+++ b/tests/test_clientpaths_windows.py
@@ -1,0 +1,47 @@
+"""Tests for the Hermes Windows-path branch in ``clientpaths.hermes_search_dirs``.
+
+Only Hermes needs a real Windows branch (see ``docs/WINDOWS_CLIENT_PATHS.md``); every
+other client is already correct on Windows via ``Path.home()`` and is untouched by this
+chunk. Branching is done on ``tokdash.osinfo.is_windows()`` (not ``os.name``) so the
+Windows path can be exercised on this Linux host without monkeypatching ``os.name``,
+which would corrupt ``pathlib``'s ``WindowsPath``/``PosixPath`` dispatch process-wide
+(see ``onboard/paths.py::_windows_venv_layout`` for the same pattern).
+"""
+from pathlib import Path
+
+from tokdash import clientpaths, osinfo
+
+
+def test_hermes_search_dirs_posix_default(monkeypatch):
+    """POSIX default (this host): ``~/.hermes``, unchanged."""
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    assert clientpaths.hermes_search_dirs() == [Path.home() / ".hermes"]
+
+
+def test_hermes_search_dirs_windows_default(monkeypatch):
+    """Simulated Windows default: ``%LOCALAPPDATA%\\hermes``."""
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(osinfo, "is_windows", lambda: True)
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\x\AppData\Local")
+    assert clientpaths.hermes_search_dirs() == [Path(r"C:\Users\x\AppData\Local") / "hermes"]
+
+
+def test_hermes_search_dirs_windows_default_no_localappdata(monkeypatch):
+    """Simulated Windows default with ``LOCALAPPDATA`` unset: falls back to ``~/AppData/Local``."""
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    monkeypatch.setattr(osinfo, "is_windows", lambda: True)
+    assert clientpaths.hermes_search_dirs() == [Path.home() / "AppData" / "Local" / "hermes"]
+
+
+def test_hermes_search_dirs_env_override_posix(monkeypatch):
+    """``HERMES_HOME`` override still wins on POSIX, unchanged comma-split behavior."""
+    monkeypatch.setenv("HERMES_HOME", "/a/b,/c/d")
+    assert clientpaths.hermes_search_dirs() == [Path("/a/b"), Path("/c/d")]
+
+
+def test_hermes_search_dirs_env_override_windows(monkeypatch):
+    """``HERMES_HOME`` override still wins on simulated Windows, unchanged comma-split behavior."""
+    monkeypatch.setattr(osinfo, "is_windows", lambda: True)
+    monkeypatch.setenv("HERMES_HOME", "/a/b,/c/d")
+    assert clientpaths.hermes_search_dirs() == [Path("/a/b"), Path("/c/d")]

--- a/tests/test_clientpaths_windows.py
+++ b/tests/test_clientpaths_windows.py
@@ -15,6 +15,7 @@ from tokdash import clientpaths, osinfo
 def test_hermes_search_dirs_posix_default(monkeypatch):
     """POSIX default (this host): ``~/.hermes``, unchanged."""
     monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(osinfo, "is_windows", lambda: False)
     assert clientpaths.hermes_search_dirs() == [Path.home() / ".hermes"]
 
 

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1,0 +1,215 @@
+"""Tests for tokdash.filelock.process_lock (Tier 1 Windows support).
+
+Covers:
+  - The real POSIX fcntl.flock path (this box is Linux) still excludes a
+    concurrent holder and releases correctly.
+  - process_lock's reentrant-safety story with usage_store's in-process
+    threading.RLock (``usage_store._WRITE_LOCK``), which is the only "caller
+    lock" wrapping process_lock in this codebase.
+  - The Windows (``os.name == "nt"``) branch, exercised on this Linux box by
+    injecting a fake ``msvcrt`` module into ``sys.modules`` and forcing the
+    nt code path via monkeypatching ``filelock.os.name``. This validates the
+    lock/unlock call sequence and the graceful no-op degrade on OSError /
+    missing msvcrt, but cannot validate real Windows locking semantics.
+"""
+from __future__ import annotations
+
+import sys
+import threading
+
+import pytest
+
+from tokdash import filelock
+from tokdash import usage_store
+from tokdash.filelock import process_lock
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows collection path
+    fcntl = None
+
+
+# ---------------------------------------------------------------------------
+# POSIX (real fcntl) behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="exercises the real POSIX fcntl.flock code path; Windows takes the msvcrt branch instead",
+)
+def test_posix_process_lock_excludes_concurrent_holder_and_releases(tmp_path):
+    lock_path = tmp_path / "usage.sqlite3.lock"
+
+    lock_taken = threading.Event()
+    release_lock = threading.Event()
+
+    def hold_lock():
+        with process_lock(lock_path):
+            lock_taken.set()
+            release_lock.wait(timeout=5)
+
+    holder = threading.Thread(target=hold_lock, daemon=True)
+    holder.start()
+    assert lock_taken.wait(timeout=5), "background thread never acquired the lock"
+
+    # While the background thread holds the lock via process_lock, a second,
+    # independent file descriptor attempting a non-blocking exclusive flock on
+    # the same file must fail with EWOULDBLOCK/EAGAIN.
+    with lock_path.open("a+") as contender:
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(contender.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    release_lock.set()
+    holder.join(timeout=5)
+    assert not holder.is_alive()
+
+    # After process_lock's context exits, the lock must be released: a fresh
+    # non-blocking exclusive flock attempt now succeeds.
+    with lock_path.open("a+") as contender:
+        fcntl.flock(contender.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(contender.fileno(), fcntl.LOCK_UN)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="asserts the POSIX-only fcntl module is used; Windows has no fcntl",
+)
+def test_posix_process_lock_uses_fcntl_flock(tmp_path):
+    assert filelock.fcntl is not None
+    lock_path = tmp_path / "usage.sqlite3.lock"
+    with process_lock(lock_path):
+        pass  # must not raise; exercises the real fcntl.flock/LOCK_UN pair
+
+
+# ---------------------------------------------------------------------------
+# Reentrant-safety with usage_store's in-process lock
+# ---------------------------------------------------------------------------
+
+
+def test_process_lock_reentrant_safe_with_usage_store_write_lock(tmp_path):
+    """Mirrors usage_store.usage_db_process_lock's actual locking shape.
+
+    ``usage_db_process_lock`` wraps ``process_lock`` in the module-level
+    ``_WRITE_LOCK`` (a ``threading.RLock``). No call site in usage_store.py
+    nests ``usage_db_process_lock`` within itself, but a caller *can* already
+    hold ``_WRITE_LOCK`` reentrantly (same thread) before entering it — e.g. a
+    future nested call path. That must not deadlock: the RLock allows
+    reentry, and process_lock itself is only acquired once at a time.
+    """
+    db_path = tmp_path / "usage.sqlite3"
+
+    usage_store._WRITE_LOCK.acquire()
+    try:
+        with usage_store.usage_db_process_lock(db_path):
+            pass
+    finally:
+        usage_store._WRITE_LOCK.release()
+
+    # The RLock must be back to "unheld" and process_lock's fcntl state must
+    # not have leaked, so a normal (non-reentrant) call still works.
+    with usage_store.usage_db_process_lock(db_path):
+        pass
+
+    # And back-to-back sequential calls (the real usage_store call pattern)
+    # must keep working repeatedly without deadlocking or leaking lock state.
+    for _ in range(3):
+        with usage_store.usage_db_process_lock(db_path):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Windows (os.name == "nt") branch, exercised via an injected fake msvcrt
+# ---------------------------------------------------------------------------
+
+
+class _FakeMsvcrt:
+    """Stand-in for the ``msvcrt`` module, sufficient for process_lock's use."""
+
+    LK_LOCK = 1
+    LK_UNLCK = 0
+
+    def __init__(self, fail_locking: bool = False):
+        self.calls: list[tuple[int, int]] = []
+        self.fail_locking = fail_locking
+
+    def locking(self, fd, mode, nbytes):  # noqa: D401 - mirrors msvcrt.locking signature
+        self.calls.append((mode, nbytes))
+        if mode == self.LK_LOCK and self.fail_locking:
+            raise OSError("fake: region already locked")
+        # LK_UNLCK (or a successful LK_LOCK) always "succeeds".
+
+
+def _force_nt_branch(monkeypatch, fake_msvcrt):
+    monkeypatch.setattr(filelock.os, "name", "nt")
+    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+
+
+def test_windows_branch_locks_then_unlocks_around_with_body(tmp_path, monkeypatch):
+    fake = _FakeMsvcrt()
+    _force_nt_branch(monkeypatch, fake)
+
+    lock_path = tmp_path / "usage.sqlite3.lock"
+    with process_lock(lock_path):
+        # Exactly one LK_LOCK call must have happened before the body runs,
+        # and no unlock yet.
+        assert fake.calls == [(fake.LK_LOCK, 1)]
+    # After the with-block exits, LK_UNLCK must have been issued.
+    assert fake.calls == [(fake.LK_LOCK, 1), (fake.LK_UNLCK, 1)]
+
+
+def test_windows_branch_unlocks_even_when_body_raises(tmp_path, monkeypatch):
+    fake = _FakeMsvcrt()
+    _force_nt_branch(monkeypatch, fake)
+
+    lock_path = tmp_path / "usage.sqlite3.lock"
+    with pytest.raises(ValueError):
+        with process_lock(lock_path):
+            raise ValueError("boom")
+    assert fake.calls == [(fake.LK_LOCK, 1), (fake.LK_UNLCK, 1)]
+
+
+def test_windows_branch_degrades_gracefully_on_oserror(tmp_path, monkeypatch):
+    """OSError from msvcrt.locking must never crash the caller.
+
+    Matches the POSIX ``fcntl is None`` no-op fallback: locking is a
+    best-effort convenience. The bounded retry timeout/delay are shrunk so
+    the test runs fast instead of spending the real (Windows-sized) timeout.
+    """
+    fake = _FakeMsvcrt(fail_locking=True)
+    _force_nt_branch(monkeypatch, fake)
+    monkeypatch.setattr(filelock, "_WINDOWS_LOCK_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(filelock, "_WINDOWS_LOCK_RETRY_DELAY_SECONDS", 0.01)
+
+    lock_path = tmp_path / "usage.sqlite3.lock"
+    with process_lock(lock_path):
+        pass  # must not raise despite every LK_LOCK attempt failing
+
+    assert fake.calls, "expected at least one LK_LOCK retry attempt"
+    assert all(mode == fake.LK_LOCK for mode, _ in fake.calls), (
+        "since acquisition never succeeded, LK_UNLCK must never be called"
+    )
+
+
+def test_windows_branch_degrades_gracefully_when_msvcrt_missing(tmp_path, monkeypatch):
+    """If msvcrt can't be imported at all (e.g. a broken embed), no-op like POSIX."""
+    monkeypatch.setattr(filelock.os, "name", "nt")
+    monkeypatch.delitem(sys.modules, "msvcrt", raising=False)
+    # msvcrt genuinely does not exist on this POSIX box, so the lazy `import
+    # msvcrt` inside the nt branch raises ImportError for real (not faked).
+
+    lock_path = tmp_path / "usage.sqlite3.lock"
+    with process_lock(lock_path):
+        pass  # must not raise
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="validates the real msvcrt module shape only meaningful on actual Windows",
+)
+def test_real_msvcrt_has_expected_constants():  # pragma: no cover - real Windows only
+    import msvcrt
+
+    assert hasattr(msvcrt, "locking")
+    assert hasattr(msvcrt, "LK_LOCK")
+    assert hasattr(msvcrt, "LK_UNLCK")

--- a/tests/test_hermes_parser.py
+++ b/tests/test_hermes_parser.py
@@ -2,6 +2,7 @@
 import sqlite3
 from pathlib import Path
 
+from tokdash import osinfo
 from tokdash.pricing import PricingDatabase
 from tokdash.sources.coding_tools import BaseParser, HermesParser, _sig_cache
 
@@ -196,6 +197,7 @@ def test_hermes_parser_dedup_across_dbs(monkeypatch, tmp_path):
 def test_hermes_parser_default_dir(monkeypatch, tmp_path):
     """Without HERMES_HOME, defaults to ~/.hermes."""
     monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(osinfo, "is_windows", lambda: False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     _sig_cache.clear()
     BaseParser._entry_cache.clear()

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -101,6 +101,7 @@ def run_json(argv, capsys):
 
 def test_paths_follow_data_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("TOKDASH_DATA_DIR", str(tmp_path / "x"))
+    monkeypatch.setattr(paths, "_windows_venv_layout", lambda: False)
     assert paths.manifest_path() == tmp_path / "x" / "install.json"
     assert paths.managed_venv_python() == tmp_path / "x" / "runtime" / "python-venv" / "bin" / "python"
     assert not paths.is_default_data_dir()
@@ -393,6 +394,7 @@ def test_setup_open_dashboard_uses_detached_opener(monkeypatch):
         return FakeProcess()
 
     monkeypatch.setattr(engine.sys, "platform", "linux")
+    monkeypatch.setattr(engine.os, "name", "posix")
     monkeypatch.setattr(detect, "os_kind", lambda: "linux")
     monkeypatch.setattr(engine.shutil, "which", fake_which)
     monkeypatch.setattr(engine.subprocess, "Popen", fake_popen)

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -27,8 +27,11 @@ def _isolate(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
     # Deterministic, offline detection by default; individual tests override.
     monkeypatch.setattr(detect, "probe_port", lambda port=55423, *a, **k: {"port": port, "open": False, "is_tokdash": False, "version": None})
+    monkeypatch.setattr(detect, "os_kind", lambda: "linux")
     monkeypatch.setattr(detect, "is_tty", lambda: True)
     monkeypatch.setattr(detect, "systemd_user_available", lambda: True)
+    monkeypatch.setattr(detect, "launchd_available", lambda: False)
+    monkeypatch.setattr(detect, "winsched_available", lambda: False)
     updatecheck._cache.update({"ts": 0.0, "data": None})  # no cross-test cache leak
     yield
     updatecheck._cache.update({"ts": 0.0, "data": None})
@@ -1315,7 +1318,7 @@ def test_doctor_ignores_tokdash_port_prefers_manifest(monkeypatch, capsys):
     )
     manifest.write_manifest(man)
     capsys.readouterr()
-    rc = cli.cli(["doctor", "--json"])
+    cli.cli(["doctor", "--json"])
     payload = json.loads(capsys.readouterr().out)
     assert payload["port"]["port"] == 55555
 

--- a/tests/test_service_selection.py
+++ b/tests/test_service_selection.py
@@ -1,0 +1,388 @@
+"""Service-backend selection matrix (Tier 0 seams refactor, service_base.select_service).
+
+Locks in that `service_base.select_service` — and the `plan._resolve_service` adapter
+that delegates to it — return byte-identical `{"type", "reason"}` results and
+blocker/note strings to the pre-refactor inline implementation, for every non-windows OS
+kind x `--service` request combination. Also covers the `service_base` registry
+(`SERVICE_BACKENDS` / `backend_for`), and (Tier 2) the native Windows Task Scheduler
+`winsched` backend now registered there and dispatched to from the dedicated `windows`
+branch of `select_service`.
+"""
+from __future__ import annotations
+
+from tokdash.onboard import launchd, plan, service_base, systemd, winsched
+
+
+# --- select_service: auto ---------------------------------------------------------
+
+
+def test_auto_macos_launchd_available():
+    sel = service_base.select_service(
+        "auto", "macos", no_service=False, systemd_available=False, launchd_available=True
+    )
+    assert sel.result == {"type": "launchd", "reason": None}
+    assert sel.blockers == []
+    assert sel.notes == []
+
+
+def test_auto_macos_launchd_unavailable():
+    sel = service_base.select_service(
+        "auto", "macos", no_service=False, systemd_available=False, launchd_available=False
+    )
+    assert sel.result == {"type": "none", "reason": "launchctl is unavailable"}
+    assert sel.blockers == []
+    assert sel.notes == ["launchctl is unavailable; falling back to foreground guidance."]
+
+
+def test_auto_linux_systemd_available():
+    sel = service_base.select_service(
+        "auto", "linux", no_service=False, systemd_available=True, launchd_available=False
+    )
+    assert sel.result == {"type": "systemd-user", "reason": None}
+    assert sel.blockers == []
+    assert sel.notes == []
+
+
+def test_auto_linux_systemd_unavailable_no_wsl_hint():
+    sel = service_base.select_service(
+        "auto", "linux", no_service=False, systemd_available=False, launchd_available=False
+    )
+    assert sel.result == {"type": "none", "reason": "systemd user services are unavailable"}
+    assert sel.blockers == []
+    assert sel.notes == ["systemd user services are unavailable; falling back to foreground guidance."]
+
+
+def test_auto_wsl_systemd_available():
+    sel = service_base.select_service(
+        "auto", "wsl", no_service=False, systemd_available=True, launchd_available=False
+    )
+    assert sel.result == {"type": "systemd-user", "reason": None}
+    assert sel.blockers == []
+    assert sel.notes == []
+
+
+def test_auto_wsl_systemd_unavailable_includes_wsl_conf_hint():
+    sel = service_base.select_service(
+        "auto", "wsl", no_service=False, systemd_available=False, launchd_available=False
+    )
+    expected_reason = "systemd user services are unavailable (enable WSL systemd in /etc/wsl.conf)"
+    assert sel.result == {"type": "none", "reason": expected_reason}
+    assert sel.blockers == []
+    assert sel.notes == [expected_reason + "; falling back to foreground guidance."]
+
+
+def test_auto_windows_winsched_available():
+    sel = service_base.select_service(
+        "auto", "windows", no_service=False, systemd_available=False, launchd_available=False,
+        winsched_available=True,
+    )
+    assert sel.result == {"type": "winsched", "reason": None}
+    assert sel.blockers == []
+    assert sel.notes == []
+
+
+def test_auto_windows_winsched_unavailable_falls_back():
+    # winsched_available defaults to False when the caller doesn't pass it, so this also
+    # covers "the caller never even asked" the same way the pre-Tier-2 callers didn't.
+    sel = service_base.select_service(
+        "auto", "windows", no_service=False, systemd_available=False, launchd_available=False
+    )
+    assert sel.result == {"type": "none", "reason": "Task Scheduler (schtasks) is unavailable"}
+    assert sel.blockers == []
+    assert sel.notes == ["Task Scheduler (schtasks) is unavailable; falling back to foreground guidance."]
+
+
+def test_auto_other_os_kind_deferred():
+    # Any unrecognized os_kind (not just "windows") takes the same deferred path, and the
+    # note interpolates the given os_kind verbatim.
+    sel = service_base.select_service(
+        "auto", "freebsd", no_service=False, systemd_available=False, launchd_available=False
+    )
+    assert sel.result == {"type": "none", "reason": "deferred"}
+    assert sel.blockers == []
+    assert sel.notes == ["Background service setup for freebsd is not available yet; use `tokdash serve`."]
+
+
+# --- select_service: explicit --service on the "wrong" OS -------------------------
+
+
+def test_explicit_systemd_on_macos_is_blocked():
+    sel = service_base.select_service(
+        "systemd", "macos", no_service=False, systemd_available=False, launchd_available=True
+    )
+    assert sel.result == {"type": "none", "reason": "unsupported"}
+    assert sel.blockers == ["--service systemd is not supported on macOS; use --service launchd."]
+    assert sel.notes == []
+
+
+def test_explicit_launchd_on_linux_is_blocked():
+    sel = service_base.select_service(
+        "launchd", "linux", no_service=False, systemd_available=True, launchd_available=False
+    )
+    assert sel.result == {"type": "none", "reason": "unsupported"}
+    assert sel.blockers == ["--service launchd is only supported on macOS."]
+    assert sel.notes == []
+
+
+def test_explicit_launchd_on_wsl_is_blocked():
+    sel = service_base.select_service(
+        "launchd", "wsl", no_service=False, systemd_available=True, launchd_available=False
+    )
+    assert sel.result == {"type": "none", "reason": "unsupported"}
+    assert sel.blockers == ["--service launchd is only supported on macOS."]
+    assert sel.notes == []
+
+
+def test_explicit_systemd_on_windows_is_blocked():
+    sel = service_base.select_service(
+        "systemd", "windows", no_service=False, systemd_available=False, launchd_available=False
+    )
+    assert sel.result == {"type": "none", "reason": "unsupported"}
+    assert sel.blockers == ["--service systemd is not supported on windows."]
+    assert sel.notes == []
+
+
+def test_explicit_launchd_on_windows_is_blocked():
+    sel = service_base.select_service(
+        "launchd", "windows", no_service=False, systemd_available=False, launchd_available=False
+    )
+    assert sel.result == {"type": "none", "reason": "unsupported"}
+    assert sel.blockers == ["--service launchd is not supported on windows."]
+    assert sel.notes == []
+
+
+# --- select_service: explicit --service requested + available/unavailable --------
+
+
+def test_explicit_systemd_available_on_linux():
+    sel = service_base.select_service(
+        "systemd", "linux", no_service=False, systemd_available=True, launchd_available=False
+    )
+    assert sel.result == {"type": "systemd-user", "reason": None}
+    assert sel.blockers == []
+    assert sel.notes == []
+
+
+def test_explicit_systemd_unavailable_on_linux_blocks_not_notes():
+    sel = service_base.select_service(
+        "systemd", "linux", no_service=False, systemd_available=False, launchd_available=False
+    )
+    assert sel.result == {"type": "none", "reason": "systemd user services are unavailable"}
+    assert sel.blockers == [
+        "systemd user services are unavailable; re-run without --service systemd or use --no-service."
+    ]
+    assert sel.notes == []
+
+
+def test_explicit_systemd_unavailable_on_wsl_blocks_with_wsl_hint():
+    sel = service_base.select_service(
+        "systemd", "wsl", no_service=False, systemd_available=False, launchd_available=False
+    )
+    expected_reason = "systemd user services are unavailable (enable WSL systemd in /etc/wsl.conf)"
+    assert sel.result == {"type": "none", "reason": expected_reason}
+    assert sel.blockers == [
+        expected_reason + "; re-run without --service systemd or use --no-service."
+    ]
+    assert sel.notes == []
+
+
+def test_explicit_launchd_available_on_macos():
+    sel = service_base.select_service(
+        "launchd", "macos", no_service=False, systemd_available=False, launchd_available=True
+    )
+    assert sel.result == {"type": "launchd", "reason": None}
+    assert sel.blockers == []
+    assert sel.notes == []
+
+
+def test_explicit_launchd_unavailable_on_macos_blocks_not_notes():
+    sel = service_base.select_service(
+        "launchd", "macos", no_service=False, systemd_available=False, launchd_available=False
+    )
+    assert sel.result == {"type": "none", "reason": "launchctl is unavailable"}
+    assert sel.blockers == [
+        "launchctl is unavailable; re-run with --no-service or run `tokdash serve` yourself."
+    ]
+    assert sel.notes == []
+
+
+def test_explicit_winsched_available_on_windows():
+    sel = service_base.select_service(
+        "winsched", "windows", no_service=False, systemd_available=False, launchd_available=False,
+        winsched_available=True,
+    )
+    assert sel.result == {"type": "winsched", "reason": None}
+    assert sel.blockers == []
+    assert sel.notes == []
+
+
+def test_explicit_winsched_unavailable_on_windows_blocks_not_notes():
+    sel = service_base.select_service(
+        "winsched", "windows", no_service=False, systemd_available=False, launchd_available=False,
+        winsched_available=False,
+    )
+    assert sel.result == {"type": "none", "reason": "Task Scheduler (schtasks) is unavailable"}
+    assert sel.blockers == [
+        "Task Scheduler (schtasks) is unavailable; re-run with --no-service or run `tokdash serve` yourself."
+    ]
+    assert sel.notes == []
+
+
+# --- select_service: --no-service / --service none --------------------------------
+
+
+def test_no_service_flag_requested_regardless_of_os():
+    for os_kind in ("macos", "linux", "wsl", "windows"):
+        sel = service_base.select_service(
+            "auto", os_kind, no_service=True, systemd_available=True, launchd_available=True
+        )
+        assert sel.result == {"type": "none", "reason": "requested"}
+        assert sel.blockers == []
+        assert sel.notes == []
+
+
+def test_service_none_requested_regardless_of_os():
+    for os_kind in ("macos", "linux", "wsl", "windows"):
+        sel = service_base.select_service(
+            "none", os_kind, no_service=False, systemd_available=True, launchd_available=True
+        )
+        assert sel.result == {"type": "none", "reason": "requested"}
+        assert sel.blockers == []
+        assert sel.notes == []
+
+
+# --- select_service: unknown --service value on a recognized OS -------------------
+
+
+def test_unknown_service_value_on_macos():
+    sel = service_base.select_service(
+        "bogus", "macos", no_service=False, systemd_available=False, launchd_available=True
+    )
+    assert sel.result == {"type": "none", "reason": "unknown"}
+    assert sel.blockers == []
+    assert sel.notes == []
+
+
+def test_unknown_service_value_on_linux():
+    sel = service_base.select_service(
+        "bogus", "linux", no_service=False, systemd_available=True, launchd_available=False
+    )
+    assert sel.result == {"type": "none", "reason": "unknown"}
+    assert sel.blockers == []
+    assert sel.notes == []
+
+
+def test_winsched_requested_on_macos_is_unknown_not_dispatched():
+    # `winsched` only means anything inside the dedicated `windows` branch; on any other OS
+    # kind it falls through exactly like any other unrecognized --service value (the
+    # macOS/linux/wsl branches are untouched by Tier 2).
+    sel = service_base.select_service(
+        "winsched", "macos", no_service=False, systemd_available=False, launchd_available=True
+    )
+    assert sel.result == {"type": "none", "reason": "unknown"}
+    assert sel.blockers == []
+    assert sel.notes == []
+
+
+def test_winsched_requested_on_linux_is_unknown_not_dispatched():
+    sel = service_base.select_service(
+        "winsched", "linux", no_service=False, systemd_available=True, launchd_available=False
+    )
+    assert sel.result == {"type": "none", "reason": "unknown"}
+    assert sel.blockers == []
+    assert sel.notes == []
+
+
+def test_unknown_service_value_on_windows():
+    sel = service_base.select_service(
+        "bogus", "windows", no_service=False, systemd_available=False, launchd_available=False,
+        winsched_available=True,
+    )
+    assert sel.result == {"type": "none", "reason": "unknown"}
+    assert sel.blockers == []
+    assert sel.notes == []
+
+
+# --- registry: SERVICE_BACKENDS / backend_for --------------------------------------
+
+
+def test_backend_for_registered_types():
+    assert service_base.backend_for("systemd-user") is systemd
+    assert service_base.backend_for("launchd") is launchd
+    assert service_base.backend_for("winsched") is winsched
+
+
+def test_backend_for_unregistered_types_returns_none():
+    # "none" (today's no-service outcome), the deferred/unsupported other-OS outcome, and
+    # any not-yet-registered future backend name all resolve to None -- there is no backend
+    # module to dispatch to.
+    assert service_base.backend_for("none") is None
+    assert service_base.backend_for("windows") is None
+    assert service_base.backend_for("some-future-backend") is None
+
+
+def test_service_backends_registry_contents():
+    assert service_base.SERVICE_BACKENDS == {"systemd-user": systemd, "launchd": launchd, "winsched": winsched}
+
+
+# --- plan._resolve_service back-compat adapter -------------------------------------
+#
+# The factory above is exercised directly; these confirm the thin plan.py adapter
+# (opts/detection -> primitives -> service_base.select_service -> blockers/notes
+# threaded back) produces the identical externally observable result for a
+# representative sample of the matrix, using the same Options/detection shape the
+# rest of the onboarding engine uses.
+
+
+def _detection(os_kind, *, systemd_user=False, launchd_avail=False):
+    return {"os": os_kind, "systemd_user": systemd_user, "launchd": launchd_avail}
+
+
+def test_resolve_service_delegates_auto_macos_launchd():
+    opts = plan.Options(service="auto")
+    blockers, notes = [], []
+    result = plan._resolve_service(opts, _detection("macos", launchd_avail=True), blockers, notes)
+    assert result == {"type": "launchd", "reason": None}
+    assert blockers == []
+    assert notes == []
+
+
+def test_resolve_service_delegates_auto_wsl_systemd_unavailable():
+    opts = plan.Options(service="auto")
+    blockers, notes = [], []
+    result = plan._resolve_service(opts, _detection("wsl", systemd_user=False), blockers, notes)
+    expected_reason = "systemd user services are unavailable (enable WSL systemd in /etc/wsl.conf)"
+    assert result == {"type": "none", "reason": expected_reason}
+    assert blockers == []
+    assert notes == [expected_reason + "; falling back to foreground guidance."]
+
+
+def test_resolve_service_delegates_explicit_launchd_wrong_os():
+    opts = plan.Options(service="launchd")
+    blockers, notes = [], []
+    result = plan._resolve_service(opts, _detection("linux", systemd_user=True), blockers, notes)
+    assert result == {"type": "none", "reason": "unsupported"}
+    assert blockers == ["--service launchd is only supported on macOS."]
+    assert notes == []
+
+
+def test_resolve_service_delegates_no_service_requested():
+    opts = plan.Options(no_service=True)
+    blockers, notes = [], []
+    result = plan._resolve_service(opts, _detection("linux", systemd_user=True), blockers, notes)
+    assert result == {"type": "none", "reason": "requested"}
+    assert blockers == []
+    assert notes == []
+
+
+def test_resolve_service_delegates_appends_to_existing_blockers_and_notes():
+    # blockers/notes threading must extend (not replace) whatever the caller already
+    # accumulated -- mirroring how build_setup_plan calls it mid-way through building
+    # its own blockers/notes lists.
+    opts = plan.Options(service="systemd")
+    blockers = ["earlier blocker"]
+    notes = ["earlier note"]
+    result = plan._resolve_service(opts, _detection("macos", launchd_avail=True), blockers, notes)
+    assert result == {"type": "none", "reason": "unsupported"}
+    assert blockers == ["earlier blocker", "--service systemd is not supported on macOS; use --service launchd."]
+    assert notes == ["earlier note"]

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -523,6 +523,7 @@ def _codex_session_rows(
 
 def test_codex_guardian_sessions_are_hidden_from_session_view_only(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.delenv("TOKDASH_INCLUDE_CODEX_GUARDIAN", raising=False)
     _clear_parser_caches()
     codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "06" / "19"
@@ -551,6 +552,7 @@ def test_codex_sessions_echo_effective_review_default(monkeypatch, tmp_path):
     """The response echoes the effective review-session default so the dashboard
     toggle can adopt the server's TOKDASH_INCLUDE_CODEX_GUARDIAN default."""
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
     codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "06" / "19"
     _write_jsonl(codex_dir / "normal.jsonl", _codex_session_rows("normal-session"))
 
@@ -623,6 +625,7 @@ def test_session_display_name_fallbacks(monkeypatch, tmp_path):
 
 def test_codex_session_display_name_uses_state_db_title(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
     _clear_parser_caches()
 
     codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "06" / "19"
@@ -974,6 +977,7 @@ def test_get_sessions_data_passes_period_window_to_opencode_loader(monkeypatch):
 
 def test_opencode_signatures_include_wal_and_shm(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
     opencode_dir = tmp_path / ".local" / "share" / "opencode"
     opencode_dir.mkdir(parents=True)
     for name in ("opencode.db", "opencode.db-wal", "opencode.db-shm"):

--- a/tests/test_winsched.py
+++ b/tests/test_winsched.py
@@ -1,0 +1,420 @@
+"""Tier 2: native Windows Task Scheduler backend (``winsched``).
+
+Mirrors the systemd/launchd coverage in ``test_onboard.py`` — rendering, marker detection,
+lifecycle commands, and setup/uninstall *planning* — all via monkeypatched ``schtasks``
+(exactly how ``test_onboard.py`` monkeypatches ``systemctl``/``launchctl``). There is no
+Windows machine in this environment, so nothing here executes a real ``schtasks``; real
+Windows execution is deferred to CI.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tokdash import cli
+from tokdash.onboard import detect, engine, manifest, paths, plan, service_base, winsched
+from tokdash.onboard.engine import run_lifecycle
+
+
+# --- harness --------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    """Redirect every onboarding path into tmp and stub the OS-touching probes."""
+    data_dir = tmp_path / "dd"
+    monkeypatch.setenv("TOKDASH_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.setattr(detect, "probe_port", lambda port=55423, *a, **k: {"port": port, "open": False, "is_tokdash": False, "version": None})
+    monkeypatch.setattr(detect, "is_tty", lambda: True)
+    monkeypatch.setattr(detect, "systemd_user_available", lambda: True)
+    yield
+
+
+def _ok_proc():
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+@pytest.fixture
+def windows_env(monkeypatch, tmp_path):
+    """Pretend we're on native Windows with Task Scheduler available; redirect the task
+    XML into tmp (mirrors the ``macos``/``fake_launchd`` fixtures in test_onboard.py)."""
+    monkeypatch.setattr(detect, "os_kind", lambda: "windows")
+    monkeypatch.setattr(detect, "winsched_available", lambda: True)
+    monkeypatch.setattr(detect, "systemd_user_available", lambda: False)
+    monkeypatch.setattr(detect, "launchd_available", lambda: False)
+    task_path = tmp_path / "AppData" / "Tokdash" / "Tokdash.xml"
+    monkeypatch.setattr(paths, "winsched_task_path", lambda: task_path)
+
+
+@pytest.fixture
+def fake_winsched(monkeypatch):
+    """Make schtasks calls no-ops that report a healthy, registered+running task."""
+    monkeypatch.setattr(winsched, "create", lambda task_path, name=winsched.TASK_NAME: _ok_proc())
+    monkeypatch.setattr(winsched, "delete", lambda name=winsched.TASK_NAME: _ok_proc())
+    monkeypatch.setattr(winsched, "run_now", lambda name=winsched.TASK_NAME: _ok_proc())
+    monkeypatch.setattr(winsched, "end_task", lambda name=winsched.TASK_NAME: _ok_proc())
+    monkeypatch.setattr(winsched, "is_registered", lambda name=winsched.TASK_NAME: True)
+    monkeypatch.setattr(winsched, "is_registered_strict", lambda name=winsched.TASK_NAME: True)
+    monkeypatch.setattr(winsched, "is_running", lambda name=winsched.TASK_NAME: True)
+    monkeypatch.setattr(
+        engine,
+        "_wait_for_service_ready",
+        lambda bind, port, **k: {"ok": True, "port": {"port": port, "open": True, "is_tokdash": True, "version": "test"}},
+    )
+
+
+def run(argv):
+    args = cli.build_parser("tokdash").parse_args(argv)
+    return run_lifecycle(args)
+
+
+def run_json(argv, capsys):
+    import json
+
+    capsys.readouterr()
+    rc = run(argv)
+    out = capsys.readouterr().out
+    return rc, json.loads(out)
+
+
+# --- rendering --------------------------------------------------------------------
+
+
+def test_task_carries_marker_and_uses_pythonw():
+    text = winsched.render_task(
+        ["C:\\dd\\runtime\\python-venv\\Scripts\\python.exe", "-m", "tokdash"],
+        "127.0.0.1", 55423, marker_id="abc123",
+    )
+    assert text.startswith('<?xml version="1.0" encoding="UTF-8"?>')
+    assert "Managed-by: tokdash-setup" in text
+    assert "X-Tokdash-Managed id=abc123" in text
+    assert "<Command>C:\\dd\\runtime\\python-venv\\Scripts\\pythonw.exe</Command>" in text
+    assert "<Arguments>-m tokdash serve --bind 127.0.0.1 --port 55423 --no-open</Arguments>" in text
+    assert "TOKDASH_DATA_DIR" not in text  # default data dir => no env snippet
+    assert "<LogonType>InteractiveToken</LogonType>" in text  # never SYSTEM/elevated
+    assert "<RunLevel>LeastPrivilege</RunLevel>" in text
+
+
+def test_task_leaves_non_python_command_unchanged():
+    # _pythonw_for only swaps a plain "python.exe"; an unexpected runtime is passed through
+    # unchanged rather than inventing a nonexistent binary.
+    text = winsched.render_task(["C:\\rt\\tokdash.exe", "serveronly"], "127.0.0.1", 1, marker_id="x")
+    assert "<Command>C:\\rt\\tokdash.exe</Command>" in text
+
+
+def test_task_env_snippet_when_non_default_data_dir():
+    text = winsched.render_task(
+        ["C:\\py\\python.exe", "-m", "tokdash"], "127.0.0.1", 55423,
+        marker_id="x", env_data_dir="C:\\custom\\dd",
+    )
+    assert "<Command>C:\\py\\pythonw.exe</Command>" in text
+    assert "<Arguments>-c \"import os,runpy,sys;" in text
+    assert "os.environ['TOKDASH_DATA_DIR']='C:\\\\custom\\\\dd';" in text
+    assert "sys.argv=['tokdash', 'serve', '--bind', '127.0.0.1', '--port', '55423', '--no-open'];" in text
+    assert "sys.argv=['tokdash', '-m', 'tokdash'" not in text
+    assert "runpy.run_module('tokdash', run_name='__main__')\"</Arguments>" in text
+
+
+def test_task_is_managed_detection_via_file(tmp_path):
+    task_path = tmp_path / "Tokdash.xml"
+    task_path.write_text(
+        winsched.render_task(["py.exe", "-m", "tokdash"], "127.0.0.1", 1, marker_id="deadbeef"),
+        encoding="utf-8",
+    )
+    assert winsched.task_is_managed(task_path) is True
+    assert winsched.task_is_managed(task_path, "deadbeef") is True
+    assert winsched.task_is_managed(task_path, "other") is False
+
+    unmarked = tmp_path / "manual.xml"
+    unmarked.write_text("<Task><Actions/></Task>", encoding="utf-8")
+    assert winsched.task_is_managed(unmarked) is False
+
+    missing = tmp_path / "missing.xml"
+    assert winsched.task_is_managed(missing) is False
+
+
+def test_task_is_managed_detection_via_live_name(monkeypatch):
+    text = winsched.render_task(["py.exe", "-m", "tokdash"], "127.0.0.1", 1, marker_id="deadbeef")
+
+    def fake_run(args, timeout=20):
+        assert args[:2] == ["/Query", "/TN"]
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=text, stderr="")
+
+    monkeypatch.setattr(winsched, "_run", fake_run)
+    assert winsched.task_is_managed("Tokdash") is True
+    assert winsched.task_is_managed("Tokdash", "deadbeef") is True
+    assert winsched.task_is_managed("Tokdash", "other") is False
+
+
+def test_task_is_managed_via_name_query_failure_returns_false(monkeypatch):
+    monkeypatch.setattr(
+        winsched, "_run", lambda args, timeout=20: subprocess.CompletedProcess([], 1, "", "not found")
+    )
+    assert winsched.task_is_managed("NotThere") is False
+
+
+def test_write_task_writes_to_paths_location(monkeypatch, tmp_path):
+    task_path = tmp_path / "nested" / "Tokdash.xml"
+    monkeypatch.setattr(paths, "winsched_task_path", lambda: task_path)
+    text = winsched.render_task(["py.exe", "-m", "tokdash"], "127.0.0.1", 1, marker_id="x")
+    out = winsched.write_task(text)
+    assert out == task_path
+    assert task_path.read_text(encoding="utf-8") == text
+
+
+# --- lifecycle commands -----------------------------------------------------------
+
+
+def test_winsched_lifecycle_commands_allow_service_manager_timeout(monkeypatch, tmp_path):
+    seen = []
+
+    def fake_run(args, timeout=20):
+        seen.append((args, timeout))
+        return _ok_proc()
+
+    monkeypatch.setattr(winsched, "_run", fake_run)
+    task_path = tmp_path / "Tokdash.xml"
+    task_path.write_text("<Task/>", encoding="utf-8")
+    winsched.create(task_path)
+    winsched.run_now()
+    winsched.end_task()
+    winsched.delete()
+    assert seen == [
+        (["/Create", "/TN", winsched.TASK_NAME, "/XML", str(task_path), "/F"], winsched.LIFECYCLE_TIMEOUT),
+        (["/Run", "/TN", winsched.TASK_NAME], winsched.LIFECYCLE_TIMEOUT),
+        (["/End", "/TN", winsched.TASK_NAME], winsched.LIFECYCLE_TIMEOUT),
+        (["/Delete", "/TN", winsched.TASK_NAME, "/F"], winsched.LIFECYCLE_TIMEOUT),
+    ]
+
+
+def test_restart_ends_then_runs(monkeypatch):
+    calls = []
+    monkeypatch.setattr(winsched, "end_task", lambda name=winsched.TASK_NAME: calls.append("end") or _ok_proc())
+    monkeypatch.setattr(winsched, "run_now", lambda name=winsched.TASK_NAME: calls.append("run") or _ok_proc())
+    winsched.restart()
+    assert calls == ["end", "run"]
+
+
+def test_restart_tolerates_end_task_failure(monkeypatch):
+    def boom(name=winsched.TASK_NAME):
+        raise subprocess.TimeoutExpired(["schtasks"], 5)
+
+    monkeypatch.setattr(winsched, "end_task", boom)
+    ran = []
+
+    def fake_run_now(name=winsched.TASK_NAME):
+        ran.append(True)
+        return _ok_proc()
+
+    monkeypatch.setattr(winsched, "run_now", fake_run_now)
+    proc = winsched.restart()
+    assert ran == [True] and proc.returncode == 0
+
+
+def test_status_reports_registered_and_running(monkeypatch):
+    monkeypatch.setattr(winsched, "is_registered", lambda name=winsched.TASK_NAME: True)
+    monkeypatch.setattr(winsched, "is_running", lambda name=winsched.TASK_NAME: True)
+    assert winsched.status() == {"type": "winsched", "name": winsched.TASK_NAME, "enabled": True, "active": True}
+
+
+def test_status_not_registered_skips_running_probe(monkeypatch):
+    monkeypatch.setattr(winsched, "is_registered", lambda name=winsched.TASK_NAME: False)
+
+    def boom(name=winsched.TASK_NAME):
+        raise AssertionError("is_running should not be called when not registered")
+
+    monkeypatch.setattr(winsched, "is_running", boom)
+    assert winsched.status() == {"type": "winsched", "name": winsched.TASK_NAME, "enabled": False, "active": False}
+
+
+# --- paths / detect (Windows-specific bits) ---------------------------------------
+
+
+def test_winsched_task_path_uses_local_appdata(monkeypatch):
+    monkeypatch.setenv("LOCALAPPDATA", "/fake/AppData/Local")
+    assert paths.winsched_task_path() == Path("/fake/AppData/Local") / "Tokdash" / "Tokdash.xml"
+
+
+def test_winsched_task_path_falls_back_without_local_appdata(monkeypatch):
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    assert paths.winsched_task_path() == Path("~/AppData/Local").expanduser() / "Tokdash" / "Tokdash.xml"
+
+
+def test_managed_venv_python_windows_uses_scripts(monkeypatch, tmp_path):
+    # Simulate the Windows branch via the `_windows_venv_layout` seam, NOT the real `os.name`
+    # (flipping the real `os.name` would make pathlib try to build an unusable WindowsPath
+    # for every other fresh Path(...) call on this non-Windows test host).
+    monkeypatch.setenv("TOKDASH_DATA_DIR", str(tmp_path / "dd"))
+    monkeypatch.setattr(paths, "_windows_venv_layout", lambda: True)
+    assert paths.managed_venv_python() == tmp_path / "dd" / "runtime" / "python-venv" / "Scripts" / "python.exe"
+
+
+def test_managed_venv_python_posix_unchanged(tmp_path, monkeypatch):
+    # Explicit control: os.name is whatever the real test host reports (posix here); this
+    # locks in that the non-Windows shape is untouched by the Tier 2 addition.
+    monkeypatch.setenv("TOKDASH_DATA_DIR", str(tmp_path / "dd"))
+    assert paths.managed_venv_python() == tmp_path / "dd" / "runtime" / "python-venv" / "bin" / "python"
+
+
+def test_winsched_available_requires_windows_and_schtasks(monkeypatch):
+    monkeypatch.setattr(detect, "os_kind", lambda: "windows")
+    monkeypatch.setattr(detect.shutil, "which", lambda name: "C:\\Windows\\System32\\schtasks.exe" if name == "schtasks" else None)
+    assert detect.winsched_available() is True
+    monkeypatch.setattr(detect.shutil, "which", lambda name: None)
+    assert detect.winsched_available() is False
+
+
+def test_winsched_available_false_on_non_windows(monkeypatch):
+    monkeypatch.setattr(detect, "os_kind", lambda: "linux")
+    monkeypatch.setattr(detect.shutil, "which", lambda name: "/usr/bin/schtasks")
+    assert detect.winsched_available() is False
+
+
+def test_existing_service_ignores_winsched_task_on_non_windows(monkeypatch, tmp_path):
+    task_path = tmp_path / "Tokdash.xml"
+    task_path.write_text(winsched.render_task(["py.exe", "-m", "tokdash"], "127.0.0.1", 1, marker_id="x"), encoding="utf-8")
+    monkeypatch.setattr(paths, "winsched_task_path", lambda: task_path)
+    monkeypatch.setattr(detect, "os_kind", lambda: "linux")
+    existing = detect.existing_service()
+    assert existing["winsched_task"] is None
+
+
+def test_pipx_tokdash_python_windows_scripts_candidate(monkeypatch, tmp_path):
+    monkeypatch.setattr(detect, "os_kind", lambda: "windows")
+    local_appdata = tmp_path / "AppData" / "Local"
+    candidate = local_appdata / "pipx" / "venvs" / "tokdash" / "Scripts" / "python.exe"
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    candidate.write_text("", encoding="utf-8")
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    assert detect.pipx_tokdash_python() == str(candidate)
+
+
+# --- select_service: windows matrix (service_base) --------------------------------
+
+
+def test_select_service_windows_winsched_available():
+    sel = service_base.select_service(
+        "auto", "windows", no_service=False, systemd_available=False, launchd_available=False,
+        winsched_available=True,
+    )
+    assert sel.result == {"type": "winsched", "reason": None}
+    assert sel.blockers == [] and sel.notes == []
+
+
+def test_select_service_windows_winsched_unavailable():
+    sel = service_base.select_service(
+        "auto", "windows", no_service=False, systemd_available=False, launchd_available=False,
+        winsched_available=False,
+    )
+    assert sel.result == {"type": "none", "reason": "Task Scheduler (schtasks) is unavailable"}
+    assert sel.blockers == []
+    assert sel.notes == ["Task Scheduler (schtasks) is unavailable; falling back to foreground guidance."]
+
+
+def test_select_service_windows_explicit_systemd_blocked():
+    sel = service_base.select_service(
+        "systemd", "windows", no_service=False, systemd_available=False, launchd_available=False,
+    )
+    assert sel.result == {"type": "none", "reason": "unsupported"}
+    assert sel.blockers == ["--service systemd is not supported on windows."]
+
+
+def test_backend_for_winsched_registered():
+    assert service_base.backend_for("winsched") is winsched
+
+
+# --- setup / uninstall planning (via monkeypatched schtasks) ----------------------
+
+
+def test_windows_auto_uses_winsched(windows_env):
+    p = plan.build_setup_plan(plan.Options(auto=True), detect.detect_all(55423))
+    assert p["service"]["type"] == "winsched"
+
+
+def test_windows_setup_writes_task_and_manifest(windows_env, fake_winsched, capsys):
+    rc, payload = run_json(["setup", "--auto", "--service", "winsched", "--json"], capsys)
+    assert rc == 0 and payload["service"]["type"] == "winsched"
+    task_path = paths.winsched_task_path()
+    assert task_path.is_file() and "X-Tokdash-Managed" in task_path.read_text(encoding="utf-8")
+    assert manifest.read_manifest()["service"]["type"] == "winsched"
+    assert "service:winsched" in payload["changed"]
+
+
+def test_windows_setup_refuses_unmarked_task(windows_env, fake_winsched):
+    task_path = paths.winsched_task_path()
+    task_path.parent.mkdir(parents=True, exist_ok=True)
+    task_path.write_text("<Task></Task>", encoding="utf-8")
+    rc = run(["setup", "--auto", "--service", "winsched"])
+    assert rc == 1 and "X-Tokdash-Managed" not in task_path.read_text(encoding="utf-8")
+
+
+def test_windows_setup_force_overwrites_unmarked_task(windows_env, fake_winsched):
+    task_path = paths.winsched_task_path()
+    task_path.parent.mkdir(parents=True, exist_ok=True)
+    task_path.write_text("<Task></Task>", encoding="utf-8")
+    rc = run(["setup", "--auto", "--service", "winsched", "--force"])
+    assert rc == 0 and "X-Tokdash-Managed" in task_path.read_text(encoding="utf-8")
+
+
+def test_windows_uninstall_removes_winsched(windows_env, fake_winsched, capsys):
+    run(["setup", "--auto", "--service", "winsched"])
+    assert paths.winsched_task_path().is_file()
+    rc, payload = run_json(["uninstall", "--auto", "--json"], capsys)
+    assert rc == 0 and "service" in payload["changed"]
+    assert not paths.winsched_task_path().exists()
+
+
+def test_windows_uninstall_fails_closed_when_delete_fails_and_still_registered(windows_env, fake_winsched, monkeypatch):
+    run(["setup", "--auto", "--service", "winsched"])
+    monkeypatch.setattr(winsched, "delete", lambda name=winsched.TASK_NAME: subprocess.CompletedProcess([], 1, "", "denied"))
+    monkeypatch.setattr(winsched, "is_registered_strict", lambda name=winsched.TASK_NAME: True)
+    rc = run(["uninstall", "--auto"])
+    assert rc == 1
+    # The task file must still be on disk (unlink happens only after a confirmed-safe delete).
+    assert paths.winsched_task_path().is_file()
+
+
+def test_windows_doctor_reports_winsched(windows_env, fake_winsched, capsys):
+    run(["setup", "--auto", "--service", "winsched"])
+    rc, payload = run_json(["doctor", "--json"], capsys)
+    assert payload["winsched"] is True
+    assert payload["service"]["type"] == "winsched"
+    assert payload["service"]["enabled"] is True and payload["service"]["active"] is True
+    # The autouse `_isolate` fixture stubs detect.probe_port to always report closed/not-tokdash,
+    # so doctor correctly flags that (stubbed) mismatch -- mirrors
+    # test_doctor_flags_active_service_without_tokdash_port for systemd in test_onboard.py.
+    assert rc == 1 and any("not answering" in i for i in payload["issues"])
+
+
+def test_windows_update_restarts_winsched(windows_env, fake_winsched, monkeypatch, capsys):
+    svc = {"type": "winsched", "unit": str(paths.winsched_task_path()), "name": winsched.TASK_NAME,
+           "created_by_setup": True, "marker": "X-Tokdash-Managed id=x"}
+    man = manifest.build_manifest(
+        install_method="pipx", runtime_kind="pipx", runtime_command=["/p/python", "-m", "tokdash"],
+        runtime_owned_by_setup=False, python_path="/p/python", python_version="3.12.0", service=svc,
+        runtime_marker=None, data_dir=str(paths.data_dir()), bind="127.0.0.1", port=55423,
+    )
+    manifest.write_manifest(man)
+    monkeypatch.setattr(detect, "find_pipx", lambda: "/usr/bin/pipx")
+    monkeypatch.setattr(
+        engine.subprocess, "run",
+        lambda *a, **k: subprocess.CompletedProcess(args=a, returncode=0, stdout="", stderr=""),
+    )
+    restarted = []
+
+    def fake_restart(name=winsched.TASK_NAME):
+        restarted.append(True)
+        return _ok_proc()
+
+    monkeypatch.setattr(winsched, "restart", fake_restart)
+    rc, payload = run_json(["update", "--json"], capsys)
+    assert rc == 0 and payload["service_restarted"] is True and restarted == [True]
+
+
+def test_cli_service_choices_include_winsched():
+    args = cli.build_parser("tokdash").parse_args(["setup", "--service", "winsched", "--auto"])
+    assert args.service == "winsched"

--- a/tests/test_winsched.py
+++ b/tests/test_winsched.py
@@ -253,9 +253,9 @@ def test_managed_venv_python_windows_uses_scripts(monkeypatch, tmp_path):
 
 
 def test_managed_venv_python_posix_unchanged(tmp_path, monkeypatch):
-    # Explicit control: os.name is whatever the real test host reports (posix here); this
-    # locks in that the non-Windows shape is untouched by the Tier 2 addition.
+    # Explicitly force the POSIX branch so this remains meaningful on windows-latest too.
     monkeypatch.setenv("TOKDASH_DATA_DIR", str(tmp_path / "dd"))
+    monkeypatch.setattr(paths, "_windows_venv_layout", lambda: False)
     assert paths.managed_venv_python() == tmp_path / "dd" / "runtime" / "python-venv" / "bin" / "python"
 
 


### PR DESCRIPTION
## Summary

Adds native Windows support and prepares release `v1.0.5` without publishing the tag until after merge.

- Adds Tier 0 platform seams: `osinfo.py`, `clientpaths.py`, `filelock.py`, and onboarding service selection via `service_base.py`.
- Adds Tier 1/Tier 2 Windows support plumbing: `msvcrt` file locking, Windows-aware Hermes path handling, Task Scheduler backend (`winsched.py`), Windows venv/pipx path handling, and CI `windows-latest` matrix entries.
- Adds Tier 3 polish/docs: PowerShell statusline template, Windows support plan, Windows client-path research doc, README/README_CN platform notes, and Tailscale-on-Windows caveat.
- Bumps package metadata and changelog to `1.0.5` for the release tag.

## Review Notes

Native Windows behavior has unit/CI coverage plus a local Windows smoke test from WSL. The remaining real-world risk is long-running Task Scheduler lifecycle behavior on an actual user setup; the dry-run path and XML rendering were exercised, but I did not register a persistent scheduled task from a temporary test venv.

## Validation

Local Linux/WSL:

- `PYTHONPATH=src python3 -m pytest -q` -> `384 passed, 3 skipped`
- `python3 -m compileall -q src/tokdash main.py` -> passed
- `ruff check .` -> passed
- `python3 -m build` -> built `tokdash-1.0.5.tar.gz` and `tokdash-1.0.5-py3-none-any.whl`
- `git diff --check` -> passed

Native Windows from WSL:

- Created isolated Windows venv at `%TEMP%\\tokdash-win-test-1.0.5` using Windows Python 3.13.5
- Installed editable package from `H:\\Developing\\Agent\\Tokdash_Project\\tokdash`
- `tokdash.exe --version` -> `tokdash 1.0.5`
- `tokdash.exe doctor --json` -> detected Windows, Python fit, `winsched: true`; existing port `55423` is already serving Tokdash `1.0.2`
- `tokdash.exe setup --dry-run --service winsched --json` -> rendered a non-mutating Task Scheduler plan using `pythonw.exe`
- Additional smoke script passed native Windows checks for `osinfo`, managed venv `Scripts\\python.exe`, `winsched` service selection, Task Scheduler XML env trampoline, and `msvcrt` process lock

GitHub Actions:

- CI run #95 on `bdd6828c9ebe199d4462fc9370993c27e2ba9c1b` is pending after the release bump.