### PR TITLE
add Mimo usage source support

### DIFF
--- a/src/tokdash/clientpaths.py
+++ b/src/tokdash/clientpaths.py
@@ -37,6 +37,13 @@ def opencode_db_path() -> Path:
     return Path.home() / ".local/share/opencode/opencode.db"
 
 
+# --- Mimo / Mimocode -----------------------------------------------------------
+
+
+def mimocode_db_path() -> Path:
+    return Path.home() / ".local/share/mimocode/mimocode.db"
+
+
 # --- Codex --------------------------------------------------------------------
 
 

--- a/src/tokdash/sessions.py
+++ b/src/tokdash/sessions.py
@@ -15,12 +15,13 @@ from .pricing import PricingDatabase
 from .usage_store import UsageEntryStore, parser_code_signature, persistent_usage_db_enabled
 
 
-SESSION_TOOLS = ("codex", "claude", "opencode", "pi_agent")
+SESSION_TOOLS = ("codex", "claude", "opencode", "pi_agent", "mimo")
 TOOL_LABELS = {
     "codex": "Codex",
     "claude": "Claude Code",
     "opencode": "OpenCode",
     "pi_agent": "Pi",
+    "mimo": "Mimo",
 }
 
 _PRICING_DB = PricingDatabase()
@@ -54,6 +55,7 @@ def reload_pricing_db() -> None:
     _load_opencode_sessions.cache_clear()
     _parse_pi_session_file.cache_clear()
     _load_pi_sessions.cache_clear()
+    _load_mimo_sessions.cache_clear()
 
 
 def _truthy_env(name: str) -> bool:
@@ -1134,6 +1136,112 @@ def _pi_sessions() -> Dict[str, Dict[str, Any]]:
     return _load_pi_sessions(_pi_session_signatures(), _pricing_signature())
 
 
+@lru_cache(maxsize=4)
+def _load_mimo_sessions(signature: tuple, _pricing_sig: tuple = ()) -> Dict[str, Dict[str, Any]]:
+    if not signature:
+        return {}
+    db_path = Path(signature[0][0])
+    if not db_path.exists():
+        return {}
+
+    sessions: Dict[str, Dict[str, Any]] = {}
+    turn_index_by_session: Dict[str, int] = {}
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT m.session_id, m.data, m.time_created,
+                   s.title, s.directory
+            FROM message m
+            LEFT JOIN session s ON s.id = m.session_id
+            ORDER BY m.session_id, m.time_created
+            """
+        )
+        rows = cur.fetchall()
+        conn.close()
+    except Exception:
+        return {}
+
+    for session_id, data_json, ts_ms, title, directory in rows:
+        try:
+            data = json.loads(data_json)
+            if data.get("role") != "assistant":
+                continue
+            tokens = data.get("tokens")
+            if not isinstance(tokens, dict):
+                continue
+
+            cache = tokens.get("cache") if isinstance(tokens.get("cache"), dict) else {}
+            input_t = int(tokens.get("input") or 0)
+            output_t = int(tokens.get("output") or 0)
+            cache_r = int(cache.get("read") or 0)
+            cache_w = int(cache.get("write") or 0)
+            reasoning = int(tokens.get("reasoning") or 0)
+            total_tokens = input_t + output_t + cache_r + cache_w + reasoning
+            if total_tokens == 0:
+                continue
+
+            model = str(data.get("modelID") or "unknown")
+            provider = str(data.get("providerID") or "")
+            full_model = f"{provider}/{model}" if provider else model
+
+            data_cost = float(data.get("cost") or 0.0)
+            cost = data_cost if data_cost > 0 else _PRICING_DB.get_cost(full_model, input_t, output_t, cache_r, cache_w)
+
+            sid = str(session_id)
+            project = _project_from_repo_or_path(None, directory or None)
+            display_name = _clean_display_name(title) or _fallback_display_name(sid, project)
+
+            raw = sessions.setdefault(
+                sid,
+                {
+                    "tool": "mimo",
+                    "session_id": sid,
+                    "display_name": display_name,
+                    "project": project,
+                    "turns": [],
+                },
+            )
+            if not raw.get("display_name"):
+                raw["display_name"] = display_name
+
+            turn_index = turn_index_by_session.get(sid, 0) + 1
+            turn_index_by_session[sid] = turn_index
+            raw["turns"].append(
+                _build_turn(
+                    turn_index=turn_index,
+                    timestamp_ms=int(ts_ms or 0),
+                    model=model,
+                    tokens_in=input_t + cache_w,
+                    tokens_cache=cache_r,
+                    tokens_out=output_t,
+                    tokens_reasoning=reasoning,
+                    cost=cost,
+                )
+            )
+        except Exception:
+            continue
+
+    return sessions
+
+
+def _mimo_session_signatures() -> tuple:
+    db_path = clientpaths.mimocode_db_path()
+    if not db_path.exists():
+        return ()
+    try:
+        s = db_path.stat()
+        return ((str(db_path), s.st_mtime_ns, s.st_size),)
+    except (FileNotFoundError, OSError):
+        return ()
+
+
+def _mimo_sessions() -> Dict[str, Dict[str, Any]]:
+    return _load_mimo_sessions(_mimo_session_signatures(), _pricing_signature())
+
+
 def _raw_sessions_for_tool(
     tool: str,
     since_ms: Optional[int] = None,
@@ -1153,6 +1261,8 @@ def _raw_sessions_for_tool(
         return _opencode_sessions(since_ms=since_ms, until_ms=until_ms)
     if key == "pi_agent":
         return _pi_sessions()
+    if key == "mimo":
+        return _mimo_sessions()
     raise ValueError(f"Unsupported session tool: {tool}")
 
 

--- a/src/tokdash/sources/coding_tools.py
+++ b/src/tokdash/sources/coding_tools.py
@@ -1920,6 +1920,134 @@ class HermesParser(BaseParser):
         return out
 
 
+class MimoParser(BaseParser):
+    """
+    Parser for Mimocode / Mimo token usage.
+
+    =======================================================================
+    MIMO SQLite DATABASE SCHEMA
+    =======================================================================
+    Location: ~/.local/share/mimocode/mimocode.db
+
+    Table: message
+      - id TEXT
+      - session_id TEXT
+      - time_created INTEGER  (epoch ms)
+      - time_updated INTEGER  (epoch ms)
+      - data TEXT             (JSON blob)
+
+    The data JSON for assistant messages contains:
+      - role: "assistant"
+      - cost: float (direct cost when available)
+      - tokens:
+          - input: int
+          - output: int
+          - reasoning: int
+          - cache:
+              - read: int
+              - write: int
+      - modelID: str
+      - providerID: str
+      - time.created: int (epoch ms)
+      - time.completed: int (epoch ms)
+
+    Field mapping to normalized entry:
+      source    <- "mimo"
+      model     <- data.modelID
+      provider  <- data.providerID
+      input     <- data.tokens.input
+      output    <- data.tokens.output
+      cacheRead <- data.tokens.cache.read
+      cacheWrite<- data.tokens.cache.write
+      reasoning <- data.tokens.reasoning
+      cost      <- data.cost when > 0, else pricing DB lookup
+      timestamp <- time_created (column, epoch ms)
+
+    Dedup: message.id (text primary key).
+    =======================================================================
+    """
+
+    source_name = "mimo"
+    sync_capability = SourceSyncCapability(
+        mode="source_replace",
+        reason="Mimocode stores messages in a SQLite DB; full source replacement on DB file change.",
+    )
+
+    def __init__(self, pricing_db: PricingDatabase):
+        super().__init__(pricing_db)
+        self.db_path = clientpaths.mimocode_db_path()
+
+    def _build_entry(self, data: Dict[str, Any], ts_ms: int) -> Dict[str, Any]:
+        tokens = data.get("tokens") if isinstance(data.get("tokens"), dict) else {}
+        cache = tokens.get("cache") if isinstance(tokens.get("cache"), dict) else {}
+        input_t = self._i(tokens.get("input"))
+        output_t = self._i(tokens.get("output"))
+        cache_r = self._i(cache.get("read"))
+        cache_w = self._i(cache.get("write"))
+        reasoning = self._i(tokens.get("reasoning"))
+        model = str(data.get("modelID") or "unknown")
+        provider = str(data.get("providerID") or "")
+
+        # Prefer direct cost from the data when available.
+        data_cost = float(data.get("cost") or 0.0)
+        if data_cost > 0:
+            cost = data_cost
+        else:
+            cost = self.pricing_db.get_cost(model, input_t, output_t, cache_r, cache_w)
+
+        return {
+            "source": self.source_name,
+            "model": model,
+            "provider": provider,
+            "input": input_t,
+            "output": output_t,
+            "cacheRead": cache_r,
+            "cacheWrite": cache_w,
+            "reasoning": reasoning,
+            "cost": cost,
+            "timestamp": int(ts_ms),
+        }
+
+    def _file_signatures(self) -> tuple:
+        if not self.db_path.exists():
+            return ()
+        out: list[tuple[str, int, int]] = []
+        for candidate in (self.db_path, Path(str(self.db_path) + "-wal"), Path(str(self.db_path) + "-shm")):
+            try:
+                s = candidate.stat()
+                out.append((str(candidate), s.st_mtime_ns, s.st_size))
+            except (FileNotFoundError, OSError):
+                continue
+        return tuple(out)
+
+    def _parse_all(self) -> List[Dict[str, Any]]:
+        out: List[Dict[str, Any]] = []
+        if not self.db_path.exists():
+            return out
+        try:
+            conn = sqlite3.connect(str(self.db_path))
+            cur = conn.cursor()
+            cur.execute("SELECT id, data, time_created FROM message ORDER BY time_created")
+            rows = cur.fetchall()
+            conn.close()
+            for msg_id, data_json, ts_ms in rows:
+                try:
+                    data = json.loads(data_json)
+                    if data.get("role") != "assistant":
+                        continue
+                    tokens = data.get("tokens")
+                    if not isinstance(tokens, dict):
+                        continue
+                    entry = self._build_entry(data, self._i(ts_ms))
+                    entry["entry_id"] = f"mimo:{msg_id}"
+                    out.append(entry)
+                except Exception:
+                    continue
+        except Exception:
+            pass
+        return out
+
+
 class CodingToolsUsageTracker:
     """Registry-driven tracker for coding clients."""
 
@@ -1941,6 +2069,7 @@ class CodingToolsUsageTracker:
             "pi_agent": PiAgentParser(self.pricing_db),
             "copilot_cli": CopilotCLIParser(self.pricing_db),
             "hermes": HermesParser(self.pricing_db),
+            "mimo": MimoParser(self.pricing_db),
         }
 
     def collect(self, since_date: Optional[datetime] = None, until_date: Optional[datetime] = None, sources: Optional[List[str]] = None):
@@ -1970,7 +2099,7 @@ def main():
     parser.add_argument("--since", type=str)
     parser.add_argument("--until", type=str)
     parser.add_argument("--json", action="store_true")
-    parser.add_argument("--sources", type=str, default="opencode,codex,claude,gemini_cli,antigravity_cli,amp,kimi,pi_agent,copilot_cli,hermes")
+    parser.add_argument("--sources", type=str, default="opencode,codex,claude,gemini_cli,antigravity_cli,amp,kimi,pi_agent,copilot_cli,hermes,mimo")
     args = parser.parse_args()
 
     since_date, until_date = _date_range(args)

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -1288,6 +1288,65 @@
         </div>
       </section>
 
+      <section class="surface p-5 mb-6">
+        <div class="flex items-center justify-between gap-3 mb-4">
+          <div>
+            <h2 class="text-base font-extrabold mono">Mimo Sessions</h2>
+            <p class="text-xs mt-1" style="color: var(--color-muted);" data-i18n="sessionsRangeDesc">Latest session plus sessions for the selected range.</p>
+          </div>
+        </div>
+        <div id="mimoLatestSession" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-4 mb-5">
+          <div class="surface p-4">
+            <div class="text-xs font-semibold uppercase tracking-wider" style="color: var(--color-label);" data-i18n="latestSession">Latest Session</div>
+            <div id="mimoLatestProject" class="mt-2 font-extrabold mono">Loading…</div>
+            <div id="mimoLatestMeta" class="text-sm mt-1" style="color: var(--color-muted);">-</div>
+          </div>
+          <div class="surface p-4">
+            <div class="text-xs font-semibold uppercase tracking-wider" style="color: var(--color-label);" data-i18n="input">Input</div>
+            <div id="mimoLatestInput" class="mt-2 font-extrabold">-</div>
+          </div>
+          <div class="surface p-4">
+            <div class="text-xs font-semibold uppercase tracking-wider" style="color: var(--color-label);" data-i18n="cacheRead">Cache Read</div>
+            <div id="mimoLatestCache" class="mt-2 font-extrabold">-</div>
+            <div id="mimoLatestCachePct" class="text-sm mt-1" style="color: var(--color-muted);">-</div>
+          </div>
+          <div class="surface p-4">
+            <div class="text-xs font-semibold uppercase tracking-wider" style="color: var(--color-label);" data-i18n="output">Output</div>
+            <div id="mimoLatestOutput" class="mt-2 font-extrabold">-</div>
+          </div>
+          <div class="surface p-4">
+            <div class="text-xs font-semibold uppercase tracking-wider" style="color: var(--color-label);" data-i18n="totalTokens">Total Tokens</div>
+            <div id="mimoLatestTotal" class="mt-2 font-extrabold">-</div>
+          </div>
+          <div class="surface p-4">
+            <div class="text-xs font-semibold uppercase tracking-wider" style="color: var(--color-label);" data-i18n="events">Events</div>
+            <div id="mimoLatestEvents" class="mt-2 font-extrabold">-</div>
+            <div id="mimoLatestSeen" class="text-sm mt-1" style="color: var(--color-muted);">-</div>
+          </div>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm session-table" aria-label="Mimo sessions table" data-panel="mimo">
+            <colgroup><col style="width:18%"><col style="width:12%"><col style="width:10%"><col style="width:10%"><col style="width:8%"><col style="width:9%"><col style="width:11%"><col style="width:9%"><col style="width:13%"></colgroup>
+            <thead>
+              <tr class="border-b" style="border-color: var(--color-border);">
+                <th class="text-left py-3 px-4 font-semibold" style="color: var(--color-muted);" data-i18n="session" data-sortable="display_name">Session</th>
+                <th class="text-left py-3 px-4 font-semibold" style="color: var(--color-muted);" data-i18n="model">Model</th>
+                <th class="text-right py-3 px-4 font-semibold" style="color: var(--color-muted);" data-i18n="input" data-sortable="tokens_in">Input</th>
+                <th class="text-right py-3 px-4 font-semibold" style="color: var(--color-muted);" data-i18n="cache" data-sortable="tokens_cache">Cache</th>
+                <th class="text-right py-3 px-4 font-semibold" style="color: var(--color-muted);" data-i18n="hitPct" data-sortable="cache_hit_rate">Hit %</th>
+                <th class="text-right py-3 px-4 font-semibold" style="color: var(--color-muted);" data-i18n="output" data-sortable="tokens_out">Output</th>
+                <th class="text-right py-3 px-4 font-semibold" style="color: var(--color-muted);" data-i18n="total" data-sortable="tokens">Total</th>
+                <th class="text-right py-3 px-4 font-semibold" style="color: var(--color-muted);" data-i18n="cost" data-sortable="cost">Cost</th>
+                <th class="text-right py-3 px-4 font-semibold" style="color: var(--color-muted);" data-i18n="lastUpdated" data-sortable="last_seen_at">Last updated</th>
+              </tr>
+            </thead>
+            <tbody id="mimoSessionsTable">
+              <tr><td colspan="9" class="text-center py-10" style="color: var(--color-muted);" data-i18n="loading">Loading…</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
       <section class="surface p-5">
         <div class="flex items-center justify-between gap-3 mb-4">
           <div>
@@ -1854,8 +1913,8 @@
     let refreshCooldownTimer = null;
     let refreshCooldownRemaining = 0;
     let lastUsageResponse = null;
-    const SESSION_TOOL_KEYS = ['codex', 'claude', 'opencode', 'pi_agent'];
-    let lastSessionsResponses = { codex: null, claude: null, opencode: null, pi_agent: null, combined: null };
+    const SESSION_TOOL_KEYS = ['codex', 'claude', 'opencode', 'pi_agent', 'mimo'];
+    let lastSessionsResponses = { codex: null, claude: null, opencode: null, pi_agent: null, mimo: null, combined: null };
     let lastCombinedModels = [];
     let lastAppsBreakdown = null;
     let lastByTool = {};
@@ -2950,6 +3009,7 @@
         pi_agent: 'Pi',
         copilot_cli: 'GitHub Copilot CLI',
         hermes: 'Hermes',
+        mimo: 'Mimo',
       };
       if (mapping[key]) return mapping[key];
 
@@ -3596,6 +3656,7 @@
       claude: { ...DEFAULT_SORT },
       opencode: { ...DEFAULT_SORT },
       pi_agent: { ...DEFAULT_SORT },
+      mimo: { ...DEFAULT_SORT },
       combined: { ...DEFAULT_SORT },
     };
 
@@ -3826,6 +3887,7 @@
       updateSessionPanel("claude", lastSessionsResponses.claude);
       updateSessionPanel("opencode", lastSessionsResponses.opencode);
       updateSessionPanel("pi_agent", lastSessionsResponses.pi_agent);
+      updateSessionPanel("mimo", lastSessionsResponses.mimo);
       lastSessionsResponses.combined = buildCombinedSessionsData(lastSessionsResponses);
       updateSessionPanel("combined", lastSessionsResponses.combined, { showTool: true });
 
@@ -3834,6 +3896,7 @@
       initSortHeaders("claude", renderSessionsTab);
       initSortHeaders("opencode", renderSessionsTab);
       initSortHeaders("pi_agent", renderSessionsTab);
+      initSortHeaders("mimo", renderSessionsTab);
       initSortHeaders("combined", renderSessionsTab);
     }
 


### PR DESCRIPTION
Adds support for reading Mimo/Mimocode usage from the local SQLite database.

Reads assistant message usage from:
~/.local/share/mimocode/mimocode.db

Extracted fields:
- providerID
- modelID
- cost
- input/output tokens
- reasoning tokens
- cache read/write tokens
- session ID
- timestamp

This allows Tokdash to include Mimo usage in sync/status/dashboard data.