### PR TITLE
Add Last Week range and refresh roadmap

### DIFF
--- a/docs/development/ROADMAP.md
+++ b/docs/development/ROADMAP.md
@@ -1,16 +1,16 @@
 # Tokdash Roadmap / Notes
 
-_Last updated: 2026-06-02_
+_Last updated: 2026-07-29_
 
-## History retention / durable usage store (deferred)
-Tokdash recomputes everything live from client logs, so history erodes when a client deletes its
-old logs — notably **Claude Code** and **Gemini CLI** (30-day default cleanup). **Decision
-(2026-06): use config-based retention** — keep each client's own logs by raising/disabling its
-cleanup window — rather than building an in-app snapshot store. Rationale, the full per-client
-survey, and the one-line fixes live in [`docs/HISTORY_RETENTION.md`](../reference/HISTORY_RETENTION.md). A
-fully-reviewed design for an in-app snapshot/durable store is **parked** in
-[`docs/SNAPSHOTS_PLAN.md`](SNAPSHOTS_PLAN.md), to revisit only if a client ships
-non-disable-able cleanup or multi-machine history sync becomes a goal.
+## History retention / durable usage store
+Tokdash now keeps a local SQLite usage index at `~/.tokdash/usage.sqlite3` by default. Durable
+mode keeps rows that were already indexed when a source file later disappears, but it cannot
+recover logs deleted before Tokdash indexed them. Client retention settings therefore still
+matter — notably for **Claude Code** and **Gemini CLI** (30-day default cleanup). The full
+per-client survey and one-line retention fixes live in
+[`docs/reference/HISTORY_RETENTION.md`](../reference/HISTORY_RETENTION.md). The separate
+snapshot-store design remains parked in [`docs/SNAPSHOTS_PLAN.md`](SNAPSHOTS_PLAN.md) for a
+future need such as non-disable-able client cleanup or multi-machine history sync.
 
 ## Goals
 - **Easy install**: `pip install tokdash` (no Docker on the roadmap for now).
@@ -44,9 +44,9 @@ _Target UX:_
 - `tokdash serve` → open `http://127.0.0.1:55423`
 
 _Phased approach:_
-1. Add `pyproject.toml` and a `src/tokdash/` package layout.
+1. ✅ Add `pyproject.toml` and a `src/tokdash/` package layout.
 2. ✅ Moved backend + parsers into `src/tokdash/` and removed `sys.path` hacks.
-3. Bundle `static/` + `pricing_db.json` as package data (setuptools package-data).
+3. ✅ Bundle `static/` + `pricing_db.json` as package data (setuptools package-data).
 4. ✅ Added a small CLI (`tokdash`) with subcommands:
    - `tokdash serve` (host/port/CORS/cache-ttl flags; env vars still supported)
    - `tokdash export --json` (one-shot terminal output)
@@ -96,7 +96,7 @@ service worker), which covers the "standalone app window" want with zero code.
 - Non-goals: an Electron/Tauri desktop app (heavy, separate release train; the PWA already
   provides an app window).
 
-## Dashboard update notice — ✅ shipped (Unreleased)
+## Dashboard update notice — ✅ shipped
 Opt-in update badge in the dashboard header backed by the existing `§14` update-check endpoints
 (`/api/version`, `GET /api/update-check`, `POST /api/update-check/consent`). Constraints that
 must hold for any future change: no network check without consent (§14), and the web UI never
@@ -123,26 +123,23 @@ Each addition needs: (1) a local credential seam (like `clientpaths` resolvers),
 fixture-frozen response shape, (3) a consent key, and (4) a provider card/series in the tab.
 
 ## README / polish
-- Add a clear “Supported clients” matrix (✅ implemented vs 🟡 placeholder).
-- Create a Tokdash logo (AIGC is fine) and set dashboard favicon to it.
-- Add supported-client logos/badges (probably via shields.io) and a security note (LAN binding + CORS).
-- Add UI demo assets:
-  - screenshots in `docs/assets/` (overview + stats)
-  - optional short GIF of refresh + scrolling
+- ✅ Add a clear “Supported clients” matrix (implemented vs placeholder).
+- ✅ Create a Tokdash logo and set the dashboard favicon to it.
+- ✅ Add supported-client logos/badges and a security note (LAN binding + CORS).
+- ✅ Add screenshots in `docs/assets/` (Overview, Sessions, Stats, and Quota).
+- Optional: add a short GIF of refresh + scrolling.
 
 ## Performance
 Symptom: browser becomes less responsive while refreshing/scrolling.
 
-Likely causes:
-- Recreating Chart.js objects each refresh (and animating).
-- Large DOM updates (apps breakdown + combined models) happening immediately.
-- Overlapping refreshes (manual + auto refresh).
+Shipped:
+- ✅ Defer big table renders via `requestIdleCallback` (with a timer fallback).
+- ✅ Cap combined-model rows by default with a “Show all” toggle.
+- ✅ Skip Overview rendering while another tab is active.
+- ✅ Prevent overlapping dashboard refreshes.
 
-Fixes to keep:
+Remaining:
 - Reuse Chart.js instances and disable animations.
-- Defer big table renders via `requestIdleCallback`.
-- Cap combined-model rows by default with a “Show all” toggle.
-- Skip Overview DOM work while user is on Stats.
 
 ## Pricing DB updates
 - Keep `src/tokdash/pricing_db.json` open-source.
@@ -155,6 +152,4 @@ Fixes to keep:
 - Keep `requirements-dev.txt` (optional) as a pinned convenience file for contributors.
 
 ## Open questions
-- Publish to PyPI immediately, or start with `pip install git+https://...`?
 - If we allow `0.0.0.0`, do we want an auth token / basic auth option?
-- Do we want Windows path support in v1?

--- a/docs/development/ROADMAP.md
+++ b/docs/development/ROADMAP.md
@@ -139,7 +139,7 @@ Shipped:
 - ✅ Prevent overlapping dashboard refreshes.
 
 Remaining:
-- Reuse Chart.js instances and disable animations.
+- Reuse the session-detail Chart.js instances; chart animations are already disabled.
 
 ## Pricing DB updates
 - Keep `src/tokdash/pricing_db.json` open-source.

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -999,6 +999,7 @@
             <button class="btn btn-ghost quick-range-btn" data-range="today" style="min-height:32px; padding:4px 10px; font-size:12px;" data-i18n="today">Today</button>
             <button class="btn btn-ghost quick-range-btn" data-range="yesterday" style="min-height:32px; padding:4px 10px; font-size:12px;" data-i18n="yesterday">Yesterday</button>
             <button class="btn btn-ghost quick-range-btn" data-range="last7days" style="min-height:32px; padding:4px 10px; font-size:12px;" data-i18n="last7days">Last 7 Days</button>
+            <button class="btn btn-ghost quick-range-btn" data-range="lastWeek" style="min-height:32px; padding:4px 10px; font-size:12px;" data-i18n="lastWeek">Last Week</button>
             <button class="btn btn-ghost quick-range-btn" data-range="last14days" style="min-height:32px; padding:4px 10px; font-size:12px;" data-i18n="last14days">Last 14 Days</button>
             <button class="btn btn-ghost quick-range-btn" data-range="last4weeks" style="min-height:32px; padding:4px 10px; font-size:12px;" data-i18n="last4weeks">Last 4 Weeks</button>
             <button class="btn btn-ghost quick-range-btn" data-range="thisMonth" style="min-height:32px; padding:4px 10px; font-size:12px;" data-i18n="thisMonth">This Month</button>
@@ -2193,6 +2194,7 @@
         yesterday: 'Yesterday',
         last3days: 'Last 3 Days',
         last7days: 'Last 7 Days',
+        lastWeek: 'Last Week',
         last14days: 'Last 14 Days',
         last4weeks: 'Last 4 Weeks',
         thisMonth: 'This Month',
@@ -2450,6 +2452,7 @@
         yesterday: '昨天',
         last3days: '最近 3 天',
         last7days: '过去 7 天',
+        lastWeek: '上周',
         last14days: '过去 14 天',
         last4weeks: '过去 4 周',
         thisMonth: '本月',
@@ -3529,52 +3532,61 @@
       });
     }
 
+    function getQuickRangeDates(range, today = new Date()) {
+      const referenceDate = new Date(today.getTime());
+      let startDate = new Date(referenceDate.getTime());
+      let endDate = new Date(referenceDate.getTime());
+
+      switch(range) {
+        case 'today':
+          break;
+        case 'yesterday':
+          startDate.setDate(referenceDate.getDate() - 1);
+          endDate.setDate(referenceDate.getDate() - 1);
+          break;
+        case 'last7days':
+          startDate.setDate(referenceDate.getDate() - 6);
+          break;
+        case 'lastWeek': {
+          const daysSinceMonday = (referenceDate.getDay() + 6) % 7;
+          const currentMonday = new Date(referenceDate.getTime());
+          currentMonday.setDate(referenceDate.getDate() - daysSinceMonday);
+          startDate = new Date(currentMonday.getTime());
+          startDate.setDate(currentMonday.getDate() - 7);
+          endDate = new Date(currentMonday.getTime());
+          endDate.setDate(currentMonday.getDate() - 1);
+          break;
+        }
+        case 'last14days':
+          startDate.setDate(referenceDate.getDate() - 13);
+          break;
+        case 'last4weeks':
+          startDate.setDate(referenceDate.getDate() - 27);
+          break;
+        case 'thisMonth':
+          startDate.setDate(1); // First day of current month
+          break;
+        case 'lastMonth':
+          startDate = new Date(referenceDate.getFullYear(), referenceDate.getMonth() - 1, 1);
+          endDate = new Date(referenceDate.getFullYear(), referenceDate.getMonth(), 0); // Last day of last month
+          break;
+        case 'thisYear':
+          startDate = new Date(referenceDate.getFullYear(), 0, 1);
+          break;
+        case 'lastYear':
+          startDate = new Date(referenceDate.getFullYear() - 1, 0, 1);
+          endDate = new Date(referenceDate.getFullYear() - 1, 11, 31);
+          break;
+      }
+
+      return { startDate, endDate };
+    }
+
     // Quick range buttons
     document.querySelectorAll('.quick-range-btn').forEach(btn => {
       btn.addEventListener('click', function() {
         const range = this.getAttribute('data-range');
-        const today = new Date();
-        let startDate = new Date();
-        let endDate = new Date(today);
-
-        switch(range) {
-          case 'today':
-            startDate = today;
-            endDate = today;
-            break;
-          case 'yesterday':
-            startDate.setDate(today.getDate() - 1);
-            endDate.setDate(today.getDate() - 1);
-            break;
-          case 'last7days':
-            startDate.setDate(today.getDate() - 6);
-            endDate = today;
-            break;
-          case 'last14days':
-            startDate.setDate(today.getDate() - 13);
-            endDate = today;
-            break;
-          case 'last4weeks':
-            startDate.setDate(today.getDate() - 27);
-            endDate = today;
-            break;
-          case 'thisMonth':
-            startDate.setDate(1); // First day of current month
-            endDate = today;
-            break;
-          case 'lastMonth':
-            startDate = new Date(today.getFullYear(), today.getMonth() - 1, 1);
-            endDate = new Date(today.getFullYear(), today.getMonth(), 0); // Last day of last month
-            break;
-          case 'thisYear':
-            startDate = new Date(today.getFullYear(), 0, 1);
-            endDate = today;
-            break;
-          case 'lastYear':
-            startDate = new Date(today.getFullYear() - 1, 0, 1);
-            endDate = new Date(today.getFullYear() - 1, 11, 31);
-            break;
-        }
+        const { startDate, endDate } = getQuickRangeDates(range);
 
         if (flatpickrInstance) {
           commitDateSelection(startDate, endDate, { closePicker: true, triggerUpdate: true, triggerPickerSync: true });

--- a/tests/test_quick_ranges_frontend.py
+++ b/tests/test_quick_ranges_frontend.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import tokdash
+
+INDEX_HTML = Path(tokdash.__file__).parent / "static" / "index.html"
+
+
+def _extract_js_function(source: str, signature: str) -> str:
+    start = source.find(signature)
+    assert start != -1, f"{signature} not found in index.html"
+    depth = 0
+    for index in range(source.find("{", start), len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unterminated JavaScript function: {signature}")
+
+
+def _run_quick_range_js(
+    tmp_path: Path, cases: list[dict[str, str]]
+) -> list[dict[str, object]]:
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    function = _extract_js_function(
+        source, "function getQuickRangeDates(range, today = new Date()) {"
+    )
+    harness = tmp_path / "quick-ranges.js"
+    harness.write_text(
+        function
+        + "\nfunction ymd(date) {"
+        + " return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;"
+        + " }\n"
+        + "const cases = JSON.parse(process.argv[2]);\n"
+        + "const result = cases.map((item) => {\n"
+        + "  const today = new Date(`${item.today}T12:00:00`);\n"
+        + "  const before = today.getTime();\n"
+        + "  const range = getQuickRangeDates(item.range, today);\n"
+        + "  return { start: ymd(range.startDate), end: ymd(range.endDate), inputUnchanged: today.getTime() === before };\n"
+        + "});\n"
+        + "process.stdout.write(JSON.stringify(result));\n",
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        ["node", str(harness), json.dumps(cases)],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    return json.loads(result.stdout)
+
+
+def test_last_week_button_and_localizations_are_present():
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    assert 'data-range="lastWeek"' in source
+    assert "lastWeek: 'Last Week'" in source
+    assert "lastWeek: '上周'" in source
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_last_week_is_previous_monday_through_sunday_without_mutation(
+    tmp_path: Path,
+):
+    cases = [
+        {"range": "lastWeek", "today": "2026-07-27"},
+        {"range": "lastWeek", "today": "2026-08-02"},
+        {"range": "lastWeek", "today": "2026-01-01"},
+    ]
+    assert _run_quick_range_js(tmp_path, cases) == [
+        {"start": "2026-07-20", "end": "2026-07-26", "inputUnchanged": True},
+        {"start": "2026-07-20", "end": "2026-07-26", "inputUnchanged": True},
+        {"start": "2025-12-22", "end": "2025-12-28", "inputUnchanged": True},
+    ]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_existing_quick_ranges_keep_their_current_dates(tmp_path: Path):
+    cases = [
+        {"range": "today", "today": "2026-07-29"},
+        {"range": "yesterday", "today": "2026-07-29"},
+        {"range": "last7days", "today": "2026-07-29"},
+        {"range": "last14days", "today": "2026-07-29"},
+        {"range": "last4weeks", "today": "2026-07-29"},
+        {"range": "thisMonth", "today": "2026-07-29"},
+        {"range": "lastMonth", "today": "2026-07-29"},
+        {"range": "thisYear", "today": "2026-07-29"},
+        {"range": "lastYear", "today": "2026-07-29"},
+    ]
+    assert _run_quick_range_js(tmp_path, cases) == [
+        {"start": "2026-07-29", "end": "2026-07-29", "inputUnchanged": True},
+        {"start": "2026-07-28", "end": "2026-07-28", "inputUnchanged": True},
+        {"start": "2026-07-23", "end": "2026-07-29", "inputUnchanged": True},
+        {"start": "2026-07-16", "end": "2026-07-29", "inputUnchanged": True},
+        {"start": "2026-07-02", "end": "2026-07-29", "inputUnchanged": True},
+        {"start": "2026-07-01", "end": "2026-07-29", "inputUnchanged": True},
+        {"start": "2026-06-01", "end": "2026-06-30", "inputUnchanged": True},
+        {"start": "2026-01-01", "end": "2026-07-29", "inputUnchanged": True},
+        {"start": "2025-01-01", "end": "2025-12-31", "inputUnchanged": True},
+    ]


### PR DESCRIPTION
## Summary

- add a **Last Week** quick range for the previous complete Monday-through-Sunday period
- extract quick-range calculation into a testable helper and lock existing presets against regressions
- refresh verified Roadmap status without reprioritizing unfinished work

## Behavior and compatibility

- `Last 7 Days` remains a rolling seven-day range
- `Last Week` uses the browser's local timezone and the existing explicit `date_from` / `date_to` flow
- no API or CLI period values change
- narrow layouts may wrap the quick-range controls one item earlier because of the additional button

## Verification

- `TZ=UTC .venv/bin/python -m pytest -q` — 716 passed, 3 skipped
- `.venv/bin/python -m pytest tests/test_quick_ranges_frontend.py tests/test_profile_stats_frontend.py tests/test_frontend_normalizer_sync.py -q` — 36 passed
- `.venv/bin/python -m compileall -q src/tokdash main.py docs/guides/agents/openclaw_reporting/openclaw_cron_job.py`
- `.venv/bin/python -m ruff check tests/test_quick_ranges_frontend.py`
- `.venv/bin/python -m mypy --follow-untyped-imports tests/test_quick_ranges_frontend.py`
