### PR TITLE
fix: preserve persistent usage cache across upgrades

### DIFF
--- a/src/tokdash/compute.py
+++ b/src/tokdash/compute.py
@@ -141,7 +141,10 @@ def _sync_usage_store(tracker: CodingToolsUsageTracker) -> tuple[UsageEntryStore
         parser = tracker.parsers[name]
         capability = getattr(parser, "sync_capability")
         files = parser._file_signatures()
-        pricing = parser._pricing_signature()
+        # Persistent cache keys must survive package reinstalls. The runtime pricing
+        # signature includes site-packages path/mtime for cheap in-process invalidation;
+        # using it here made every historical source file look stale after an upgrade.
+        pricing = parser._persistent_pricing_signature()
         parser_sig = parser_code_signature(parser)
         if capability.mode == "file_replace":
             store.sync_files(

--- a/src/tokdash/sources/coding_tools.py
+++ b/src/tokdash/sources/coding_tools.py
@@ -272,18 +272,27 @@ class BaseParser(ABC):
         return ()
 
     def _pricing_signature(self) -> tuple:
-        """Signature of the EFFECTIVE pricing DB (packaged baseline + data-dir override).
+        """Runtime signature of the effective pricing DB.
 
         Must cover BOTH files: a dashboard pricing edit writes ONLY the override under
-        ``TOKDASH_DATA_DIR`` and never touches the packaged baseline, so statting the
-        baseline alone would never bust ``_entry_cache`` (nor the persistent usage store,
-        which keys on this same signature) and edited rates would silently not apply.
-        ``PricingDatabase.signature()`` stats both files and is itself OSError-safe.
+        ``TOKDASH_DATA_DIR`` and never touches the packaged baseline. This metadata-based
+        signature keeps the in-process entry cache cheap and responsive to out-of-band
+        edits. Persistent caches use ``_persistent_pricing_signature()`` instead so a
+        reinstall cannot invalidate historical rows merely by changing path or mtime.
         """
         try:
             return tuple(self.pricing_db.signature())
         except (OSError, AttributeError):
             return ()
+
+    def _persistent_pricing_signature(self) -> tuple:
+        """Content identity used by the persistent usage cache across installs."""
+        try:
+            return tuple(self.pricing_db.content_signature())
+        except (OSError, AttributeError, TypeError, ValueError):
+            # Custom/older PricingDatabase implementations may not expose a content
+            # identity. Preserve their previous behavior rather than disabling caching.
+            return self._pricing_signature()
 
     @abstractmethod
     def _parse_all(self) -> List[Dict[str, Any]]:

--- a/src/tokdash/sources/openclaw.py
+++ b/src/tokdash/sources/openclaw.py
@@ -241,15 +241,20 @@ def _collect_entries(session_dirs: list[str]) -> List[Dict[str, Any]]:
 
 
 def _pricing_signature(pricing_db: PricingDatabase) -> tuple:
-    # Cover BOTH the packaged baseline AND the data-dir override (PricingDatabase.signature()
-    # stats both and is OSError-safe). A dashboard pricing edit writes only the override, so
-    # statting the baseline alone would never bust this cache — and because this same
-    # signature gates the persistent SQLite usage store, the stale costs would survive a
-    # process restart until a source log file changed on disk.
+    # Cover BOTH the packaged baseline AND the data-dir override. This metadata identity
+    # keeps the in-process cache responsive to out-of-band edits; the persistent store uses
+    # the content identity below so reinstall path/mtime changes do not trigger a rebuild.
     try:
         return tuple(pricing_db.signature())
     except (OSError, AttributeError):
         return ()
+
+
+def _persistent_pricing_signature(pricing_db: PricingDatabase) -> tuple:
+    try:
+        return tuple(pricing_db.content_signature())
+    except (OSError, AttributeError, TypeError, ValueError):
+        return _pricing_signature(pricing_db)
 
 
 def _normalized_entry(entry: Dict[str, Any], pricing_db: PricingDatabase) -> Dict[str, Any]:
@@ -309,7 +314,7 @@ def _sync_openclaw_store(session_dirs: list[str], pricing_db: PricingDatabase) -
     store = UsageEntryStore()
     signature = build_source_signature(  # type: ignore[misc]
         files=sig,
-        pricing=_pricing_signature(pricing_db),
+        pricing=_persistent_pricing_signature(pricing_db),
         parser=parser_code_signature(_collect_normalized_entries),  # type: ignore[misc]
     )
     store.sync_source(

--- a/tests/test_pricing_override_cache_busting.py
+++ b/tests/test_pricing_override_cache_busting.py
@@ -1,18 +1,18 @@
-"""Regression: a dashboard pricing edit writes ONLY the data-dir override, so the
-coding-tools and OpenClaw cache-busting signatures must cover the override too.
+"""Regressions for runtime and persistent pricing cache identities.
 
-Before the fix these signatures stat'd only the packaged baseline (``pricing_db.db_path``),
-so an edit never changed them — the in-memory entry caches AND the persistent usage store
-(which key on the same signature) kept serving costs computed at the OLD prices.
+Both identities must cover the data-dir override. Runtime identities may use filesystem
+metadata, while persistent identities must survive reinstall path and mtime changes.
 """
 import json
 import os
 
 import tokdash.api as api
+import tokdash.compute as compute
 from tokdash.onboard import paths
 from tokdash.pricing import PricingDatabase
 from tokdash.sources import openclaw
 from tokdash.sources.coding_tools import ClaudeParser
+from tokdash.usage_store import UsageEntryStore
 
 
 def _write_override() -> None:
@@ -50,20 +50,118 @@ def test_coding_tools_pricing_signature_busts_on_override():
     pdb = PricingDatabase()
     parser = ClaudeParser(pdb)
     before = parser._pricing_signature()
+    persistent_before = parser._persistent_pricing_signature()
     _write_override()
     after = parser._pricing_signature()
+    persistent_after = parser._persistent_pricing_signature()
     assert before != after  # the override write must change the cache-busting signature
+    assert persistent_before != persistent_after
     # ...and it must track exactly the files PricingDatabase.load() reads (baseline + override)
     assert after == tuple(pdb.signature())
+    assert persistent_after == tuple(pdb.content_signature())
 
 
 def test_openclaw_pricing_signature_busts_on_override():
     pdb = PricingDatabase()
     before = openclaw._pricing_signature(pdb)
+    persistent_before = openclaw._persistent_pricing_signature(pdb)
     _write_override()
     after = openclaw._pricing_signature(pdb)
+    persistent_after = openclaw._persistent_pricing_signature(pdb)
     assert before != after
+    assert persistent_before != persistent_after
     assert after == tuple(pdb.signature())
+    assert persistent_after == tuple(pdb.content_signature())
+
+
+def test_persistent_pricing_signatures_survive_reinstall_metadata(tmp_path):
+    payload = '{\n  "models": {"foo": {"input": 1, "output": 2}}\n}\n'
+    first_path = tmp_path / "first-install" / "pricing_db.json"
+    second_path = tmp_path / "second-install" / "pricing_db.json"
+    first_path.parent.mkdir()
+    second_path.parent.mkdir()
+    first_path.write_text(payload, encoding="utf-8")
+    second_path.write_text(payload, encoding="utf-8")
+    os.utime(second_path, ns=(1_800_000_000_000_000_000, 1_800_000_000_000_000_000))
+
+    first = PricingDatabase(db_path=first_path, override_path=tmp_path / "missing-first.json")
+    second = PricingDatabase(db_path=second_path, override_path=tmp_path / "missing-second.json")
+
+    # Runtime identities intentionally include install metadata.
+    assert first.signature() != second.signature()
+    # Persistent identities depend only on effective pricing content.
+    assert (
+        ClaudeParser(first)._persistent_pricing_signature()
+        == ClaudeParser(second)._persistent_pricing_signature()
+    )
+    assert openclaw._persistent_pricing_signature(first) == openclaw._persistent_pricing_signature(second)
+
+    store = UsageEntryStore(tmp_path / "usage.sqlite3")
+    files = ((str(tmp_path / "session.jsonl"), 1, 100),)
+    parse_calls = []
+
+    def parse_file(file_signature):
+        parse_calls.append(file_signature)
+        return []
+
+    assert store.sync_files(
+        "claude",
+        files,
+        pricing=ClaudeParser(first)._persistent_pricing_signature(),
+        parse_file_entries=parse_file,
+    )
+    assert not store.sync_files(
+        "claude",
+        files,
+        pricing=ClaudeParser(second)._persistent_pricing_signature(),
+        parse_file_entries=parse_file,
+    )
+    assert parse_calls == [files[0]]
+
+
+def test_usage_store_sync_uses_persistent_pricing_identity(monkeypatch):
+    tracker = compute.CodingToolsUsageTracker()
+    parser = tracker.parsers["claude"]
+    captured = {}
+
+    class FakeStore:
+        def sync_files(self, source, files, **kwargs):
+            captured["source"] = source
+            captured["pricing"] = kwargs["pricing"]
+            return False
+
+    monkeypatch.setattr(compute, "UsageEntryStore", FakeStore)
+    monkeypatch.setattr(compute, "_usage_store_sources", lambda _tracker: ["claude"])
+    monkeypatch.setattr(parser, "_file_signatures", lambda: ())
+    monkeypatch.setattr(parser, "_pricing_signature", lambda: ("runtime-metadata",))
+    monkeypatch.setattr(parser, "_persistent_pricing_signature", lambda: ("content",))
+
+    compute._sync_usage_store(tracker)
+
+    assert captured == {"source": "claude", "pricing": ("content",)}
+
+
+def test_openclaw_store_sync_uses_persistent_pricing_identity(monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeStore:
+        def sync_source(self, source, signature, collect):
+            captured["source"] = source
+            captured["signature"] = json.loads(signature)
+            return False
+
+    pricing = PricingDatabase(
+        db_path=tmp_path / "missing-baseline.json",
+        override_path=tmp_path / "missing-override.json",
+    )
+    monkeypatch.setattr(openclaw, "UsageEntryStore", FakeStore)
+    monkeypatch.setattr(openclaw, "_session_files", lambda _session_dirs: [])
+    monkeypatch.setattr(openclaw, "_persistent_pricing_signature", lambda _pricing: ("content",))
+
+    openclaw._sync_openclaw_store([], pricing)
+
+    assert captured["source"] == "openclaw"
+    assert captured["signature"]["pricing"] == ["content"]
 
 
 def test_sessions_singleton_reloads_when_override_changes_out_of_band():


### PR DESCRIPTION
## Summary

- separate runtime pricing metadata from the content identity used by the persistent usage store
- preserve cached coding-tool and OpenClaw rows when an upgrade only changes install path or file mtime
- keep invalidation for real effective-pricing changes, including dashboard overrides
- add regression coverage proving identical pricing content does not invoke the parser again

Fixes #19.

## Root cause

The persistent usage-store key reused the runtime pricing signature. That signature intentionally includes the packaged pricing file path and mtime, so pip/pipx upgrades made every historical source file appear stale even when parser and pricing contents were byte-identical.

The persistent path now uses PricingDatabase.content_signature(), while the in-process cache keeps the inexpensive metadata signature.

## Performance

In the reported local case, an unchanged upgrade triggered about 126 seconds of cache rebuilding. Computing content identities for all registered parsers took about 15 ms locally and adds no dependency, schema migration, or background worker.

Existing metadata-keyed databases may rebuild once when first running this fix because the signature format changes. Subsequent upgrades with unchanged parser and pricing content retain the cache.

## Validation

- TZ=UTC python -m pytest -q: 813 passed, 3 skipped
- targeted pricing/usage-store tests: 57 passed
- compileall for CI-covered Python sources
- Ruff baseline checks (E4, E7, E9, F)
- git diff --check
