### PR TITLE
fix: remove quick range horizontal scrollbar

### DIFF
--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -478,7 +478,7 @@
     .quick-range-panel {
       grid-area: quick;
       display: flex;
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
       gap: 8px;
       align-items: center;
       width: 100%;
@@ -1583,12 +1583,12 @@
 
           <!-- Quick Range Buttons -->
           <div class="quick-range-panel" role="toolbar" aria-labelledby="dateRangeControlLabel">
-            <button type="button" class="btn btn-ghost quick-range-btn" data-range="today" aria-pressed="true" data-i18n="today">Today</button>
-            <button type="button" class="btn btn-ghost quick-range-btn" data-range="yesterday" aria-pressed="false" data-i18n="yesterday">Yesterday</button>
-            <button type="button" class="btn btn-ghost quick-range-btn" data-range="last7days" aria-pressed="false" data-i18n="last7days">Last 7 Days</button>
-            <button type="button" class="btn btn-ghost quick-range-btn" data-range="lastWeek" aria-pressed="false" data-i18n="lastWeek">Last Week</button>
-            <button type="button" class="btn btn-ghost quick-range-btn" data-range="thisMonth" aria-pressed="false" data-i18n="thisMonth">This Month</button>
-            <button type="button" class="btn btn-ghost quick-range-btn" data-range="lastMonth" aria-pressed="false" data-i18n="lastMonth">Last Month</button>
+            <button type="button" class="btn btn-ghost quick-range-btn" data-range="today" data-quick-primary aria-pressed="true" data-i18n="today">Today</button>
+            <button type="button" class="btn btn-ghost quick-range-btn" data-range="yesterday" data-quick-primary aria-pressed="false" data-i18n="yesterday">Yesterday</button>
+            <button type="button" class="btn btn-ghost quick-range-btn" data-range="last7days" data-quick-primary aria-pressed="false" data-i18n="last7days">Last 7 Days</button>
+            <button type="button" class="btn btn-ghost quick-range-btn" data-range="lastWeek" data-quick-primary aria-pressed="false" data-i18n="lastWeek">Last Week</button>
+            <button type="button" class="btn btn-ghost quick-range-btn" data-range="thisMonth" data-quick-primary aria-pressed="false" data-i18n="thisMonth">This Month</button>
+            <button type="button" class="btn btn-ghost quick-range-btn" data-range="lastMonth" data-quick-primary aria-pressed="false" data-i18n="lastMonth">Last Month</button>
             <div class="quick-range-more">
               <button id="quickRangeMoreToggle" type="button" class="btn btn-ghost quick-range-more-trigger" aria-expanded="false" aria-controls="quickRangeMoreMenu" aria-pressed="false">
                 <span id="quickRangeMoreLabel" data-i18n="moreRanges">More ranges</span>
@@ -4676,6 +4676,7 @@
       updateMetricControls();
       syncDatePickerFooter();
       syncDateRangeControl();
+      scheduleQuickRangeLayout();
       if (typeof profileActivityMode !== 'undefined') {
         renderProfileActivityLegend('profileActivityLegend', profileActivityMode);
         renderProfileActivityLegend('overviewProfileLegend', profileActivityMode);
@@ -5268,6 +5269,52 @@
     const quickRangeMore = document.querySelector('.quick-range-more');
     const quickRangeMoreToggle = document.getElementById('quickRangeMoreToggle');
     const quickRangeMoreMenu = document.getElementById('quickRangeMoreMenu');
+    const quickRangePanel = document.querySelector('.quick-range-panel');
+    const quickRangePrimaryButtons = Array.from(document.querySelectorAll('[data-quick-primary]'));
+    let quickRangeLayoutFrame = null;
+
+    function quickRangeRequiredWidth() {
+      if (!quickRangePanel) return 0;
+      const children = Array.from(quickRangePanel.children);
+      const styles = window.getComputedStyle(quickRangePanel);
+      const gap = Number.parseFloat(styles.columnGap || styles.gap) || 0;
+      return children.reduce((total, child) => total + child.offsetWidth, 0)
+        + Math.max(0, children.length - 1) * gap;
+    }
+
+    function syncQuickRangeLayout() {
+      if (!quickRangePanel || !quickRangeMore || !quickRangeMoreMenu) return;
+
+      // Start from the preferred desktop set, then progressively move the least
+      // important visible presets into the existing disclosure until one row fits.
+      quickRangePrimaryButtons.forEach((button) => {
+        quickRangePanel.insertBefore(button, quickRangeMore);
+      });
+      syncDateRangeControl();
+
+      for (let index = quickRangePrimaryButtons.length - 1;
+        index > 0 && quickRangeRequiredWidth() > quickRangePanel.clientWidth;
+        index -= 1) {
+        quickRangeMoreMenu.prepend(quickRangePrimaryButtons[index]);
+        syncDateRangeControl();
+      }
+    }
+
+    function scheduleQuickRangeLayout() {
+      if (quickRangeLayoutFrame !== null) cancelAnimationFrame(quickRangeLayoutFrame);
+      quickRangeLayoutFrame = requestAnimationFrame(() => {
+        quickRangeLayoutFrame = null;
+        syncQuickRangeLayout();
+      });
+    }
+
+    if (quickRangePanel && typeof ResizeObserver === 'function') {
+      new ResizeObserver(scheduleQuickRangeLayout).observe(quickRangePanel);
+    } else {
+      window.addEventListener('resize', scheduleQuickRangeLayout, { passive: true });
+    }
+    document.fonts?.ready.then(scheduleQuickRangeLayout);
+
     quickRangeMoreToggle?.addEventListener('click', () => {
       setQuickRangeMoreOpen(Boolean(quickRangeMoreMenu?.hidden));
     });

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -478,23 +478,82 @@
     .quick-range-panel {
       grid-area: quick;
       display: flex;
-      flex-wrap: nowrap;
-      gap: 10px;
-      align-items: flex-start;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
       width: 100%;
       min-width: 0;
-      overflow-x: auto;
-      overscroll-behavior-inline: contain;
-      padding-bottom: 4px;
-      scrollbar-width: thin;
+      overflow: visible;
     }
 
     .quick-range-btn {
       flex: 0 0 auto;
       min-height: 32px;
-      padding: 4px 10px;
+      padding: 4px 9px;
       font-size: 12px;
       white-space: nowrap;
+    }
+
+    .quick-range-more {
+      position: relative;
+      flex: 0 0 auto;
+    }
+
+    .quick-range-more-trigger {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      min-height: 32px;
+      padding: 4px 9px;
+      font-size: 12px;
+    }
+
+    .quick-range-more-trigger[aria-pressed="true"] {
+      border-color: color-mix(in srgb, var(--color-primary) 58%, var(--color-border));
+      background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+      color: var(--color-primary);
+    }
+
+    .quick-range-more-chevron {
+      flex: 0 0 auto;
+      transition: transform var(--t-fast) ease;
+    }
+
+    .quick-range-more-trigger[aria-expanded="true"] .quick-range-more-chevron {
+      transform: rotate(180deg);
+    }
+
+    .quick-range-more-menu {
+      position: absolute;
+      z-index: 80;
+      top: calc(100% + 7px);
+      right: 0;
+      display: grid;
+      min-width: 168px;
+      gap: 3px;
+      padding: 6px;
+      border: 1px solid color-mix(in srgb, var(--color-primary) 18%, var(--color-border));
+      border-radius: 12px;
+      background: color-mix(in srgb, var(--color-surface-glass) 96%, var(--color-bg));
+      box-shadow: var(--shadow-md), 0 14px 34px color-mix(in srgb, var(--color-text) 13%, transparent);
+      backdrop-filter: blur(16px);
+      transform-origin: top right;
+      animation: quick-range-menu-in var(--t-fast) cubic-bezier(.16, 1, .3, 1);
+    }
+
+    .quick-range-more-menu[hidden] { display: none; }
+
+    .quick-range-more-menu .quick-range-btn {
+      width: 100%;
+      justify-content: flex-start;
+      min-height: 34px;
+      border-color: transparent;
+      background: transparent;
+    }
+
+    @keyframes quick-range-menu-in {
+      from { opacity: 0; transform: translateY(-3px) scale(.98); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
     }
 
     .topbar-actions {
@@ -579,6 +638,7 @@
 
     @media (max-width: 640px) {
       .date-range-control { width: 100%; min-width: 0; }
+      .quick-range-more-menu { right: auto; left: 0; transform-origin: top left; }
       .settings-trigger>span { display: none; }
       .settings-trigger { width: 44px; padding-inline: 10px; }
       .overview-token-exact-tooltip { max-width: min(260px, calc(100vw - 40px)); overflow: hidden; text-overflow: ellipsis; }
@@ -587,9 +647,11 @@
     @media (prefers-reduced-motion: reduce) {
       .date-range-trigger,
       .date-range-chevron,
+      .quick-range-more-chevron,
       .overview-readable-tokens-track,
       .overview-readable-tokens-track::after,
       .overview-token-exact-tooltip { transition: none; }
+      .quick-range-more-menu { animation: none; }
       .server-health-dot[data-state="testing"] { animation: none; }
     }
 
@@ -1520,17 +1582,27 @@
           </div>
 
           <!-- Quick Range Buttons -->
-          <div class="quick-range-panel">
+          <div class="quick-range-panel" role="toolbar" aria-labelledby="dateRangeControlLabel">
             <button type="button" class="btn btn-ghost quick-range-btn" data-range="today" aria-pressed="true" data-i18n="today">Today</button>
             <button type="button" class="btn btn-ghost quick-range-btn" data-range="yesterday" aria-pressed="false" data-i18n="yesterday">Yesterday</button>
             <button type="button" class="btn btn-ghost quick-range-btn" data-range="last7days" aria-pressed="false" data-i18n="last7days">Last 7 Days</button>
             <button type="button" class="btn btn-ghost quick-range-btn" data-range="lastWeek" aria-pressed="false" data-i18n="lastWeek">Last Week</button>
-            <button type="button" class="btn btn-ghost quick-range-btn" data-range="last14days" aria-pressed="false" data-i18n="last14days">Last 14 Days</button>
-            <button type="button" class="btn btn-ghost quick-range-btn" data-range="last4weeks" aria-pressed="false" data-i18n="last4weeks">Last 4 Weeks</button>
             <button type="button" class="btn btn-ghost quick-range-btn" data-range="thisMonth" aria-pressed="false" data-i18n="thisMonth">This Month</button>
             <button type="button" class="btn btn-ghost quick-range-btn" data-range="lastMonth" aria-pressed="false" data-i18n="lastMonth">Last Month</button>
-            <button type="button" class="btn btn-ghost quick-range-btn" data-range="thisYear" aria-pressed="false" data-i18n="thisYear">This Year</button>
-            <button type="button" class="btn btn-ghost quick-range-btn" data-range="lastYear" aria-pressed="false" data-i18n="lastYear">Last Year</button>
+            <div class="quick-range-more">
+              <button id="quickRangeMoreToggle" type="button" class="btn btn-ghost quick-range-more-trigger" aria-expanded="false" aria-controls="quickRangeMoreMenu" aria-pressed="false">
+                <span id="quickRangeMoreLabel" data-i18n="moreRanges">More ranges</span>
+                <svg class="quick-range-more-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="m7 10 5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </button>
+              <div id="quickRangeMoreMenu" class="quick-range-more-menu" role="group" aria-labelledby="quickRangeMoreLabel" hidden>
+                <button type="button" class="btn btn-ghost quick-range-btn" data-range="last14days" aria-pressed="false" data-i18n="last14days">Last 14 Days</button>
+                <button type="button" class="btn btn-ghost quick-range-btn" data-range="last4weeks" aria-pressed="false" data-i18n="last4weeks">Last 4 Weeks</button>
+                <button type="button" class="btn btn-ghost quick-range-btn" data-range="thisYear" aria-pressed="false" data-i18n="thisYear">This Year</button>
+                <button type="button" class="btn btn-ghost quick-range-btn" data-range="lastYear" aria-pressed="false" data-i18n="lastYear">Last Year</button>
+              </div>
+            </div>
           </div>
 
           <div class="topbar-actions">
@@ -3069,6 +3141,7 @@
         last3months: 'Last 3 Months',
         thisYear: 'This Year',
         lastYear: 'Last Year',
+        moreRanges: 'More ranges',
         customDays: 'Custom Days…',
         daysPlaceholder: 'Days',
         apply: 'Apply',
@@ -3389,6 +3462,7 @@
         last3months: '最近 3 个月',
         thisYear: '本年',
         lastYear: '去年',
+        moreRanges: '更多范围',
         customDays: '自定义天数…',
         daysPlaceholder: '天数',
         apply: '应用',
@@ -4977,10 +5051,18 @@
       preset.textContent = t(presetKey);
       exact.textContent = formatDateRangeTriggerText(currentStartDate, currentEndDate);
       trigger.setAttribute('title', t('selectRange'));
+      let isSecondaryActive = false;
       document.querySelectorAll('.quick-range-btn').forEach((button) => {
         const isActive = button.dataset.range === activeQuickRange;
         button.setAttribute('aria-pressed', String(isActive));
+        if (isActive && button.closest('#quickRangeMoreMenu')) isSecondaryActive = true;
       });
+      const moreToggle = document.getElementById('quickRangeMoreToggle');
+      const moreLabel = document.getElementById('quickRangeMoreLabel');
+      moreToggle?.setAttribute('aria-pressed', String(isSecondaryActive));
+      if (moreLabel) {
+        moreLabel.textContent = isSecondaryActive ? t(activeQuickRange) : t('moreRanges');
+      }
     }
 
     function syncDatePickerFooter() {
@@ -5174,6 +5256,32 @@
       return { startDate, endDate };
     }
 
+    function setQuickRangeMoreOpen(isOpen, restoreFocus = false) {
+      const toggle = document.getElementById('quickRangeMoreToggle');
+      const menu = document.getElementById('quickRangeMoreMenu');
+      if (!toggle || !menu) return;
+      menu.hidden = !isOpen;
+      toggle.setAttribute('aria-expanded', String(isOpen));
+      if (!isOpen && restoreFocus) toggle.focus();
+    }
+
+    const quickRangeMore = document.querySelector('.quick-range-more');
+    const quickRangeMoreToggle = document.getElementById('quickRangeMoreToggle');
+    const quickRangeMoreMenu = document.getElementById('quickRangeMoreMenu');
+    quickRangeMoreToggle?.addEventListener('click', () => {
+      setQuickRangeMoreOpen(Boolean(quickRangeMoreMenu?.hidden));
+    });
+    document.addEventListener('click', (event) => {
+      if (!quickRangeMoreMenu?.hidden && !quickRangeMore?.contains(event.target)) {
+        setQuickRangeMoreOpen(false);
+      }
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !quickRangeMoreMenu?.hidden) {
+        setQuickRangeMoreOpen(false, true);
+      }
+    });
+
     // Quick range buttons
     document.querySelectorAll('.quick-range-btn').forEach(btn => {
       btn.addEventListener('click', function() {
@@ -5188,6 +5296,7 @@
             rangeKey: range,
           });
         }
+        if (this.closest('#quickRangeMoreMenu')) setQuickRangeMoreOpen(false, true);
       });
     });
 

--- a/tests/test_date_range_control_frontend.py
+++ b/tests/test_date_range_control_frontend.py
@@ -101,11 +101,15 @@ def test_quick_ranges_use_progressive_disclosure_without_horizontal_scroll() -> 
     assert 'data-i18n="moreRanges"' in quick_markup
     assert '"quick quick"' in source
     assert "display: flex;" in source
-    assert "flex-wrap: wrap;" in quick_css
+    assert "flex-wrap: nowrap;" in quick_css
     assert "flex: 0 0 auto;" in source
     assert "overflow: visible;" in quick_css
     assert "overflow-x: auto;" not in quick_css
     assert "white-space: nowrap;" in source
+    assert quick_markup.count("data-quick-primary") == 6
+    assert "function syncQuickRangeLayout()" in source
+    assert "quickRangeMoreMenu.prepend(quickRangePrimaryButtons[index]);" in source
+    assert "new ResizeObserver(scheduleQuickRangeLayout).observe(quickRangePanel);" in source
 
 
 def test_date_range_state_sync_does_not_fetch() -> None:

--- a/tests/test_date_range_control_frontend.py
+++ b/tests/test_date_range_control_frontend.py
@@ -82,21 +82,29 @@ def test_date_range_trigger_markup_and_localization_contract() -> None:
     assert source.count("selectRange: '") == 2
 
 
-def test_quick_ranges_extend_right_without_stretching_buttons() -> None:
+def test_quick_ranges_use_progressive_disclosure_without_horizontal_scroll() -> None:
     source = INDEX_HTML.read_text(encoding="utf-8")
     rail_start = source.index('<div class="topbar-control-rail">')
     quick_start = source.index("<!-- Quick Range Buttons -->")
     actions_start = source.index('<div class="topbar-actions">')
     tabs_start = source.index("<!-- Tabs -->")
+    quick_markup = source[quick_start:actions_start]
+    quick_css_start = source.index("    .quick-range-panel {")
+    quick_css_end = source.index("    .topbar-actions {")
+    quick_css = source[quick_css_start:quick_css_end]
 
     assert rail_start < quick_start < actions_start < tabs_start
-    assert source[quick_start:actions_start].count('class="btn btn-ghost quick-range-btn"') == 10
+    assert quick_markup.count('class="btn btn-ghost quick-range-btn"') == 10
+    assert quick_markup.index('data-range="lastMonth"') < quick_markup.index('id="quickRangeMoreToggle"')
+    assert quick_markup.index('id="quickRangeMoreToggle"') < quick_markup.index('data-range="last14days"')
+    assert 'id="quickRangeMoreMenu"' in quick_markup
+    assert 'data-i18n="moreRanges"' in quick_markup
     assert '"quick quick"' in source
     assert "display: flex;" in source
-    assert "flex-wrap: nowrap;" in source
+    assert "flex-wrap: wrap;" in quick_css
     assert "flex: 0 0 auto;" in source
-    assert "padding: 4px 10px;" in source
-    assert "overflow-x: auto;" in source
+    assert "overflow: visible;" in quick_css
+    assert "overflow-x: auto;" not in quick_css
     assert "white-space: nowrap;" in source
 
 
@@ -112,6 +120,8 @@ def test_date_range_state_sync_does_not_fetch() -> None:
     assert "activeQuickRange || 'customRange'" in sync
     assert "formatDateRangeTriggerText(currentStartDate, currentEndDate)" in sync
     assert "button.setAttribute('aria-pressed', String(isActive));" in sync
+    assert "moreToggle?.setAttribute('aria-pressed', String(isSecondaryActive));" in sync
+    assert "moreLabel.textContent = isSecondaryActive ? t(activeQuickRange) : t('moreRanges');" in sync
     assert "trigger.setAttribute('title', t('selectRange'));" in sync
     assert "fetch(" not in sync
     assert "updateDashboard" not in sync


### PR DESCRIPTION
## Summary

- remove the horizontal scrollbar from the dashboard's quick date ranges
- keep six frequent presets visible and move four lower-frequency presets into a compact More ranges disclosure
- show the selected secondary preset directly on the disclosure button so the active range never becomes hidden
- let the shortcut row wrap naturally at narrow widths
- add click-outside, Escape, focus-return, reduced-motion, and bilingual label support

## Design rationale

Quick ranges are shortcuts to the full date picker, not primary navigation. Giving all ten presets equal permanent space created overflow and visual noise. Progressive disclosure keeps the weekly and monthly reporting shortcuts immediately available while preserving every existing range.

## Behavior and compatibility

- Date calculations, range keys, API requests, and stored preferences are unchanged.
- Last 14 Days, Last 4 Weeks, This Year, and Last Year now require opening More ranges.
- Selecting one of those ranges closes the disclosure, returns keyboard focus, and replaces the More ranges label with the active preset.
- No dependency or backend changes.

## Validation

- TZ=UTC python -m pytest -q: 810 passed, 3 skipped
- focused date-range tests: 8 passed
- Ruff baseline checks and mypy for the modified Python test
- compileall and git diff --check
- hands-on Chrome QA at 110% zoom: default row, expanded disclosure, selected secondary state, and no horizontal scrollbar
