### PR TITLE
Preserve usage cache across upgrades and fix multi-server quota UI

### DIFF
--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Preserved the persistent usage cache across package upgrades when parser and pricing contents are unchanged, while still invalidating cached costs when pricing data or calculation code changes.
+- Hid the unused single-server quota history shells in multi-server mode, removing the duplicate empty charts above per-server quota sections.
 
 ## 1.6.2 - 2026-08-12
 

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Preserved the persistent usage cache across package upgrades when parser and pricing contents are unchanged, while still invalidating cached costs when pricing data or calculation code changes.
+
 ## 1.6.2 - 2026-08-12
 
 ### Added

--- a/src/tokdash/compute.py
+++ b/src/tokdash/compute.py
@@ -20,6 +20,7 @@ from .usage_store import (
     UsageEntryStore,
     build_source_signature,
     parser_code_signature,
+    persistent_pricing_signature,
     persistent_usage_db_enabled,
 )
 
@@ -137,11 +138,11 @@ def _collect_parser_tail(parser: Any, file_sig: tuple[str, int, int], start_offs
 def _sync_usage_store(tracker: CodingToolsUsageTracker) -> tuple[UsageEntryStore, list[str]]:
     store = UsageEntryStore()
     selected = _usage_store_sources(tracker)
+    pricing = persistent_pricing_signature(tracker.pricing_db)
     for name in selected:
         parser = tracker.parsers[name]
         capability = getattr(parser, "sync_capability")
         files = parser._file_signatures()
-        pricing = parser._pricing_signature()
         parser_sig = parser_code_signature(parser)
         if capability.mode == "file_replace":
             store.sync_files(

--- a/src/tokdash/sources/coding_tools.py
+++ b/src/tokdash/sources/coding_tools.py
@@ -272,12 +272,12 @@ class BaseParser(ABC):
         return ()
 
     def _pricing_signature(self) -> tuple:
-        """Signature of the EFFECTIVE pricing DB (packaged baseline + data-dir override).
+        """Runtime signature of the effective pricing DB.
 
         Must cover BOTH files: a dashboard pricing edit writes ONLY the override under
         ``TOKDASH_DATA_DIR`` and never touches the packaged baseline, so statting the
-        baseline alone would never bust ``_entry_cache`` (nor the persistent usage store,
-        which keys on this same signature) and edited rates would silently not apply.
+        baseline alone would never bust ``_entry_cache`` and edited rates would silently
+        not apply.
         ``PricingDatabase.signature()`` stats both files and is itself OSError-safe.
         """
         try:

--- a/src/tokdash/sources/openclaw.py
+++ b/src/tokdash/sources/openclaw.py
@@ -13,6 +13,7 @@ try:
         UsageEntryStore,
         build_source_signature,
         parser_code_signature,
+        persistent_pricing_signature,
         persistent_usage_db_enabled,
     )
 except ImportError:  # pragma: no cover
@@ -21,6 +22,7 @@ except ImportError:  # pragma: no cover
     UsageEntryStore = None  # type: ignore
     build_source_signature = None  # type: ignore
     parser_code_signature = None  # type: ignore
+    persistent_pricing_signature = None  # type: ignore
 
     def persistent_usage_db_enabled() -> bool:  # type: ignore
         return False
@@ -243,9 +245,7 @@ def _collect_entries(session_dirs: list[str]) -> List[Dict[str, Any]]:
 def _pricing_signature(pricing_db: PricingDatabase) -> tuple:
     # Cover BOTH the packaged baseline AND the data-dir override (PricingDatabase.signature()
     # stats both and is OSError-safe). A dashboard pricing edit writes only the override, so
-    # statting the baseline alone would never bust this cache — and because this same
-    # signature gates the persistent SQLite usage store, the stale costs would survive a
-    # process restart until a source log file changed on disk.
+    # statting the baseline alone would never notice the edit.
     try:
         return tuple(pricing_db.signature())
     except (OSError, AttributeError):
@@ -309,7 +309,7 @@ def _sync_openclaw_store(session_dirs: list[str], pricing_db: PricingDatabase) -
     store = UsageEntryStore()
     signature = build_source_signature(  # type: ignore[misc]
         files=sig,
-        pricing=_pricing_signature(pricing_db),
+        pricing=persistent_pricing_signature(pricing_db),
         parser=parser_code_signature(_collect_normalized_entries),  # type: ignore[misc]
     )
     store.sync_source(

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -2494,7 +2494,7 @@
         </div>
         <span id="quotaGlobalStatusLine" class="text-xs" style="color:var(--color-muted)"></span>
       </div>
-      <section class="surface p-5 mb-6">
+      <section id="quotaSingleServerPanel" class="surface p-5 mb-6">
         <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-5">
           <div>
             <h2 class="text-base font-extrabold mono" data-i18n="subscriptionQuota">Subscription Quota</h2>
@@ -2531,7 +2531,7 @@
         </div>
       </section>
 
-      <section class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <section id="quotaSingleServerCharts" class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <div class="surface p-5">
           <div class="flex items-center justify-between mb-3">
             <h3 class="text-base font-extrabold mono" data-i18n="utilizationHistory">Remaining History</h3>
@@ -7457,6 +7457,18 @@
       }
     }
 
+    function setQuotaSingleServerLayout(multi) {
+      ['quotaSingleServerPanel', 'quotaSingleServerCharts'].forEach((id) => {
+        const section = document.getElementById(id);
+        if (!section) return;
+        section.hidden = multi;
+        // Tailwind's author-level display utilities can override the browser's
+        // default [hidden] rule. The inline display keeps these single-server
+        // shells out of multi-server layout while hidden preserves semantics.
+        section.style.display = multi ? 'none' : '';
+      });
+    }
+
     function createQuotaServerBlock(server) {
       const block = document.createElement('section');
       block.className = 'surface p-5';
@@ -7503,8 +7515,7 @@
         if (!rows.length) throw new Error(t('loadFailed'));
         const multi = servers.length > 1;
         positionQuotaGlobalControls(multi);
-        document.querySelector('#quota-content > section.surface')?.toggleAttribute('hidden', multi);
-        document.querySelector('#quota-content > section.grid')?.toggleAttribute('hidden', multi);
+        setQuotaSingleServerLayout(multi);
         const blocks = ensureQuotaServerBlocks();
         blocks.style.display = multi ? 'grid' : 'none';
         if (multi) {

--- a/src/tokdash/usage_store.py
+++ b/src/tokdash/usage_store.py
@@ -382,6 +382,23 @@ def parser_code_signature(obj: Any) -> dict[str, Any]:
         return {"object": obj.__class__.__name__}
 
 
+def persistent_pricing_signature(pricing_db: PricingDatabase) -> dict[str, Any]:
+    """Identify effective pricing data and the code that interprets it.
+
+    Persistent rows contain computed costs, so they must be invalidated when either the
+    pricing content or ``PricingDatabase`` implementation changes. Both components are
+    content-based so reinstall paths and mtimes do not affect the identity.
+    """
+    try:
+        content = tuple(pricing_db.content_signature())
+    except (OSError, AttributeError, ValueError, TypeError):
+        content = ("pricing-content-v1", "missing", 0, "")
+    return {
+        "content": content,
+        "implementation": parser_code_signature(PricingDatabase),
+    }
+
+
 def build_source_signature(*, files: Any, pricing: Any = None, parser: Any = None, extra: Any = None) -> str:
     return stable_json(
         {

--- a/tests/test_multi_server_frontend.py
+++ b/tests/test_multi_server_frontend.py
@@ -151,6 +151,31 @@ def test_multi_server_contract_is_client_only_and_service_worker_is_same_origin(
     assert "selectedServers().length > 1 && lastQuotaServerRows.length" in source
 
 
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_multi_server_quota_hides_single_server_sections(tmp_path):
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    quota_start = source.index('id="quota-content"')
+    quota_end = source.index('id="pricing-content"')
+    assert quota_start < source.index('id="quotaSingleServerPanel"') < quota_end
+    assert quota_start < source.index('id="quotaSingleServerCharts"') < quota_end
+    function = _extract_js_function(source, "function setQuotaSingleServerLayout(multi) {")
+    expression = """(() => {
+      const sections = {
+        quotaSingleServerPanel: { hidden: false, style: { display: '' } },
+        quotaSingleServerCharts: { hidden: false, style: { display: '' } },
+      };
+      global.document = { getElementById: (id) => sections[id] };
+      setQuotaSingleServerLayout(input);
+      return sections;
+    })()"""
+
+    hidden = _run(tmp_path, "quota-multi", [function], expression, True)
+    assert all(section == {"hidden": True, "style": {"display": "none"}} for section in hidden.values())
+
+    shown = _run(tmp_path, "quota-single", [function], expression, False)
+    assert all(section == {"hidden": False, "style": {"display": ""}} for section in shown.values())
+
+
 def test_companion_v2_schema_and_loose_test_rule_are_present():
     root = INDEX_HTML.parents[3]
     windows = (root / "companion/windows/TokdashCompanion/BindableBase.cs").read_text(encoding="utf-8")

--- a/tests/test_pricing_override_cache_busting.py
+++ b/tests/test_pricing_override_cache_busting.py
@@ -1,14 +1,17 @@
-"""Regression: a dashboard pricing edit writes ONLY the data-dir override, so the
-coding-tools and OpenClaw cache-busting signatures must cover the override too.
+"""Regression coverage for runtime and persistent pricing cache identities.
 
-Before the fix these signatures stat'd only the packaged baseline (``pricing_db.db_path``),
-so an edit never changed them — the in-memory entry caches AND the persistent usage store
-(which key on the same signature) kept serving costs computed at the OLD prices.
+Runtime caches use file metadata plus override content so out-of-band edits are noticed
+immediately. Persistent stores use effective pricing content plus the pricing implementation
+so unchanged reinstalls remain fast while real data or cost-calculation changes rebuild rows.
 """
 import json
 import os
+from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import tokdash.api as api
+import tokdash.compute as compute_module
+import tokdash.usage_store as usage_store_module
 from tokdash.onboard import paths
 from tokdash.pricing import PricingDatabase
 from tokdash.sources import openclaw
@@ -19,6 +22,31 @@ def _write_override() -> None:
     ov = paths.pricing_db_override_path()
     ov.parent.mkdir(parents=True, exist_ok=True)
     ov.write_text(json.dumps({"models": {"foo": {"input": 999.0, "output": 999.0}}}), encoding="utf-8")
+
+
+def _installed_pricing_db(root, input_rate: float, mtime: float) -> PricingDatabase:
+    root.mkdir(parents=True, exist_ok=True)
+    baseline = root / "pricing_db.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "models": {
+                    "foo": {
+                        "input": input_rate,
+                        "output": 2.0,
+                        "unit": "per_million_tokens",
+                    }
+                }
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    os.utime(baseline, (mtime, mtime))
+    return PricingDatabase(
+        db_path=baseline,
+        override_path=root / "missing-override.json",
+    )
 
 
 def test_pricing_content_signature_ignores_reinstall_metadata(tmp_path):
@@ -64,6 +92,165 @@ def test_openclaw_pricing_signature_busts_on_override():
     after = openclaw._pricing_signature(pdb)
     assert before != after
     assert after == tuple(pdb.signature())
+
+
+def test_coding_tools_persistent_store_survives_identical_reinstall(monkeypatch, tmp_path):
+    first_db = _installed_pricing_db(tmp_path / "install-v1", 1.0, 1_700_000_000)
+    reinstalled_db = _installed_pricing_db(tmp_path / "install-v2", 1.0, 1_800_000_000)
+    changed_db = _installed_pricing_db(tmp_path / "install-v3", 9.0, 1_900_000_000)
+
+    file_sig = ((str(tmp_path / "usage.jsonl"), 123, 456),)
+    parse_calls: list[str] = []
+
+    def tracker_for(pricing_db: PricingDatabase):
+        parser = ClaudeParser(pricing_db)
+        parser._file_signatures = lambda: file_sig
+
+        def parse_all():
+            parse_calls.append(str(pricing_db.db_path))
+            return [
+                {
+                    "source": "claude",
+                    "model": "foo",
+                    "provider": "anthropic",
+                    "timestamp": 1_700_000_000_000,
+                    "input": 10,
+                    "output": 5,
+                    "cost": 0.0,
+                }
+            ]
+
+        parser._parse_all = parse_all
+        tracker = type("Tracker", (), {})()
+        tracker.pricing_db = pricing_db
+        tracker.parsers = {"claude": parser}
+        return tracker, parser
+
+    first_tracker, first_parser = tracker_for(first_db)
+    reinstalled_tracker, reinstalled_parser = tracker_for(reinstalled_db)
+    changed_tracker, changed_parser = tracker_for(changed_db)
+
+    assert first_parser._pricing_signature() != reinstalled_parser._pricing_signature()
+    assert usage_store_module.persistent_pricing_signature(
+        first_db
+    ) == usage_store_module.persistent_pricing_signature(reinstalled_db)
+    assert usage_store_module.persistent_pricing_signature(
+        first_db
+    ) != usage_store_module.persistent_pricing_signature(changed_db)
+
+    compute_module._sync_usage_store(first_tracker)
+    compute_module._sync_usage_store(reinstalled_tracker)
+    assert len(parse_calls) == 1
+
+    original_code_signature = usage_store_module.parser_code_signature
+
+    def changed_pricing_implementation(obj):
+        signature = original_code_signature(obj)
+        if obj is PricingDatabase:
+            return {**signature, "content_sha1": "changed-pricing-implementation"}
+        return signature
+
+    monkeypatch.setattr(
+        usage_store_module,
+        "parser_code_signature",
+        changed_pricing_implementation,
+    )
+    compute_module._sync_usage_store(reinstalled_tracker)
+    assert len(parse_calls) == 2
+
+    compute_module._sync_usage_store(changed_tracker)
+    assert len(parse_calls) == 3
+
+
+def test_coding_tools_computes_persistent_pricing_signature_once_per_tracker(monkeypatch):
+    sync_calls: list[str] = []
+    pricing_calls: list[object] = []
+
+    class FakeStore:
+        def sync_files(self, source, _files, **_kwargs):
+            sync_calls.append(source)
+
+    pricing_db = object()
+    capability = SimpleNamespace(mode="file_replace", append_jsonl=False)
+    parsers = {
+        name: SimpleNamespace(
+            sync_capability=capability,
+            _file_signatures=lambda: (),
+        )
+        for name in ("claude", "codex", "gemini_cli")
+    }
+    tracker = SimpleNamespace(pricing_db=pricing_db, parsers=parsers)
+
+    monkeypatch.setattr(compute_module, "UsageEntryStore", FakeStore)
+    monkeypatch.setattr(
+        compute_module,
+        "persistent_pricing_signature",
+        lambda value: pricing_calls.append(value) or {"pricing": "signature"},
+    )
+
+    compute_module._sync_usage_store(tracker)
+
+    assert pricing_calls == [pricing_db]
+    assert sync_calls == ["claude", "codex", "gemini_cli"]
+
+
+def test_openclaw_persistent_store_survives_identical_reinstall(monkeypatch, tmp_path):
+    first_db = _installed_pricing_db(tmp_path / "openclaw-v1", 1.0, 1_700_000_000)
+    reinstalled_db = _installed_pricing_db(tmp_path / "openclaw-v2", 1.0, 1_800_000_000)
+    changed_db = _installed_pricing_db(tmp_path / "openclaw-v3", 9.0, 1_900_000_000)
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    (sessions_dir / "session.jsonl").write_text("{}\n", encoding="utf-8")
+    parse_calls: list[str] = []
+
+    def collect_entries(_session_dirs):
+        parse_calls.append("parsed")
+        return [
+            {
+                "msg_dt": datetime(2026, 8, 12, tzinfo=timezone.utc),
+                "model": "foo",
+                "input_raw": 10,
+                "cache_write": 0,
+                "output": 5,
+                "cache_read": 0,
+                "payload_cost": 0.0,
+                "entry_id": "openclaw:test-entry",
+            }
+        ]
+
+    monkeypatch.setattr(openclaw, "_collect_entries", collect_entries)
+
+    assert openclaw._pricing_signature(first_db) != openclaw._pricing_signature(reinstalled_db)
+    assert usage_store_module.persistent_pricing_signature(
+        first_db
+    ) == usage_store_module.persistent_pricing_signature(reinstalled_db)
+    assert usage_store_module.persistent_pricing_signature(
+        first_db
+    ) != usage_store_module.persistent_pricing_signature(changed_db)
+
+    openclaw._sync_openclaw_store([str(sessions_dir)], first_db)
+    openclaw._sync_openclaw_store([str(sessions_dir)], reinstalled_db)
+    assert len(parse_calls) == 1
+
+    original_code_signature = usage_store_module.parser_code_signature
+
+    def changed_pricing_implementation(obj):
+        signature = original_code_signature(obj)
+        if obj is PricingDatabase:
+            return {**signature, "content_sha1": "changed-pricing-implementation"}
+        return signature
+
+    monkeypatch.setattr(
+        usage_store_module,
+        "parser_code_signature",
+        changed_pricing_implementation,
+    )
+    openclaw._sync_openclaw_store([str(sessions_dir)], reinstalled_db)
+    assert len(parse_calls) == 2
+
+    openclaw._sync_openclaw_store([str(sessions_dir)], changed_db)
+    assert len(parse_calls) == 3
 
 
 def test_sessions_singleton_reloads_when_override_changes_out_of_band():


### PR DESCRIPTION
## Summary

- preserve persistent coding-tool and OpenClaw usage rows across package reinstalls when pricing and parser contents are unchanged
- invalidate stored costs when effective pricing data, pricing calculation code, parser code, or source logs change
- compute the shared persistent pricing identity once per coding-tools tracker
- hide the unused single-server quota panels in multi-server mode

## Cache root cause

The persistent store reused a runtime pricing signature containing the installed pricing file path and mtime. A pip or pipx upgrade therefore made unchanged historical files look stale. The persistent identity now combines effective pricing content with the `PricingDatabase` implementation hash, while runtime caches retain metadata-based invalidation for out-of-band edits.

Fixes #19.

## Attribution

Thanks to @674019130 for reporting #19 and proposing the content-based persistent pricing identity in #20. This PR builds on that direction and adds pricing-implementation invalidation, once-per-tracker signature calculation, and the quota UI fix. PR #20 is superseded by this combined change but should remain open until this PR is merged and released.

## Validation

- `PYTHONPATH=src python3 -m pytest -q`: 813 passed, 4 skipped
- focused cache, usage-store, OpenClaw, and quota UI tests: 68 passed
- `python3 -m compileall -q src/tokdash main.py docs/guides/agents/openclaw_reporting/openclaw_cron_job.py`
- `git diff --check`

## Release

Planned for v1.6.3 after merge.