### PR TITLE
Dedup Codex fork replay and fix model attribution

### DIFF
--- a/docs/development/technical-notes/CODEX_USAGE_COUNTING.md
+++ b/docs/development/technical-notes/CODEX_USAGE_COUNTING.md
@@ -1,16 +1,36 @@
 # Codex usage counting: replay de-duplication
 
 How Tokdash avoids double-counting Codex usage when rollout files copy an existing
-thread's history. Observed against Codex CLI **0.144.1** (subagent replay) and
-**0.146.0** (ordinary resumed-thread replay).
+thread's history. Observed against Codex CLI **0.144.1** (subagent replay),
+**0.146.0** (ordinary resumed-thread replay), and **0.147.0** (single-meta fork
+replay).
 
 ## The problem
 
-Codex writes JSONL rollout files under `~/.codex/sessions/YYYY/MM/DD/`. A later
-rollout can replay token events already present in an older file:
+Codex writes JSONL rollout files under `~/.codex/sessions/YYYY/MM/DD/` and moves
+completed rollouts to `~/.codex/archived_sessions/`. Tokdash scans both roots; an
+archived copy that still exists under `sessions/` too collapses via the stable
+event key, so overlap cannot double-count. A later rollout can also replay token
+events already present in an older file:
 
-- A MultiAgent V2 `thread_spawn` file replays its parent thread before recording
-  the subagent's own work.
+- A fork file replays its ancestor thread before recording its own work. Forks are
+  recognized from any ancestry declaration in the first `session_meta`:
+  `source.subagent.thread_spawn.parent_thread_id` (MultiAgent V2), or the
+  top-level `forked_from_id` / `parent_thread_id` fields (user `/fork`, exec
+  forks). Only `thread_spawn` marks a session as non-primary for activity
+  purposes. The bare top-level `session_id` field is deliberately not treated as
+  ancestry: no observed log (0/1009 files) carries ancestry there, and its generic
+  name would risk rekeying ordinary sessions into a shared scope. Note the
+  non-`thread_spawn` fork path is designed-for but not yet observed replaying in
+  real logs — all 274 plain-fork files examined had zero pre-`turn_context`
+  `token_count` rows — so real-data confidence sits with `thread_spawn`. Two
+  replay shapes exist:
+  - **0.144 shape**: the file replays the parent's `session_meta`, so the active
+    session id flips to the parent's — and stays there for the subagent's own
+    turns too (no second child `session_meta` is ever written).
+  - **0.146+ single-meta fork shape**: the file has exactly one `session_meta`
+    carrying the child's own id, and the replayed parent prefix precedes the
+    child's first `turn_context`.
 - An ordinary VS Code/CLI resume can open with a new file id, switch to the older
   logical session id, and replay the full history before recording new work.
 
@@ -41,10 +61,29 @@ The logical session id scopes the key. Identical counters in two independent
 sessions, or on opposite sides of a real session-id/compaction change, remain
 distinct.
 
+For `thread_spawn` files the scoping id is chosen so replayed segments collide
+with the parent's originals:
+
+- events recorded under the parent's id (0.144 shape) are already parent-scoped;
+- events before the child's first `turn_context` in a single-meta fork file are
+  keyed to the declared parent id, because that prefix is the replayed parent
+  history. The child's own turns always follow its first `turn_context` and keep
+  the child scope.
+
+If the parent file was never indexed (archived or deleted), the rekeyed rows
+survive under the parent scope and are counted once — replay handling never
+silently drops usage. The parent scope also means a parent file indexed later
+still collapses the earlier copy.
+
 If either usage snapshot is absent, Tokdash deliberately falls back to the
 file/line identity. That can visibly over-count an old or unrecognized replay,
 but it cannot silently merge two genuine calls that happened to use the same
 number of tokens.
+
+Known limitation: the parent scope is the *immediate* parent. A nested
+`thread_spawn` (a subagent spawning its own subagent) replays the grandparent's
+prefix under the parent scope, which does not collide with the grandparent's
+keys; that segment can still double-count at depth ≥ 2.
 
 ## Parser and store behavior
 
@@ -56,10 +95,42 @@ Both Codex parsers use the same key:
 - `_parse_codex_session_file` stores the key on each internal turn. Codex session
   records with the same logical id are merged, and duplicate turns are removed by
   event key instead of allowing the later file to overwrite the earlier one.
+  Single-meta fork sessions keep their own id and never merge, so after loading,
+  child sessions carrying `_subagent_parent_id` drop the turns whose event key
+  the parent session already owns. Windowed stored reads only load sessions that
+  touch the window, so the parent is additionally looked up in the store
+  unbounded by time — including durable rows kept after the parent file was
+  deleted. The child drops the prefix whenever the parent is indexed anywhere.
+  When the parent is genuinely absent, sibling forks would each retain an
+  identical copy of the prefix, so the earliest sibling keeps it and later
+  siblings drop it: exactly one survivor either way.
 - The API removes the internal key before returning public turn data.
 
-The existing `thread_spawn` parent-id gate remains as an additional fallback for
-subagent files whose older token events lack cumulative snapshots.
+The `thread_spawn` parent-id gate remains as a fallback for subagent rows that
+lack cumulative snapshots (no stable key). Rows with a stable key are never
+hard-skipped: in the 0.144 shape the subagent's own turns also run under the
+parent's session id, and gating them would lose genuine subagent work.
+
+## Model attribution
+
+`turn_context` owns per-turn model attribution. Newer Codex also emits
+`thread_settings_applied` before the first `turn_context`, and issue #23 reported
+builds nesting the selection under `session_meta.base_instructions
+.provenance.model` (unconfirmed — no real log through 0.147.0 carries that key,
+but the lookup is harmless); Tokdash accepts both as early model sources. Rows
+written before a file's first model signal — a fork's replayed parent prefix that
+outlives an unindexed parent, or old formats — are backfilled with the file's own
+first observed model instead of the placeholder default, so surviving replay rows
+are never billed under a model that never ran. Files with no model signal at all
+label their rows explicitly `unknown` (issue #23): token counts are kept, cost is
+$0, and no usage is attributed to a model that never ran.
+
+The placeholder (`CODEX_DEFAULT_MODEL`) is a real, selectable model, so its value
+is never used as the backfill sentinel: rows carry an internal placeholder marker
+from creation until the file's first model signal, and only marked rows are
+backfilled. An explicit mid-file switch to the default model keeps its own
+attribution (real logs contain files whose dominant model is exactly that name;
+a value-equality sentinel mislabeled thousands of their rows).
 
 The persistent usage store has a unique `(source, entry_key)` index. Codex file
 sync resolves a duplicate in favor of the earliest timestamp, regardless of file
@@ -73,12 +144,15 @@ that retain all owned keys stay file-local.
 ## Expected consequences
 
 - Historical Codex totals can decrease after upgrade because copied events and
-  repeated unchanged snapshots are removed.
+  repeated unchanged snapshots are removed; they can also rise slightly where a
+  subagent's own turns were previously skipped together with the replay.
 - Usage returns to the original event date instead of the resume date.
 - A resumed multi-file thread appears as one logical session. Period filters keep
   only genuine turns whose original timestamps fall inside the requested window.
 - Genuine resumed work is retained even when Codex continues writing it under
   the older logical session id.
+- A single-meta fork subagent session shows only its own turns when the parent
+  session is indexed, and the full replayed prefix when it is not.
 
 ## Guardrails and tests
 
@@ -86,11 +160,25 @@ Regression coverage must keep these cases distinct:
 
 - ordinary resumed-thread history with restamped timestamps;
 - genuine new work following the replay;
-- `thread_spawn` parent history and real subagent work;
+- `thread_spawn` parent history and real subagent work, in both the 0.144
+  replayed-`session_meta` shape and the 0.146+ single-meta fork shape;
+- forks declared only via top-level `forked_from_id` / `parent_thread_id` (no
+  `thread_spawn` marker) — same replay dedup, still primary;
+- a mid-file switch into an explicit selection of the placeholder default model
+  (explicit rows keep their attribution; only pre-signal placeholder rows are
+  backfilled);
+- a single-meta fork whose parent was never indexed (replay survives once,
+  backfilled to the file's own model), and sibling orphans of the same parent
+  (exactly one keeps the prefix);
+- a windowed stored read whose window hides the parent session (replay dedup
+  looks the parent up in the store, unbounded, including durable rows whose
+  files were deleted);
 - primary session-id changes/compaction;
 - identical token amounts in different logical sessions;
 - persistent-store append/resync, in-place canonical rewrites, and file removal;
-- partial logs without `total_token_usage` (loud over-count fallback).
+- partial logs without `total_token_usage` (loud over-count fallback);
+- archived-only sessions (files under `archived_sessions/` are scanned) and
+  archived/live overlap (identical copies collapse by event key).
 
 `CodexParser.replay_events_skipped` counts both source-gated replay events and
 stable-key duplicates so format changes remain observable.

--- a/src/tokdash/clientpaths.py
+++ b/src/tokdash/clientpaths.py
@@ -81,6 +81,15 @@ def codex_sessions_dir() -> Path:
     return codex_home() / "sessions"
 
 
+def codex_archived_sessions_dir() -> Path:
+    """Codex moves completed rollouts here (``codex archive`` / auto-archive).
+
+    Files keep their content, so the stable event key collapses any overlap with
+    ``sessions/`` — scanning both roots cannot double-count.
+    """
+    return codex_home() / "archived_sessions"
+
+
 def codex_state_db_path() -> Path:
     return codex_home() / "state_5.sqlite"
 

--- a/src/tokdash/sessions.py
+++ b/src/tokdash/sessions.py
@@ -24,7 +24,13 @@ from .activity_insights import (
 from .compute import cache_hit_rate, pct_change, period_to_days, previous_period_range
 from .dateutil import parse_date_range
 from .pricing import PricingDatabase
-from .sources.coding_tools import KimiParser, codex_token_event_key
+from .sources.coding_tools import (
+    CODEX_DEFAULT_MODEL,
+    KimiParser,
+    codex_fork_ancestry,
+    codex_replay_key_session_id,
+    codex_token_event_key,
+)
 from .sources import dsh_log
 from .sources.dsh_log import (
     decode_dsh_session_file,
@@ -55,7 +61,10 @@ DISPLAY_NAME_MAX_CHARS = 96
 # sessions.py are edited. Bump only the affected version when that parser's
 # stored output changes.
 _SESSION_FILE_PARSER_VERSIONS = {
-    "_parse_codex_session_file": 1,
+    # 2: thread_spawn replay turns are keyed to the parent session (incl. the 0.146+
+    #    single-meta fork shape) and raws carry _subagent_parent_id for cross-session
+    #    replay dedup; stored v1 keys/rows predate both.
+    "_parse_codex_session_file": 2,
     # 2: turns carry _stream_id so subagents are timed separately from the main agent.
     "_parse_claude_session_file": 2,
     # 2: turns carry _stream_id so concurrent agents are timed separately.
@@ -774,6 +783,9 @@ def _merge_raw_session(existing: Dict[str, Any], new: Dict[str, Any]) -> Dict[st
         or "_display_name_explicit" in new
     ):
         merged["_display_name_explicit"] = existing_name_is_explicit or new_name_is_explicit
+    subagent_parent = existing.get("_subagent_parent_id") or new.get("_subagent_parent_id")
+    if subagent_parent:
+        merged["_subagent_parent_id"] = subagent_parent
 
     merged_by_key: dict[tuple[Any, ...], Dict[str, Any]] = {}
     for turn in list(existing.get("turns", [])) + list(new.get("turns", [])):
@@ -793,6 +805,124 @@ def _merge_raw_session(existing: Dict[str, Any], new: Dict[str, Any]) -> Dict[st
     return merged
 
 
+def _drop_codex_subagent_replay_turns(
+    sessions: Dict[str, Dict[str, Any]],
+    external_parent_keys: Optional[Dict[str, set]] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Remove replayed parent-prefix turns from thread_spawn child sessions.
+
+    A single-meta fork file (Codex 0.146+, ``forked_from_id``) keeps its own session
+    id, so it never merges with the parent's session, and its replayed prefix turns
+    — keyed to the parent session id by ``_parse_codex_session_file`` — would count
+    twice across sessions. Drop the child turns whose event key the parent session
+    already owns, and drop the child session entirely if nothing else remains. When
+    the parent was never indexed (archived or deleted), the child keeps the prefix
+    so the usage is counted once instead of lost. Only Codex raws carry the marker.
+
+    ``external_parent_keys`` supplies event keys for parent sessions absent from
+    ``sessions`` — a windowed stored read can exclude every parent file while the
+    child's restamped replay turns fall inside the window (see
+    ``_stored_sessions_for_tool``).
+
+    When the parent is not indexed anywhere, sibling forks of the same parent
+    would each retain an identical parent-scoped copy of the replay prefix. The
+    earliest sibling (by first turn timestamp, then session id) keeps it; later
+    siblings drop turns whose event key an earlier sibling already retained —
+    the same single-survivor rule Overview's global event-key index applies.
+    """
+    keys_by_session = {
+        session_id: {
+            str(turn.get("_event_key"))
+            for turn in session.get("turns", [])
+            if turn.get("_event_key")
+        }
+        for session_id, session in sessions.items()
+    }
+    orphan_children: list[tuple[int, str, Dict[str, Any]]] = []
+    for session_id, session in list(sessions.items()):
+        parent_id = str(session.get("_subagent_parent_id") or "")
+        if not parent_id or parent_id == session_id:
+            continue
+        parent_keys = keys_by_session.get(parent_id)
+        if parent_keys is None and external_parent_keys:
+            parent_keys = external_parent_keys.get(parent_id)
+        if not parent_keys:
+            orphan_children.append((parent_id, session_id, session))
+            continue
+        kept = [
+            turn
+            for turn in session.get("turns", [])
+            if not turn.get("_event_key") or str(turn.get("_event_key")) not in parent_keys
+        ]
+        if kept:
+            session["turns"] = kept
+            keys_by_session[session_id] = {
+                str(turn.get("_event_key")) for turn in kept if turn.get("_event_key")
+            }
+        else:
+            del sessions[session_id]
+            keys_by_session.pop(session_id, None)
+
+    orphans_by_parent: Dict[str, list] = {}
+    for parent_id, session_id, session in orphan_children:
+        orphans_by_parent.setdefault(parent_id, []).append((session_id, session))
+    for siblings in orphans_by_parent.values():
+        if len(siblings) < 2:
+            continue
+        siblings.sort(
+            key=lambda item: (
+                min((int(t.get("timestamp_ms", 0) or 0) for t in item[1].get("turns", [])), default=0),
+                item[0],
+            )
+        )
+        retained_keys: set = set()
+        for session_id, session in siblings:
+            kept = []
+            for turn in session.get("turns", []):
+                event_key = str(turn.get("_event_key") or "")
+                if event_key and event_key in retained_keys:
+                    continue
+                kept.append(turn)
+                if event_key:
+                    retained_keys.add(event_key)
+            if kept:
+                session["turns"] = kept
+            else:
+                del sessions[session_id]
+                keys_by_session.pop(session_id, None)
+    return sessions
+
+
+def _codex_unwindowed_parent_keys(
+    store: "UsageEntryStore", sessions: Dict[str, Dict[str, Any]]
+) -> Dict[str, set]:
+    """Event keys of fork-parent sessions that a windowed read excluded.
+
+    ``query_session_records(whole_sessions=True)`` only loads sessions touching the
+    window. A forked subagent file keeps its own session id while its replayed
+    prefix turns are restamped into the window, so the parent session can be absent
+    from the result while present in the store. Fetch those parents unbounded by
+    time so the replay dedup is window-independent. A parent with no stored rows
+    yields no keys and the child keeps the prefix (counted once, never dropped).
+    """
+    missing = {
+        str(session["_subagent_parent_id"])
+        for session in sessions.values()
+        if session.get("_subagent_parent_id")
+    } - set(sessions)
+    if not missing:
+        return {}
+    parent_keys: Dict[str, set] = {}
+    for record in store.query_session_records_by_ids("codex", missing):
+        session_id = str(record.get("session_id") or "")
+        keys = parent_keys.setdefault(session_id, set())
+        for turn in record.get("turns") or []:
+            event_key = turn.get("_event_key")
+            if event_key:
+                keys.add(str(event_key))
+    return parent_keys
+
+
 def _file_signature(path: Path) -> tuple[str, int, int]:
     stat = path.stat()
     return str(path), int(stat.st_mtime_ns), int(stat.st_size)
@@ -807,6 +937,16 @@ def _iter_file_signatures(root: Path) -> tuple[tuple[str, int, int], ...]:
             items.append(_file_signature(path))
         except FileNotFoundError:
             continue
+    items.sort(key=lambda item: item[0])
+    return tuple(items)
+
+
+def _codex_file_signatures() -> tuple[tuple[str, int, int], ...]:
+    """Signatures from both Codex rollout roots (``sessions/`` and
+    ``archived_sessions/``). Archived files keep their content, so the stable
+    event key collapses any overlap instead of double-counting."""
+    items = list(_iter_file_signatures(clientpaths.codex_sessions_dir()))
+    items.extend(_iter_file_signatures(clientpaths.codex_archived_sessions_dir()))
     items.sort(key=lambda item: item[0])
     return tuple(items)
 
@@ -918,8 +1058,10 @@ def _parse_codex_session_file(path_str: str, _mtime_ns: int, _size: int, _pricin
     own_session_id = None
     subagent_parent_id = None
     is_subagent_file = False
-    current_model = "gpt-5.3-codex"
+    current_model: Optional[str] = None
     current_provider = "openai"
+    first_model_seen: Optional[str] = None
+    first_provider_seen: Optional[str] = None
     cwd = ""
     repo_url = ""
     thread_name = ""
@@ -928,6 +1070,7 @@ def _parse_codex_session_file(path_str: str, _mtime_ns: int, _size: int, _pricin
     turn_index = 0
     seen_event_keys: set[str] = set()
     saw_session_meta = False
+    saw_turn_context = False
     activity = new_activity_record(is_primary=True, has_explicit_session_id=False)
 
     with session_path.open("r", encoding="utf-8") as handle:
@@ -952,14 +1095,11 @@ def _parse_codex_session_file(path_str: str, _mtime_ns: int, _size: int, _pricin
                     activity["is_primary"] = False
                 if not saw_session_meta:
                     saw_session_meta = True
-                    source = payload.get("source")
-                    subagent = source.get("subagent") if isinstance(source, dict) else None
-                    if isinstance(subagent, dict) and isinstance(
-                        subagent.get("thread_spawn"), dict
-                    ):
-                        is_subagent_file = True
-                        pid = (subagent.get("thread_spawn") or {}).get("parent_thread_id")
-                        subagent_parent_id = str(pid) if pid else None
+                    # thread_spawn drives activity classification; any declared
+                    # ancestry (thread_spawn parent, forked_from_id, top-level
+                    # parent_thread_id) drives replay keying.
+                    is_thread_spawn, subagent_parent_id = codex_fork_ancestry(payload)
+                    is_subagent_file = is_thread_spawn
                     activity["is_primary"] = not is_subagent_file and not is_guardian_meta
                 if explicit_meta_id:
                     session_id = explicit_meta_id      # current (last-seen) session id
@@ -969,16 +1109,51 @@ def _parse_codex_session_file(path_str: str, _mtime_ns: int, _size: int, _pricin
                 repo_url = str(((payload.get("git") or {}).get("repository_url")) or repo_url)
                 if payload.get("model_provider"):
                     current_provider = str(payload.get("model_provider"))
+                if not saw_turn_context:
+                    # Issue #23 reported the selected model nested under
+                    # base_instructions.provenance. Unconfirmed: no real log
+                    # through Codex 0.147.0 carries that key, but the lookup is
+                    # harmless and keeps the reporter's case covered.
+                    base = payload.get("base_instructions") if isinstance(payload.get("base_instructions"), dict) else {}
+                    provenance = base.get("provenance") if isinstance(base.get("provenance"), dict) else {}
+                    if provenance.get("model"):
+                        current_model = str(provenance.get("model"))
+                        if first_model_seen is None:
+                            first_model_seen = current_model
+                            first_provider_seen = current_provider
                 continue
 
             if obj_type == "turn_context":
-                current_model = str(payload.get("model") or current_model)
+                saw_turn_context = True
+                if payload.get("model"):
+                    current_model = str(payload.get("model"))
+                    if first_model_seen is None:
+                        first_model_seen = current_model
+                        first_provider_seen = current_provider
                 cwd = str(payload.get("cwd") or cwd)
                 record_reasoning_turn(
                     activity,
                     turn_id=payload.get("turn_id"),
                     effort=payload.get("effort"),
                 )
+                continue
+
+            if (
+                not saw_turn_context
+                and obj_type == "event_msg"
+                and payload_type == "thread_settings_applied"
+            ):
+                # Newer Codex applies the thread settings before the first
+                # turn_context; an authoritative early model source. Once a
+                # turn_context exists it owns per-turn attribution.
+                settings = payload.get("thread_settings") if isinstance(payload.get("thread_settings"), dict) else {}
+                if settings.get("model"):
+                    current_model = str(settings.get("model"))
+                    if settings.get("model_provider_id"):
+                        current_provider = str(settings.get("model_provider_id"))
+                    if first_model_seen is None:
+                        first_model_seen = current_model
+                        first_provider_seen = current_provider
                 continue
 
             if payload_type == "thread_name_updated":
@@ -1012,17 +1187,6 @@ def _parse_codex_session_file(path_str: str, _mtime_ns: int, _size: int, _pricin
             if obj_type != "event_msg" or payload.get("type") != "token_count":
                 continue
 
-            # Source-shape fallback for thread_spawn replays whose older events lack
-            # cumulative state. Stable identity below handles ordinary resume copies.
-            if is_subagent_file and own_session_id is not None:
-                is_replay = (
-                    session_id == subagent_parent_id
-                    if subagent_parent_id is not None
-                    else session_id != own_session_id
-                )
-                if is_replay:
-                    continue
-
             timestamp_ms = _parse_iso_to_ms(obj.get("timestamp"))
             if timestamp_ms is None:
                 continue
@@ -1032,7 +1196,21 @@ def _parse_codex_session_file(path_str: str, _mtime_ns: int, _size: int, _pricin
             if not usage:
                 continue
 
-            event_key = codex_token_event_key(session_id, info)
+            # Key fork replay segments to the parent session so the stable
+            # event key collapses them against the parent file (shared with
+            # CodexParser._parse_all; see CODEX_USAGE_COUNTING.md). The source-shape
+            # skip fires only for rows without the cumulative state a key needs.
+            key_session_id, replay_fallback = codex_replay_key_session_id(
+                is_subagent_file or subagent_parent_id is not None,
+                own_session_id,
+                session_id,
+                subagent_parent_id,
+                saw_turn_context,
+            )
+
+            event_key = codex_token_event_key(key_session_id, info)
+            if replay_fallback and event_key is None:
+                continue
             if event_key and event_key in seen_event_keys:
                 continue
             if event_key:
@@ -1047,12 +1225,13 @@ def _parse_codex_session_file(path_str: str, _mtime_ns: int, _size: int, _pricin
             if total_tokens == 0:
                 continue
 
-            full_model_name = f"{current_provider}/{current_model}" if current_provider else current_model
+            turn_model = current_model or CODEX_DEFAULT_MODEL
+            full_model_name = f"{current_provider}/{turn_model}" if current_provider else turn_model
             turn_index += 1
             turn = _build_turn(
                 turn_index=turn_index,
                 timestamp_ms=timestamp_ms,
-                model=current_model,
+                model=turn_model,
                 tokens_in=input_tokens,
                 tokens_cache=cache_read,
                 tokens_out=output_tokens,
@@ -1067,6 +1246,10 @@ def _parse_codex_session_file(path_str: str, _mtime_ns: int, _size: int, _pricin
                     cache_read=cache_read,
                 ),
             )
+            if current_model is None:
+                # Placeholder, not an explicit gpt-5.3-codex selection — only
+                # these rows may be backfilled to the file's first real model.
+                turn["_model_placeholder"] = True
             if event_key:
                 turn["_event_key"] = event_key
             turns.append(turn)
@@ -1074,8 +1257,38 @@ def _parse_codex_session_file(path_str: str, _mtime_ns: int, _size: int, _pricin
     if not turns and not activity["is_primary"]:
         return None
 
+    if first_model_seen:
+        # Turns written before the file's first model signal (a fork's replayed
+        # parent prefix that outlives an unindexed parent, or old formats) would
+        # otherwise bill under the placeholder default. Only flagged placeholder
+        # turns move: an explicit CODEX_DEFAULT_MODEL selection is real data and
+        # must survive even when the file switches models mid-stream.
+        qualified = (
+            f"{first_provider_seen}/{first_model_seen}" if first_provider_seen else first_model_seen
+        )
+        for turn in turns:
+            if not turn.pop("_model_placeholder", False):
+                continue
+            turn["model"] = first_model_seen
+            bill = turn.get("_bill")
+            if isinstance(bill, dict):
+                bill["model"] = qualified
+                turn["cost"] = _turn_cost(bill)
+    else:
+        # No model signal anywhere in the file: label the turns explicitly
+        # unknown (issue #23) instead of billing them under a default model that
+        # never ran. Unknown models keep token counts but price to $0.
+        for turn in turns:
+            if not turn.pop("_model_placeholder", False):
+                continue
+            turn["model"] = "unknown"
+            bill = turn.get("_bill")
+            if isinstance(bill, dict):
+                bill["model"] = "unknown"
+                turn["cost"] = _turn_cost(bill)
+
     project = _project_from_repo_or_path(repo_url or None, cwd or None)
-    return {
+    raw = {
         "tool": "codex",
         "session_id": session_id,
         "display_name": thread_name or _fallback_display_name(session_id, project),
@@ -1085,6 +1298,13 @@ def _parse_codex_session_file(path_str: str, _mtime_ns: int, _size: int, _pricin
         "turns": turns,
         "_activity": activity,
     }
+    if subagent_parent_id:
+        # Lets the cross-session merge drop this file's replayed parent-prefix
+        # turns when the parent session is present (fork files never merge with
+        # the parent on their own). Set for any declared ancestry, not only
+        # thread_spawn.
+        raw["_subagent_parent_id"] = subagent_parent_id
+    return raw
 
 
 @lru_cache(maxsize=8)
@@ -1099,12 +1319,11 @@ def _load_codex_sessions(signature: tuple[tuple[str, int, int], ...], pricing_si
                 sessions[session_id] = _merge_raw_session(sessions[session_id], raw)
             else:
                 sessions[session_id] = raw
-    return sessions
+    return _drop_codex_subagent_replay_turns(sessions)
 
 
 def _codex_sessions() -> Dict[str, Dict[str, Any]]:
-    root = clientpaths.codex_sessions_dir()
-    return _apply_codex_title_map(_load_codex_sessions(_iter_file_signatures(root), _pricing_signature()))
+    return _apply_codex_title_map(_load_codex_sessions(_codex_file_signatures(), _pricing_signature()))
 
 
 @lru_cache(maxsize=8)
@@ -1139,7 +1358,7 @@ def _codex_session_parser_signature() -> dict[str, Any]:
 
 
 def get_codex_activity_insights() -> dict[str, Any]:
-    signatures = _iter_file_signatures(clientpaths.codex_sessions_dir())
+    signatures = _codex_file_signatures()
     pricing_sig = _pricing_signature()
     if not persistent_usage_db_enabled():
         return build_activity_insights(
@@ -2678,6 +2897,9 @@ def _session_records_to_raw_sessions(tool: str, records: Iterable[Dict[str, Any]
         else:
             sessions[session_id] = raw
 
+    if tool == "codex":
+        # Codex-only pass; skip the keys_by_session build for every other tool.
+        sessions = _drop_codex_subagent_replay_turns(sessions)
     for session in sessions.values():
         session.setdefault("display_name", _fallback_display_name(session.get("session_id"), session.get("project")))
         session["is_review_session"] = bool(session.get("is_review_session", False))
@@ -2692,8 +2914,7 @@ def _stored_sessions_for_tool(
 ) -> Dict[str, Dict[str, Any]]:
     store = UsageEntryStore()
     if tool == "codex":
-        root = clientpaths.codex_sessions_dir()
-        signatures = _iter_file_signatures(root)
+        signatures = _codex_file_signatures()
         pricing_sig = _pricing_signature()
         store.sync_session_files(
             "codex",
@@ -2753,6 +2974,10 @@ def _stored_sessions_for_tool(
         ),
     )
     if tool == "codex":
+        sessions = _drop_codex_subagent_replay_turns(
+            sessions,
+            external_parent_keys=_codex_unwindowed_parent_keys(store, sessions),
+        )
         return _apply_codex_title_map(sessions)
     if tool == "kimi":
         # Applied on read, not baked into the rows: workspaces.json changes

--- a/src/tokdash/sources/coding_tools.py
+++ b/src/tokdash/sources/coding_tools.py
@@ -150,6 +150,83 @@ def codex_token_event_key(session_id: Any, info: Any) -> Optional[str]:
     return f"codex-token-v1:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
 
 
+# Placeholder resolved for rows written before a file's first model signal (a
+# fork's replayed parent prefix, or old formats without turn_context). Rows
+# carry a ``_model_placeholder`` marker until then so backfill can tell "no
+# signal yet" apart from an explicit user selection of this same model — the
+# name is real, so the value alone must never be the sentinel.
+CODEX_DEFAULT_MODEL = "gpt-5.3-codex"
+
+
+def codex_replay_key_session_id(
+    is_fork_file: bool,
+    own_session_id: Any,
+    current_session_id: Any,
+    subagent_parent_id: Any,
+    saw_turn_context: bool,
+) -> Tuple[Any, bool]:
+    """Return ``(key scope, replay_fallback)`` for a Codex token_count event.
+
+    Fork files (``thread_spawn`` subagents, user ``/fork``, exec forks — any file
+    whose first ``session_meta`` declares an ancestor) replay the parent thread's
+    history before their own work. Keying the replay to the parent session
+    collapses it against the parent file via the stable event key:
+
+    - Codex 0.144 shape: the file replays the parent's ``session_meta``, so the
+      current session id IS the parent's and the key is already parent-scoped.
+    - Codex 0.146+ single-meta fork shape (``forked_from_id``): one session_meta
+      carrying the child's own id; the replayed parent prefix precedes the
+      child's first ``turn_context``.
+
+    ``replay_fallback`` marks rows that may be source-gated, but only when they
+    lack the cumulative state a stable key needs (old/partial logs); anything
+    unrecognized degrades toward visible over-counting, not silent loss.
+    Shared by both Codex parsers so Overview and Sessions cannot drift apart.
+    See CODEX_USAGE_COUNTING.md.
+    """
+    if not is_fork_file or own_session_id is None or current_session_id is None:
+        return current_session_id, False
+    if subagent_parent_id is not None:
+        if current_session_id == subagent_parent_id:
+            return current_session_id, True
+        if current_session_id == own_session_id and not saw_turn_context:
+            return subagent_parent_id, False
+    elif current_session_id != own_session_id:
+        return current_session_id, True
+    return current_session_id, False
+
+
+def codex_fork_ancestry(payload: Any) -> Tuple[bool, Optional[str]]:
+    """Return ``(is_thread_spawn, declared_parent_id)`` from a session_meta payload.
+
+    Codex has declared fork ancestry three ways: ``source.subagent.thread_spawn
+    .parent_thread_id`` (MultiAgent V2) and the top-level ``forked_from_id`` /
+    ``parent_thread_id`` fields (user ``/fork``, exec forks, and single-meta
+    spawn files). Any of them marks the file as a history-replaying fork;
+    ``thread_spawn`` additionally distinguishes subagent sessions for activity
+    classification. A self-reference is not ancestry. The bare ``session_id``
+    top-level field is deliberately NOT accepted: it has never carried ancestry
+    in any observed log (0/1009 files) and its generic name risks treating
+    ordinary sessions as forks, which would rekey real rows into a shared scope.
+    """
+    p = payload if isinstance(payload, dict) else {}
+    own_id = str(p.get("id") or "")
+    source = p.get("source") if isinstance(p.get("source"), dict) else {}
+    subagent = source.get("subagent") if isinstance(source.get("subagent"), dict) else None
+    thread_spawn = subagent.get("thread_spawn") if isinstance(subagent, dict) else None
+    is_thread_spawn = isinstance(thread_spawn, dict)
+    pid = None
+    if is_thread_spawn:
+        pid = (thread_spawn or {}).get("parent_thread_id")
+    if not pid:
+        for field in ("forked_from_id", "parent_thread_id"):
+            candidate = p.get(field)
+            if candidate and str(candidate) != own_id:
+                pid = candidate
+                break
+    return is_thread_spawn, (str(pid) if pid else None)
+
+
 def _sqlite_table_exists(conn: sqlite3.Connection, table: str) -> bool:
     try:
         cur = conn.cursor()
@@ -477,6 +554,7 @@ class CodexParser(BaseParser):
     def __init__(self, pricing_db: PricingDatabase):
         super().__init__(pricing_db)
         self.sessions_dir = clientpaths.codex_sessions_dir()
+        self.archived_sessions_dir = clientpaths.codex_archived_sessions_dir()
         self.replay_events_skipped = 0
 
     @staticmethod
@@ -491,7 +569,14 @@ class CodexParser(BaseParser):
         return fallback
 
     def _file_signatures(self) -> tuple:
-        return _timed_sigs(f"codex:{self.sessions_dir}", lambda: _rglob_sigs(self.sessions_dir))
+        # Both roots: archived rollouts keep their content, so stable event keys
+        # collapse any overlap with sessions/ instead of double-counting.
+        def _scan() -> tuple:
+            sigs = list(_rglob_sigs(self.sessions_dir)) + list(_rglob_sigs(self.archived_sessions_dir))
+            sigs.sort()
+            return tuple(sigs)
+
+        return _timed_sigs(f"codex:{self.sessions_dir}:{self.archived_sessions_dir}", _scan)
 
     def _parse_all(self) -> List[Dict[str, Any]]:
         out: List[Dict[str, Any]] = []
@@ -501,12 +586,21 @@ class CodexParser(BaseParser):
         for path_str, _, _ in self._file_signatures():
             session_file = Path(path_str)
             try:
-                model = "gpt-5.3-codex"
+                model: Optional[str] = None
                 provider = "openai"
                 own_session_id = None
                 current_session_id = None
                 subagent_parent_id = None
-                is_subagent_file = False
+                is_fork_file = False
+                saw_turn_context = False
+                first_model_seen: Optional[str] = None
+                first_provider_seen: Optional[str] = None
+                # Indices this file inserted OR replaced. A duplicate with an
+                # earlier timestamp can replace an entry owned by a previously
+                # parsed file (index < len(out) at file start), so a slice from
+                # the file's first append would miss it — its placeholder marker
+                # must still be resolved by THIS file's model signal.
+                file_entry_indices: set[int] = set()
 
                 for line_no, line in enumerate(session_file.read_text(encoding="utf-8").splitlines(), start=1):
                     try:
@@ -515,46 +609,64 @@ class CodexParser(BaseParser):
                         continue
 
                     p = msg.get("payload") or {}
-                    if msg.get("type") == "turn_context" and p.get("model"):
-                        model = str(p.get("model"))
-                        provider = self._infer_provider(model, provider)
+                    if msg.get("type") == "turn_context":
+                        saw_turn_context = True
+                        if p.get("model"):
+                            model = str(p.get("model"))
+                            provider = self._infer_provider(model, provider)
+                            if first_model_seen is None:
+                                first_model_seen = model
+                                first_provider_seen = provider
+                    elif (
+                        not saw_turn_context
+                        and msg.get("type") == "event_msg"
+                        and p.get("type") == "thread_settings_applied"
+                    ):
+                        # Newer Codex applies the thread settings before the first
+                        # turn_context; an authoritative early model source. Once a
+                        # turn_context exists it owns per-turn attribution.
+                        settings = p.get("thread_settings") if isinstance(p.get("thread_settings"), dict) else {}
+                        if settings.get("model"):
+                            model = str(settings.get("model"))
+                            provider = self._infer_provider(model, provider)
+                            if settings.get("model_provider_id"):
+                                provider = str(settings.get("model_provider_id"))
+                            if first_model_seen is None:
+                                first_model_seen = model
+                                first_provider_seen = provider
                     elif msg.get("type") == "session_meta":
                         sid = p.get("id")
                         if sid:
                             sid = str(sid)
                             if own_session_id is None:
                                 own_session_id = sid
-                                # First session_meta identifies the file. A thread_spawn subagent file
-                                # replays ancestor history; capture the declared parent so we skip only
-                                # those replays (never the subagent's own or a stray id).
-                                source = p.get("source")
-                                subagent = source.get("subagent") if isinstance(source, dict) else None
-                                if isinstance(subagent, dict) and isinstance(subagent.get("thread_spawn"), dict):
-                                    is_subagent_file = True
-                                    pid = (subagent.get("thread_spawn") or {}).get("parent_thread_id")
-                                    subagent_parent_id = str(pid) if pid else None
+                                # First session_meta identifies the file. A fork file
+                                # (thread_spawn subagent, user /fork, exec fork)
+                                # replays ancestor history; capture the declared parent
+                                # from any ancestry field so we skip only those replays
+                                # (never the fork's own or a stray id).
+                                _is_thread_spawn, subagent_parent_id = codex_fork_ancestry(p)
+                                is_fork_file = _is_thread_spawn or subagent_parent_id is not None
                             current_session_id = sid
                         if p.get("model_provider"):
                             provider = str(p.get("model_provider"))
+                        if not saw_turn_context:
+                            # Issue #23 reported the selected model nested under
+                            # base_instructions.provenance. Unconfirmed: no real
+                            # log through Codex 0.147.0 carries that key, but the
+                            # lookup is harmless and keeps the reporter's case
+                            # covered if a future build adds it.
+                            base = p.get("base_instructions") if isinstance(p.get("base_instructions"), dict) else {}
+                            provenance = base.get("provenance") if isinstance(base.get("provenance"), dict) else {}
+                            if provenance.get("model"):
+                                model = str(provenance.get("model"))
+                                provider = self._infer_provider(model, provider)
+                                if first_model_seen is None:
+                                    first_model_seen = model
+                                    first_provider_seen = provider
 
                     if msg.get("type") != "event_msg" or p.get("type") != "token_count":
                         continue
-
-                    # Keep the Codex 0.144 thread_spawn source-shape gate as a fallback
-                    # for old/partial rows that lack the cumulative state needed by the
-                    # stable key below. Ordinary primary/guardian files are never source-
-                    # gated; their exact copies are handled by stable identity instead.
-                    # Any unrecognized partial format therefore degrades toward visible
-                    # over-counting, not silent loss. See CODEX_USAGE_COUNTING.md.
-                    if is_subagent_file and own_session_id is not None and current_session_id is not None:
-                        is_replay = (
-                            current_session_id == subagent_parent_id
-                            if subagent_parent_id is not None
-                            else current_session_id != own_session_id
-                        )
-                        if is_replay:
-                            self.replay_events_skipped += 1
-                            continue
 
                     ts_raw = msg.get("timestamp")
                     if not ts_raw:
@@ -571,7 +683,18 @@ class CodexParser(BaseParser):
                     if not usage:
                         continue
 
-                    event_key = codex_token_event_key(current_session_id, info)
+                    key_session_id, replay_fallback = codex_replay_key_session_id(
+                        is_fork_file,
+                        own_session_id,
+                        current_session_id,
+                        subagent_parent_id,
+                        saw_turn_context,
+                    )
+
+                    event_key = codex_token_event_key(key_session_id, info)
+                    if replay_fallback and event_key is None:
+                        self.replay_events_skipped += 1
+                        continue
 
                     # In Codex: input_tokens INCLUDES cached tokens
                     # So fresh_input = input_tokens - cached_input_tokens
@@ -584,28 +707,63 @@ class CodexParser(BaseParser):
                     if input_t == 0 and output_t == 0 and cache_read == 0 and reasoning == 0:
                         continue
 
+                    entry_model = model or CODEX_DEFAULT_MODEL
                     entry = {
                         "source": self.source_name,
-                        "model": model,
+                        "model": entry_model,
                         "provider": provider,
                         "input": input_t,
                         "output": output_t,
                         "cacheRead": cache_read,
                         "cacheWrite": 0,
                         "reasoning": reasoning,
-                        "cost": self.pricing_db.get_cost(model, input_t, output_t, cache_read, 0),
+                        "cost": self.pricing_db.get_cost(entry_model, input_t, output_t, cache_read, 0),
                         "timestamp": int(ts.timestamp() * 1000),
                         "entry_id": event_key or f"{session_file}:{line_no}",
                     }
+                    if model is None:
+                        entry["_model_placeholder"] = True
                     if event_key and event_key in event_index_by_key:
                         self.replay_events_skipped += 1
                         existing_index = event_index_by_key[event_key]
                         if entry["timestamp"] < out[existing_index]["timestamp"]:
                             out[existing_index] = entry
+                            # The replacement may sit before this file's first
+                            # append; the file now owns that slot's marker too.
+                            file_entry_indices.add(existing_index)
                         continue
                     if event_key:
                         event_index_by_key[event_key] = len(out)
+                    file_entry_indices.add(len(out))
                     out.append(entry)
+
+                if first_model_seen:
+                    # Rows written before the file's first model signal (a fork's
+                    # replayed parent prefix that outlives an unindexed parent, or
+                    # old formats) would otherwise bill under the placeholder
+                    # default. The file's own first model is the closest truthful
+                    # attribution. Only placeholder rows move: an explicit
+                    # selection of CODEX_DEFAULT_MODEL is real data, not a signal
+                    # gap, and must survive even when the model changes mid-file.
+                    for index in file_entry_indices:
+                        entry = out[index]
+                        if not entry.pop("_model_placeholder", False):
+                            continue
+                        entry["model"] = first_model_seen
+                        entry["provider"] = first_provider_seen or entry["provider"]
+                        entry["cost"] = self.pricing_db.get_cost(
+                            first_model_seen, entry["input"], entry["output"], entry["cacheRead"], 0
+                        )
+                else:
+                    # No model signal anywhere in the file: label the rows
+                    # explicitly unknown (issue #23) instead of billing them
+                    # under a default model that never ran. Unknown models carry
+                    # token counts but price to $0.
+                    for index in file_entry_indices:
+                        entry = out[index]
+                        if entry.pop("_model_placeholder", False):
+                            entry["model"] = "unknown"
+                            entry["cost"] = 0.0
             except Exception:
                 continue
 

--- a/src/tokdash/usage_store.py
+++ b/src/tokdash/usage_store.py
@@ -1604,6 +1604,46 @@ class UsageEntryStore:
                 out.append(obj)
         return out
 
+    def query_session_records_by_ids(
+        self,
+        tool: str,
+        session_ids: Iterable[str],
+    ) -> list[dict[str, Any]]:
+        """Return stored session records for specific session ids, unbounded by time.
+
+        Windowed reads (``query_session_records``) only return sessions touching
+        the window; cross-session checks like the Codex thread_spawn replay dedup
+        need the parent session even when every one of its files is older than the
+        requested window.
+        """
+        ids = sorted({str(session_id) for session_id in session_ids if session_id})
+        if not ids:
+            return []
+        out: list[dict[str, Any]] = []
+        with closing(self._connect()) as conn:
+            for start in range(0, len(ids), 500):
+                batch = ids[start : start + 500]
+                placeholders = ",".join("?" for _ in batch)
+                # No missing filter: durable rows kept after their file disappeared
+                # still prove the session was indexed, and their event keys remain
+                # valid for cross-session replay dedup.
+                rows = conn.execute(
+                    f"""
+                    SELECT raw_json FROM session_records
+                    WHERE tool = ? AND session_id IN ({placeholders})
+                    ORDER BY file_path ASC, session_id ASC
+                    """,
+                    [tool, *batch],
+                ).fetchall()
+                for row in rows:
+                    try:
+                        obj = json.loads(row["raw_json"])
+                    except Exception:
+                        continue
+                    if isinstance(obj, dict):
+                        out.append(obj)
+        return out
+
     def query_session_activity_records(self, tool: str) -> list[dict[str, Any]]:
         with closing(self._connect()) as conn:
             rows = conn.execute(

--- a/tests/test_activity_insights.py
+++ b/tests/test_activity_insights.py
@@ -571,6 +571,10 @@ def test_codex_activity_warm_persistent_load_does_not_reparse(
     monkeypatch.setattr(
         sessions_module.clientpaths, "codex_sessions_dir", lambda: session_root
     )
+    monkeypatch.setattr(
+        sessions_module.clientpaths, "codex_archived_sessions_dir",
+        lambda: tmp_path / "archived_sessions",
+    )
     _clear_codex_activity_caches()
     calls = _install_counting_codex_parser(monkeypatch)
 
@@ -598,6 +602,10 @@ def test_codex_activity_warm_store_disabled_load_does_not_reparse(
     monkeypatch.setenv("TOKDASH_USAGE_DB_PATH", str(db_path))
     monkeypatch.setattr(
         sessions_module.clientpaths, "codex_sessions_dir", lambda: session_root
+    )
+    monkeypatch.setattr(
+        sessions_module.clientpaths, "codex_archived_sessions_dir",
+        lambda: tmp_path / "archived_sessions",
     )
     _clear_codex_activity_caches()
     calls = _install_counting_codex_parser(monkeypatch)

--- a/tests/test_clientpaths_windows.py
+++ b/tests/test_clientpaths_windows.py
@@ -54,6 +54,7 @@ def test_quota_client_roots_honor_environment_overrides(monkeypatch):
 
     assert clientpaths.codex_home() == Path("/tmp/codex-home")
     assert clientpaths.codex_sessions_dir() == Path("/tmp/codex-home") / "sessions"
+    assert clientpaths.codex_archived_sessions_dir() == Path("/tmp/codex-home") / "archived_sessions"
     assert clientpaths.claude_config_dir() == Path("/tmp/claude-config")
     assert clientpaths.antigravity_cli_dir() == Path.home() / ".gemini" / "antigravity-cli"
     assert clientpaths.antigravity_conversations_dir() == Path.home() / ".gemini" / "antigravity-cli" / "conversations"

--- a/tests/test_kimi_sessions.py
+++ b/tests/test_kimi_sessions.py
@@ -430,7 +430,7 @@ def test_store_rows_are_rebuilt_when_the_parser_version_changes(monkeypatch, _is
 
 
 def test_kimi_parser_signature_has_no_v159_compat_token():
-    """Only the two original parsers carry the frozen v1.5.9 token."""
+    """Only original parsers still at version 1 carry the frozen v1.5.9 token."""
     signature = sessions._session_file_parser_signature("_parse_kimi_session_file")
     assert signature == {
         "object": f"{sessions.__name__}._parse_kimi_session_file",
@@ -438,10 +438,13 @@ def test_kimi_parser_signature_has_no_v159_compat_token():
         "version": sessions._SESSION_FILE_PARSER_VERSIONS["_parse_kimi_session_file"],
     }
     assert "content_sha1" not in signature
-    assert (
-        sessions._session_file_parser_signature("_parse_codex_session_file")["content_sha1"]
-        == sessions._SESSION_FILE_PARSER_V1_COMPAT_TOKEN
-    )
+    # The frozen v1.5.9 token applies only to original parsers still at version 1.
+    # Codex (v2: thread_spawn replay rekeying) and Claude (v2: _stream_id) have both
+    # left that path, so every current parser emits a plain version token.
+    for name, version in sessions._SESSION_FILE_PARSER_VERSIONS.items():
+        sig = sessions._session_file_parser_signature(name)
+        if version > 1:
+            assert "content_sha1" not in sig
 
 
 def test_workspace_project_correction_survives_a_cached_read(_isolated_kimi_roots):

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -871,8 +871,6 @@ def test_parser_code_signature_unwraps_lru_cache_functions():
 
 
 def test_session_file_parser_signatures_are_explicit_and_v159_compatible(monkeypatch):
-    expected_token = "422eaad7926b4c5362a3c6d7cbcad86dc8244cb8"
-
     codex = sessions_module._session_file_parser_signature(
         "_parse_codex_session_file"
     )
@@ -880,13 +878,15 @@ def test_session_file_parser_signatures_are_explicit_and_v159_compatible(monkeyp
         "_parse_claude_session_file"
     )
 
-    # Codex still emits the frozen v1.5.9 token, so rows written by that version
-    # remain reusable. Claude left the compat path at version 2, when its turns
-    # started carrying _stream_id — its old rows must be reparsed, not reused.
+    # Both original parsers have left the frozen v1.5.9 compat token behind:
+    # Claude at version 2 (turns carry _stream_id), Codex at version 2 (thread_spawn
+    # replay turns are keyed to the parent session and raws carry
+    # _subagent_parent_id). Their old rows must be reparsed, not reused.
     assert codex == {
         "object": "tokdash.sessions._parse_codex_session_file",
-        "content_sha1": expected_token,
+        "version": sessions_module._SESSION_FILE_PARSER_VERSIONS["_parse_codex_session_file"],
     }
+    assert codex["version"] > 1
     assert claude == {
         "object": "tokdash.sessions._parse_claude_session_file",
         "version": sessions_module._SESSION_FILE_PARSER_VERSIONS["_parse_claude_session_file"],
@@ -1530,6 +1530,820 @@ def test_codex_subagent_thread_spawn_replay_is_skipped(monkeypatch, tmp_path):
     )
     assert same_id_raw is not None
     assert len(same_id_raw["turns"]) == 2
+
+
+def _codex_fork_usage_rows():
+    """Cumulative usage snapshots for a parent thread and a forked subagent that
+    continues the same counters after the fork point."""
+    usage_1 = dict(last_input=100, last_cache=10, last_output=20, last_reasoning=5,
+                   total_input=100, total_cache=10, total_output=20, total_reasoning=5)
+    usage_2 = dict(last_input=110, last_cache=11, last_output=21, last_reasoning=6,
+                   total_input=210, total_cache=21, total_output=41, total_reasoning=11)
+    usage_3 = dict(last_input=120, last_cache=12, last_output=22, last_reasoning=7,
+                   total_input=330, total_cache=33, total_output=63, total_reasoning=18)
+    own_1 = dict(last_input=130, last_cache=13, last_output=23, last_reasoning=8,
+                 total_input=460, total_cache=46, total_output=86, total_reasoning=26)
+    own_2 = dict(last_input=140, last_cache=14, last_output=24, last_reasoning=9,
+                 total_input=600, total_cache=60, total_output=110, total_reasoning=35)
+    return usage_1, usage_2, usage_3, own_1, own_2
+
+
+def test_codex_subagent_single_meta_fork_replay_is_deduplicated(monkeypatch, tmp_path):
+    """Codex 0.146+ writes thread_spawn fork files with ONE session_meta (the child's
+    own id, parent declared via thread_spawn/forked_from_id) and replays the parent's
+    token_count prefix BEFORE the child's first turn_context. The parent-id gate never
+    fires (current id never flips) and the session-scoped stable key hashes the copies
+    under the child id, so both dedup mechanisms miss them. The replayed prefix must be
+    keyed to the parent session so it collapses against the parent file."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _clear_parser_caches()
+
+    parent_id = "019f8024-8014-7202-aa03-9f039f67a648"
+    child_id = "019f80ad-f48c-7361-a358-532ff84dcba9"
+    codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "07" / "20"
+    usage_1, usage_2, usage_3, own_1, own_2 = _codex_fork_usage_rows()
+
+    parent_rows = [
+        {
+            "timestamp": "2026-07-20T16:28:24.000Z",
+            "type": "session_meta",
+            "payload": {"id": parent_id, "cwd": "/work/tokdash", "source": "vscode", "model_provider": "openai"},
+        },
+        {
+            "timestamp": "2026-07-20T16:28:25.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.6-sol", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total("2026-07-20T16:30:10.000Z", **usage_1),
+        _codex_token_count_row_with_total("2026-07-20T16:31:10.000Z", **usage_2),
+        _codex_token_count_row_with_total("2026-07-20T16:32:10.000Z", **usage_3),
+    ]
+    child_rows = [
+        {
+            "timestamp": "2026-07-20T18:58:31.000Z",
+            "type": "session_meta",
+            "payload": {
+                "id": child_id,
+                "cwd": "/work/tokdash",
+                "forked_from_id": parent_id,
+                "source": {
+                    "subagent": {
+                        "thread_spawn": {
+                            "parent_thread_id": parent_id,
+                            "depth": 1,
+                            "agent_path": "/root/fix-bug",
+                            "agent_nickname": "worker",
+                            "agent_role": None,
+                        }
+                    }
+                },
+                "model_provider": "openai",
+            },
+        },
+        # Replayed parent prefix: restamped copies under the child's own session id,
+        # before any turn_context.
+        _codex_token_count_row_with_total("2026-07-20T18:58:32.000Z", **usage_1),
+        _codex_token_count_row_with_total("2026-07-20T18:58:32.001Z", **usage_2),
+        _codex_token_count_row_with_total("2026-07-20T18:58:32.002Z", **usage_3),
+        # The child's first turn_context ends the replay prefix.
+        {
+            "timestamp": "2026-07-20T18:58:33.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.6-sol", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total("2026-07-20T19:00:10.000Z", **own_1),
+        _codex_token_count_row_with_total("2026-07-20T19:01:10.000Z", **own_2),
+    ]
+
+    # Child sorts first: the parent file must still win each shared key on timestamp.
+    child_path = codex_dir / "rollout-1-child.jsonl"
+    parent_path = codex_dir / "rollout-2-parent.jsonl"
+    _write_jsonl(child_path, child_rows)
+    _write_jsonl(parent_path, parent_rows)
+
+    parser = CodexParser(PricingDatabase())
+    entries = parser._parse_all()
+    assert len(entries) == 5
+    assert parser.replay_events_skipped == 3
+    expected_timestamps = [
+        sessions_module._parse_iso_to_ms("2026-07-20T16:30:10.000Z"),
+        sessions_module._parse_iso_to_ms("2026-07-20T16:31:10.000Z"),
+        sessions_module._parse_iso_to_ms("2026-07-20T16:32:10.000Z"),
+        sessions_module._parse_iso_to_ms("2026-07-20T19:00:10.000Z"),
+        sessions_module._parse_iso_to_ms("2026-07-20T19:01:10.000Z"),
+    ]
+    assert [entry["timestamp"] for entry in entries] == expected_timestamps
+    assert all(entry["entry_id"].startswith("codex-token-v1:") for entry in entries)
+    # The parent's turn_context model wins; no phantom default model from the replay.
+    assert all(entry["model"] == "gpt-5.6-sol" for entry in entries)
+
+    signatures = tuple(
+        (str(path), path.stat().st_mtime_ns, path.stat().st_size)
+        for path in (child_path, parent_path)
+    )
+    sessions = sessions_module._load_codex_sessions(signatures, ())
+    assert set(sessions) == {parent_id, child_id}
+    assert len(sessions[parent_id]["turns"]) == 3
+    # Cross-session dedup: the child session keeps only its own two turns.
+    assert sessions[child_id]["_subagent_parent_id"] == parent_id
+    assert [turn["timestamp_ms"] for turn in sessions[child_id]["turns"]] == expected_timestamps[3:]
+
+    child_raw = sessions_module._parse_codex_session_file(
+        str(child_path), child_path.stat().st_mtime_ns, child_path.stat().st_size, ()
+    )
+    parent_raw = sessions_module._parse_codex_session_file(
+        str(parent_path), parent_path.stat().st_mtime_ns, parent_path.stat().st_size, ()
+    )
+    assert child_raw is not None and len(child_raw["turns"]) == 5
+    stored = sessions_module._session_records_to_raw_sessions("codex", [child_raw, parent_raw])
+    assert len(stored[parent_id]["turns"]) == 3
+    assert len(stored[child_id]["turns"]) == 2
+
+
+def test_codex_subagent_single_meta_fork_replay_survives_without_parent(monkeypatch, tmp_path):
+    """If the parent file was never indexed (archived/deleted), the replayed prefix
+    must survive under the child file — counted once, never silently dropped."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _clear_parser_caches()
+
+    parent_id = "019f8024-8014-7202-aa03-9f039f67a648"
+    child_id = "019f80ad-f48c-7361-a358-532ff84dcba9"
+    codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "07" / "20"
+    usage_1, usage_2, usage_3, own_1, own_2 = _codex_fork_usage_rows()
+
+    child_rows = [
+        {
+            "timestamp": "2026-07-20T18:58:31.000Z",
+            "type": "session_meta",
+            "payload": {
+                "id": child_id,
+                "cwd": "/work/tokdash",
+                "forked_from_id": parent_id,
+                "source": {"subagent": {"thread_spawn": {"parent_thread_id": parent_id, "depth": 1}}},
+                "model_provider": "openai",
+            },
+        },
+        _codex_token_count_row_with_total("2026-07-20T18:58:32.000Z", **usage_1),
+        _codex_token_count_row_with_total("2026-07-20T18:58:32.001Z", **usage_2),
+        _codex_token_count_row_with_total("2026-07-20T18:58:32.002Z", **usage_3),
+        {
+            "timestamp": "2026-07-20T18:58:33.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.6-sol", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total("2026-07-20T19:00:10.000Z", **own_1),
+        _codex_token_count_row_with_total("2026-07-20T19:01:10.000Z", **own_2),
+    ]
+    child_path = codex_dir / "rollout-child.jsonl"
+    _write_jsonl(child_path, child_rows)
+
+    parser = CodexParser(PricingDatabase())
+    entries = parser._parse_all()
+    assert len(entries) == 5
+    assert parser.replay_events_skipped == 0
+    # Orphaned replay rows predate the file's first model signal; they must be
+    # backfilled with the file's own model, not the placeholder default.
+    assert all(entry["model"] == "gpt-5.6-sol" for entry in entries)
+
+    signatures = ((str(child_path), child_path.stat().st_mtime_ns, child_path.stat().st_size),)
+    sessions = sessions_module._load_codex_sessions(signatures, ())
+    assert set(sessions) == {child_id}
+    assert len(sessions[child_id]["turns"]) == 5
+    assert all(turn["model"] == "gpt-5.6-sol" for turn in sessions[child_id]["turns"])
+
+
+def test_codex_explicit_default_model_selection_survives_backfill(monkeypatch, tmp_path):
+    """CODEX_DEFAULT_MODEL is a real, selectable model. A file that starts on
+    another model and later switches to an explicit gpt-5.3-codex turn_context
+    must keep those rows attributed to gpt-5.3-codex — only rows written before
+    ANY model signal (the placeholder flag) may be backfilled to the file's
+    first observed model. Observed on real logs: 5 files switch into
+    gpt-5.3-codex mid-file; a name-equality backfill relabeled 2,999 of their
+    explicit rows to the earlier model."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _clear_parser_caches()
+
+    session_id = "019c3028-f83c-7842-86ab-4c02428a841f"
+    codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "02" / "05"
+    rows = [
+        {
+            "timestamp": "2026-02-05T23:35:17.000Z",
+            "type": "session_meta",
+            "payload": {"id": session_id, "cwd": "/work/tokdash", "model_provider": "openai"},
+        },
+        # No model signal yet: placeholder rows.
+        _codex_token_count_row_with_total(
+            "2026-02-05T23:35:18.000Z",
+            last_input=100, last_cache=10, last_output=20, last_reasoning=5,
+            total_input=100, total_cache=10, total_output=20, total_reasoning=5,
+        ),
+        {
+            "timestamp": "2026-02-05T23:36:00.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.2-codex", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total(
+            "2026-02-05T23:36:10.000Z",
+            last_input=110, last_cache=11, last_output=21, last_reasoning=6,
+            total_input=210, total_cache=21, total_output=41, total_reasoning=11,
+        ),
+        # Explicit switch into the placeholder's own name.
+        {
+            "timestamp": "2026-02-05T23:40:00.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.3-codex", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total(
+            "2026-02-05T23:40:10.000Z",
+            last_input=120, last_cache=12, last_output=22, last_reasoning=7,
+            total_input=330, total_cache=33, total_output=63, total_reasoning=18,
+        ),
+    ]
+    path = codex_dir / "rollout-switch.jsonl"
+    _write_jsonl(path, rows)
+
+    entries = CodexParser(PricingDatabase())._parse_all()
+    assert [entry["model"] for entry in entries] == ["gpt-5.2-codex", "gpt-5.2-codex", "gpt-5.3-codex"]
+
+    signatures = ((str(path), path.stat().st_mtime_ns, path.stat().st_size),)
+    sessions = sessions_module._load_codex_sessions(signatures, ())
+    turn_models = [turn["model"] for turn in sessions[session_id]["turns"]]
+    assert turn_models == ["gpt-5.2-codex", "gpt-5.2-codex", "gpt-5.3-codex"]
+    assert all("_model_placeholder" not in turn for turn in sessions[session_id]["turns"])
+    bill_models = [turn["_bill"]["model"] for turn in sessions[session_id]["turns"]]
+    assert bill_models == ["openai/gpt-5.2-codex", "openai/gpt-5.2-codex", "openai/gpt-5.3-codex"]
+
+
+def test_codex_cross_file_replacement_still_backfills(monkeypatch, tmp_path):
+    """A duplicate with an earlier timestamp replaces the slot owned by a
+    previously parsed file (index before the current file's first append). The
+    replacement's placeholder marker must still be resolved by the current
+    file's own model signal — not left as the default model with a leaked flag."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _clear_parser_caches()
+
+    codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "01" / "02"
+    usage = dict(last_input=100, last_cache=10, last_output=20, last_reasoning=5,
+                 total_input=100, total_cache=10, total_output=20, total_reasoning=5)
+
+    # File 1 (sorts first): owns the event-key slot with a LATER timestamp.
+    _write_jsonl(codex_dir / "rollout-1-first.jsonl", [
+        {
+            "timestamp": "2026-01-02T00:00:00.000Z",
+            "type": "session_meta",
+            "payload": {"id": "s1", "cwd": "/work/tokdash", "model_provider": "openai"},
+        },
+        {
+            "timestamp": "2026-01-02T00:00:01.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.5", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total("2026-01-02T00:00:10.000Z", **usage),
+    ])
+    # File 2: same session scope and same usage snapshot with an EARLIER
+    # timestamp, written before its own first model signal. It replaces file 1's
+    # slot while still carrying the placeholder marker.
+    _write_jsonl(codex_dir / "rollout-2-second.jsonl", [
+        {
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "type": "session_meta",
+            "payload": {"id": "s1", "cwd": "/work/tokdash", "model_provider": "openai"},
+        },
+        _codex_token_count_row_with_total("2026-01-01T00:00:05.000Z", **usage),
+        {
+            "timestamp": "2026-01-01T00:01:00.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.6-sol", "cwd": "/work/tokdash"},
+        },
+    ])
+
+    entries = CodexParser(PricingDatabase())._parse_all()
+    assert len(entries) == 1
+    assert entries[0]["model"] == "gpt-5.6-sol"
+    assert "_model_placeholder" not in entries[0]
+
+
+def test_codex_file_without_any_model_signal_is_unknown(monkeypatch, tmp_path):
+    """A file with no turn_context, no thread_settings_applied, and no provenance
+    model must label its rows explicitly unknown (issue #23) — token counts kept,
+    cost $0 — rather than fabricating usage under the default model."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _clear_parser_caches()
+
+    codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "01" / "03"
+    usage = dict(last_input=100, last_cache=10, last_output=20, last_reasoning=5,
+                 total_input=100, total_cache=10, total_output=20, total_reasoning=5)
+    _write_jsonl(codex_dir / "rollout-nosignal.jsonl", [
+        {
+            "timestamp": "2026-01-03T00:00:00.000Z",
+            "type": "session_meta",
+            "payload": {"id": "nosignal-1", "cwd": "/work/tokdash", "model_provider": "openai"},
+        },
+        _codex_token_count_row_with_total("2026-01-03T00:00:05.000Z", **usage),
+    ])
+
+    entries = CodexParser(PricingDatabase())._parse_all()
+    assert len(entries) == 1
+    assert entries[0]["model"] == "unknown"
+    assert entries[0]["cost"] == 0.0
+    assert "_model_placeholder" not in entries[0]
+
+    path = codex_dir / "rollout-nosignal.jsonl"
+    raw = sessions_module._parse_codex_session_file(
+        str(path), path.stat().st_mtime_ns, path.stat().st_size, ()
+    )
+    assert raw is not None
+    assert [turn["model"] for turn in raw["turns"]] == ["unknown"]
+    assert raw["turns"][0]["_bill"]["model"] == "unknown"
+    assert raw["turns"][0]["cost"] == 0.0
+    assert all("_model_placeholder" not in turn for turn in raw["turns"])
+
+
+def test_codex_orphan_sibling_forks_keep_one_replay_copy(monkeypatch, tmp_path):
+    """Two sibling forks of a parent that was never indexed would each retain an
+    identical parent-scoped copy of the replay prefix. Overview's global event-key
+    index keeps one; Sessions must do the same — the earliest sibling keeps the
+    prefix, later siblings drop it."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _clear_parser_caches()
+
+    parent_id = "019f8024-8014-7202-aa03-9f039f67a648"
+    child_a = "019f80ad-f48c-7361-a358-532ff84dcba9"
+    child_b = "019f80ae-1c1c-7dd3-86e5-a40140bdcb41"
+    codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "07" / "20"
+    usage_1, usage_2, usage_3, own_1, own_2 = _codex_fork_usage_rows()
+
+    def fork_rows(child_id, fork_ts, own_ts):
+        return [
+            {
+                "timestamp": f"{fork_ts}.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": child_id,
+                    "cwd": "/work/tokdash",
+                    "forked_from_id": parent_id,
+                    "source": {"subagent": {"thread_spawn": {"parent_thread_id": parent_id, "depth": 1}}},
+                    "model_provider": "openai",
+                },
+            },
+            _codex_token_count_row_with_total(f"{fork_ts}.001Z", **usage_1),
+            _codex_token_count_row_with_total(f"{fork_ts}.002Z", **usage_2),
+            _codex_token_count_row_with_total(f"{fork_ts}.003Z", **usage_3),
+            {
+                "timestamp": f"{fork_ts}.004Z",
+                "type": "turn_context",
+                "payload": {"model": "gpt-5.6-sol", "cwd": "/work/tokdash"},
+            },
+            _codex_token_count_row_with_total(f"{own_ts}.000Z", **own_1),
+            _codex_token_count_row_with_total(f"{own_ts}.001Z", **own_2),
+        ]
+
+    # child_b forked earlier, so its restamped replay copy is the survivor.
+    _write_jsonl(codex_dir / "rollout-1-a.jsonl", fork_rows(child_a, "2026-07-20T18:58:31", "2026-07-20T19:00:10"))
+    _write_jsonl(codex_dir / "rollout-2-b.jsonl", fork_rows(child_b, "2026-07-20T18:00:00", "2026-07-20T18:30:10"))
+
+    signatures = tuple(
+        (str(path), path.stat().st_mtime_ns, path.stat().st_size)
+        for path in sorted(codex_dir.glob("*.jsonl"))
+    )
+    sessions = sessions_module._load_codex_sessions(signatures, ())
+    assert set(sessions) == {child_a, child_b}
+    assert len(sessions[child_b]["turns"]) == 5   # earliest sibling keeps the prefix
+    assert [
+        turn["timestamp_ms"] for turn in sessions[child_a]["turns"]
+    ] == [
+        sessions_module._parse_iso_to_ms("2026-07-20T19:00:10.000Z"),
+        sessions_module._parse_iso_to_ms("2026-07-20T19:00:10.001Z"),
+    ]
+
+
+def test_codex_archived_sessions_root_is_scanned(monkeypatch, tmp_path):
+    """Issue #23: Codex archives rollouts to ~/.codex/archived_sessions. Both the
+    Overview parser and the Sessions signature scan must include that root, and a
+    file present in BOTH roots (archived copy not yet removed) must collapse via
+    the stable event key rather than double-count."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _clear_parser_caches()
+
+    usage = dict(last_input=100, last_cache=10, last_output=20, last_reasoning=5,
+                 total_input=100, total_cache=10, total_output=20, total_reasoning=5)
+    live_dir = tmp_path / ".codex" / "sessions" / "2026" / "08" / "01"
+    archived_dir = tmp_path / ".codex" / "archived_sessions" / "2026" / "07" / "01"
+
+    archived_only_rows = [
+        {
+            "timestamp": "2026-07-01T08:00:00.000Z",
+            "type": "session_meta",
+            "payload": {"id": "archived-only", "cwd": "/work/tokdash", "model_provider": "openai"},
+        },
+        {
+            "timestamp": "2026-07-01T08:00:01.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.6-sol", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total("2026-07-01T08:00:10.000Z", **usage),
+    ]
+    _write_jsonl(archived_dir / "rollout-archived.jsonl", archived_only_rows)
+    # Same content also still present under sessions/ (copy not yet cleaned up).
+    _write_jsonl(live_dir / "rollout-live-copy.jsonl", archived_only_rows)
+
+    entries = CodexParser(PricingDatabase())._parse_all()
+    assert len(entries) == 1  # identical snapshots in both roots collapse by key
+    assert entries[0]["model"] == "gpt-5.6-sol"
+
+    signatures = sessions_module._codex_file_signatures()
+    assert len(signatures) == 2  # both roots are scanned
+    sessions = sessions_module._load_codex_sessions(signatures, ())
+    assert set(sessions) == {"archived-only"}
+    assert len(sessions["archived-only"]["turns"]) == 1  # merged, deduped by key
+
+
+def test_codex_missing_parent_records_still_dedupe_replay(monkeypatch, tmp_path):
+    """A durable store keeps a session's rows (missing=1) after its file is deleted.
+    Those rows still prove the parent was indexed: the unbounded parent lookup must
+    include them or a deleted parent resurrects the child's replay prefix."""
+    store = UsageEntryStore(tmp_path / "usage.sqlite3")
+    parent_path = tmp_path / "rollout-parent.jsonl"
+    parent_raw = {
+        "tool": "codex",
+        "session_id": "parent-1",
+        "turns": [{"turn_index": 1, "timestamp_ms": 100, "_event_key": "k1"}],
+    }
+    assert store.sync_session_files(
+        "codex",
+        ((str(parent_path), 1, 100),),
+        parser={"v": 2},
+        parse_file_session=lambda _sig: parent_raw,
+        durable=True,
+    )
+    # Parent file deleted: durable sync marks the record missing instead of deleting.
+    assert store.sync_session_files(
+        "codex",
+        (),
+        parser={"v": 2},
+        parse_file_session=lambda _sig: None,
+        durable=True,
+    )
+    records = store.query_session_records_by_ids("codex", {"parent-1"})
+    assert len(records) == 1
+    assert records[0]["turns"][0]["_event_key"] == "k1"
+
+
+def test_codex_session_meta_provenance_model_is_an_early_model_source(monkeypatch, tmp_path):
+    """Issue #23 reported the selected model nested under session_meta
+    .base_instructions.provenance.model. No real log through Codex 0.147.0 carries
+    that key (unconfirmed shape), but the lookup stays so rows never bill under
+    the placeholder default if a future build adds it."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _clear_parser_caches()
+
+    codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "08" / "18"
+    usage_1 = dict(last_input=100, last_cache=10, last_output=20, last_reasoning=5,
+                   total_input=100, total_cache=10, total_output=20, total_reasoning=5)
+    rows = [
+        {
+            "timestamp": "2026-08-18T10:00:00.000Z",
+            "type": "session_meta",
+            "payload": {
+                "id": "provenance-session",
+                "cwd": "/work/tokdash",
+                "source": "cli",
+                "model_provider": "openai",
+                "base_instructions": {"text": "...", "provenance": {"model": "gpt-5.6-terra"}},
+            },
+        },
+        # No turn_context or thread_settings_applied: provenance is the only signal.
+        _codex_token_count_row_with_total("2026-08-18T10:01:10.000Z", **usage_1),
+    ]
+    _write_jsonl(codex_dir / "rollout-provenance.jsonl", rows)
+
+    parser = CodexParser(PricingDatabase())
+    entries = parser._parse_all()
+    assert len(entries) == 1
+    assert entries[0]["model"] == "gpt-5.6-terra"
+
+    path = codex_dir / "rollout-provenance.jsonl"
+    raw = sessions_module._parse_codex_session_file(
+        str(path), path.stat().st_mtime_ns, path.stat().st_size, ()
+    )
+    assert raw is not None
+    assert [turn["model"] for turn in raw["turns"]] == ["gpt-5.6-terra"]
+
+
+def test_codex_forked_from_id_only_file_gets_replay_dedup(monkeypatch, tmp_path):
+    """Ancestry declared only via top-level forked_from_id (no thread_spawn marker —
+    user /fork, exec forks) replays the parent prefix the same way and must get the
+    same rekeying. Without the thread_spawn marker the session stays primary."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _clear_parser_caches()
+
+    parent_id = "019f8024-8014-7202-aa03-9f039f67a648"
+    child_id = "019f90ad-f48c-7361-a358-532ff84dcba9"
+    codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "07" / "21"
+    usage_1, usage_2, usage_3, own_1, own_2 = _codex_fork_usage_rows()
+
+    parent_rows = [
+        {
+            "timestamp": "2026-07-21T08:00:00.000Z",
+            "type": "session_meta",
+            "payload": {"id": parent_id, "cwd": "/work/tokdash", "source": "vscode", "model_provider": "openai"},
+        },
+        {
+            "timestamp": "2026-07-21T08:00:01.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.6-sol", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total("2026-07-21T08:01:10.000Z", **usage_1),
+        _codex_token_count_row_with_total("2026-07-21T08:02:10.000Z", **usage_2),
+        _codex_token_count_row_with_total("2026-07-21T08:03:10.000Z", **usage_3),
+    ]
+    child_rows = [
+        {
+            "timestamp": "2026-07-21T12:00:00.000Z",
+            "type": "session_meta",
+            "payload": {
+                "id": child_id,
+                "cwd": "/work/tokdash",
+                "forked_from_id": parent_id,
+                "source": "cli",
+                "model_provider": "openai",
+            },
+        },
+        _codex_token_count_row_with_total("2026-07-21T12:00:01.000Z", **usage_1),
+        _codex_token_count_row_with_total("2026-07-21T12:00:02.000Z", **usage_2),
+        _codex_token_count_row_with_total("2026-07-21T12:00:03.000Z", **usage_3),
+        {
+            "timestamp": "2026-07-21T12:00:04.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.6-sol", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total("2026-07-21T12:10:10.000Z", **own_1),
+        _codex_token_count_row_with_total("2026-07-21T12:11:10.000Z", **own_2),
+    ]
+    _write_jsonl(codex_dir / "rollout-1-parent.jsonl", parent_rows)
+    _write_jsonl(codex_dir / "rollout-2-child.jsonl", child_rows)
+
+    parser = CodexParser(PricingDatabase())
+    entries = parser._parse_all()
+    assert len(entries) == 5
+    assert parser.replay_events_skipped == 3
+
+    signatures = tuple(
+        (str(path), path.stat().st_mtime_ns, path.stat().st_size)
+        for path in sorted(codex_dir.glob("*.jsonl"))
+    )
+    sessions = sessions_module._load_codex_sessions(signatures, ())
+    assert set(sessions) == {parent_id, child_id}
+    assert len(sessions[parent_id]["turns"]) == 3
+    assert len(sessions[child_id]["turns"]) == 2
+
+    # No thread_spawn marker: the fork is not a subagent for activity purposes.
+    child_path = codex_dir / "rollout-2-child.jsonl"
+    raw = sessions_module._parse_codex_session_file(
+        str(child_path), child_path.stat().st_mtime_ns, child_path.stat().st_size, ()
+    )
+    assert raw is not None
+    assert raw["_activity"]["is_primary"] is True
+
+
+def test_codex_subagent_replay_gate_keeps_own_turns_with_stable_keys(monkeypatch, tmp_path):
+    """Codex 0.144 shape: the child file replays the parent's session_meta, so the
+    current session id stays the parent's for the rest of the file — including the
+    subagent's OWN turns after the replay. When those events carry cumulative state,
+    the stable key already dedups the replay against the parent file; hard-skipping
+    every parent-attributed event loses the subagent's genuine work. Only rows without
+    a stable key may still hit the source-shape fallback."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _clear_parser_caches()
+
+    parent_id = "019f8024-8014-7202-aa03-9f039f67a648"
+    child_id = "019f8084-9931-7403-b9ff-6f631cb5703f"
+    codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "07" / "20"
+    usage_1, usage_2, usage_3, own_1, own_2 = _codex_fork_usage_rows()
+
+    parent_rows = [
+        {
+            "timestamp": "2026-07-20T16:28:24.000Z",
+            "type": "session_meta",
+            "payload": {"id": parent_id, "cwd": "/work/tokdash", "source": "vscode", "model_provider": "openai"},
+        },
+        {
+            "timestamp": "2026-07-20T16:28:25.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.6-sol", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total("2026-07-20T16:30:10.000Z", **usage_1),
+        _codex_token_count_row_with_total("2026-07-20T16:31:10.000Z", **usage_2),
+        _codex_token_count_row_with_total("2026-07-20T16:32:10.000Z", **usage_3),
+    ]
+    child_rows = [
+        {
+            "timestamp": "2026-07-20T18:13:21.000Z",
+            "type": "session_meta",
+            "payload": {
+                "id": child_id,
+                "cwd": "/work/tokdash",
+                "source": {"subagent": {"thread_spawn": {"parent_thread_id": parent_id, "depth": 1}}},
+                "model_provider": "openai",
+            },
+        },
+        # Replayed parent session_meta flips the current session id to the parent's.
+        {
+            "timestamp": "2026-07-20T18:13:21.001Z",
+            "type": "session_meta",
+            "payload": {"id": parent_id, "cwd": "/work/tokdash", "source": "vscode", "model_provider": "openai"},
+        },
+        {
+            "timestamp": "2026-07-20T18:13:21.002Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.6-sol", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total("2026-07-20T18:13:22.000Z", **usage_1),
+        _codex_token_count_row_with_total("2026-07-20T18:13:22.001Z", **usage_2),
+        _codex_token_count_row_with_total("2026-07-20T18:13:22.002Z", **usage_3),
+        # Genuine subagent work continues under the parent's session id (no second
+        # child session_meta is ever written).
+        _codex_token_count_row_with_total("2026-07-20T18:20:10.000Z", **own_1),
+        _codex_token_count_row_with_total("2026-07-20T18:21:10.000Z", **own_2),
+    ]
+    _write_jsonl(codex_dir / "rollout-1-parent.jsonl", parent_rows)
+    _write_jsonl(codex_dir / "rollout-2-child.jsonl", child_rows)
+
+    parser = CodexParser(PricingDatabase())
+    entries = parser._parse_all()
+    assert len(entries) == 5
+    assert parser.replay_events_skipped == 3
+    expected_timestamps = [
+        sessions_module._parse_iso_to_ms("2026-07-20T16:30:10.000Z"),
+        sessions_module._parse_iso_to_ms("2026-07-20T16:31:10.000Z"),
+        sessions_module._parse_iso_to_ms("2026-07-20T16:32:10.000Z"),
+        sessions_module._parse_iso_to_ms("2026-07-20T18:20:10.000Z"),
+        sessions_module._parse_iso_to_ms("2026-07-20T18:21:10.000Z"),
+    ]
+    assert [entry["timestamp"] for entry in entries] == expected_timestamps
+
+    # Sessions tab: the child file merges into the parent session; the replay turns
+    # dedup by event key and the subagent's own turns survive there.
+    signatures = tuple(
+        (str(path), path.stat().st_mtime_ns, path.stat().st_size)
+        for path in sorted(codex_dir.glob("*.jsonl"))
+    )
+    sessions = sessions_module._load_codex_sessions(signatures, ())
+    assert set(sessions) == {parent_id}
+    assert [turn["timestamp_ms"] for turn in sessions[parent_id]["turns"]] == expected_timestamps
+
+
+def test_codex_windowed_stored_read_dedupes_subagent_replay(monkeypatch, tmp_path):
+    """A windowed stored read only loads sessions touching the window. The forked
+    subagent file keeps its own session id and its replayed prefix is restamped
+    into the window, so the parent session is absent from the result. The replay
+    dedup must still find the parent's keys in the store, unbounded by the window
+    — otherwise Sessions disagrees with Overview exactly when the window hides
+    the parent."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _clear_parser_caches()
+
+    parent_id = "019f8024-8014-7202-aa03-9f039f67a648"
+    child_id = "019f80ad-f48c-7361-a358-532ff84dcba9"
+    codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "07" / "20"
+    usage_1, usage_2, usage_3, own_1, own_2 = _codex_fork_usage_rows()
+
+    # Parent ran on day 1 only.
+    parent_rows = [
+        {
+            "timestamp": "2026-07-20T16:28:24.000Z",
+            "type": "session_meta",
+            "payload": {"id": parent_id, "cwd": "/work/tokdash", "source": "vscode", "model_provider": "openai"},
+        },
+        {
+            "timestamp": "2026-07-20T16:28:25.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.6-sol", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total("2026-07-20T16:30:10.000Z", **usage_1),
+        _codex_token_count_row_with_total("2026-07-20T16:31:10.000Z", **usage_2),
+        _codex_token_count_row_with_total("2026-07-20T16:32:10.000Z", **usage_3),
+    ]
+    # Forked on day 2; the replayed prefix is restamped to day 2, inside the window.
+    child_rows = [
+        {
+            "timestamp": "2026-07-21T09:00:00.000Z",
+            "type": "session_meta",
+            "payload": {
+                "id": child_id,
+                "cwd": "/work/tokdash",
+                "forked_from_id": parent_id,
+                "source": {"subagent": {"thread_spawn": {"parent_thread_id": parent_id, "depth": 1}}},
+                "model_provider": "openai",
+            },
+        },
+        _codex_token_count_row_with_total("2026-07-21T09:00:01.000Z", **usage_1),
+        _codex_token_count_row_with_total("2026-07-21T09:00:02.000Z", **usage_2),
+        _codex_token_count_row_with_total("2026-07-21T09:00:03.000Z", **usage_3),
+        {
+            "timestamp": "2026-07-21T09:00:04.000Z",
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.6-sol", "cwd": "/work/tokdash"},
+        },
+        _codex_token_count_row_with_total("2026-07-21T09:10:10.000Z", **own_1),
+        _codex_token_count_row_with_total("2026-07-21T09:11:10.000Z", **own_2),
+    ]
+    _write_jsonl(codex_dir / "rollout-1-parent.jsonl", parent_rows)
+    _write_jsonl(codex_dir / "rollout-2-child.jsonl", child_rows)
+
+    store = UsageEntryStore(tmp_path / "usage.sqlite3")
+    monkeypatch.setattr(sessions_module, "UsageEntryStore", lambda: store)
+
+    day2_start = sessions_module._parse_iso_to_ms("2026-07-21T00:00:00.000Z")
+    day3_start = sessions_module._parse_iso_to_ms("2026-07-22T00:00:00.000Z")
+
+    windowed = sessions_module._stored_sessions_for_tool(
+        "codex", since_ms=day2_start, until_ms=day3_start
+    )
+    # The parent's files are entirely outside the window, so its session is not
+    # in the result — but the child must still lose the replayed prefix.
+    assert parent_id not in windowed
+    assert set(windowed) == {child_id}
+    assert [
+        turn["timestamp_ms"] for turn in windowed[child_id]["turns"]
+    ] == [
+        sessions_module._parse_iso_to_ms("2026-07-21T09:10:10.000Z"),
+        sessions_module._parse_iso_to_ms("2026-07-21T09:11:10.000Z"),
+    ]
+
+    # Unwindowed reads see the parent and dedup against it directly.
+    unbounded = sessions_module._stored_sessions_for_tool("codex")
+    assert set(unbounded) == {parent_id, child_id}
+    assert len(unbounded[parent_id]["turns"]) == 3
+    assert len(unbounded[child_id]["turns"]) == 2
+
+
+def test_codex_thread_settings_applied_is_an_early_model_source(monkeypatch, tmp_path):
+    """Newer Codex emits thread_settings_applied before the first turn_context.
+    Rows that follow it (and rows before any model signal, via backfill) must use
+    that model instead of the placeholder default."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _clear_parser_caches()
+
+    codex_dir = tmp_path / ".codex" / "sessions" / "2026" / "08" / "12"
+    usage_1 = dict(last_input=100, last_cache=10, last_output=20, last_reasoning=5,
+                   total_input=100, total_cache=10, total_output=20, total_reasoning=5)
+    rows = [
+        {
+            "timestamp": "2026-08-12T11:25:16.000Z",
+            "type": "session_meta",
+            "payload": {"id": "settings-session", "cwd": "/work/tokdash", "source": "cli", "model_provider": "openai"},
+        },
+        {
+            "timestamp": "2026-08-12T11:25:16.100Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "thread_settings_applied",
+                "thread_settings": {"model": "gpt-5.6-sol", "model_provider_id": "openai"},
+            },
+        },
+        # No turn_context in this file at all: thread_settings_applied is the only
+        # model signal and must win over the placeholder default.
+        _codex_token_count_row_with_total("2026-08-12T11:26:10.000Z", **usage_1),
+    ]
+    _write_jsonl(codex_dir / "rollout-settings.jsonl", rows)
+
+    parser = CodexParser(PricingDatabase())
+    entries = parser._parse_all()
+    assert len(entries) == 1
+    assert entries[0]["model"] == "gpt-5.6-sol"
+    assert entries[0]["provider"] == "openai"
+
+    path = codex_dir / "rollout-settings.jsonl"
+    raw = sessions_module._parse_codex_session_file(
+        str(path), path.stat().st_mtime_ns, path.stat().st_size, ()
+    )
+    assert raw is not None
+    assert [turn["model"] for turn in raw["turns"]] == ["gpt-5.6-sol"]
 
 
 def test_codex_primary_resume_replay_is_deduplicated_across_files(monkeypatch, tmp_path):


### PR DESCRIPTION
Addresses points 1-4 of #23. Points 5 and 6 are deliberately left open — see below.

## The bug

Codex subagent and fork rollout files replay the parent thread's `token_count` history before recording their own work. The existing gate only caught the 0.144 shape, where the file replays the parent's `session_meta` and the active session id flips to the parent's.

Codex 0.146+ writes a different shape: one `session_meta` carrying the child's own id, ancestry declared through `forked_from_id` or a top-level `parent_thread_id`, and the replayed parent prefix sitting before the child's first `turn_context`. The gate never fired, and the session-scoped stable event key hashed the copies under the child id, so they could not collide with the parent's originals. Every replayed event was counted twice.

## What changed

**Replay keying.** Replay segments are keyed to the declared parent session, so the stable event key collapses them against the parent file. When the parent is not indexed anywhere the rows survive under the parent scope and are counted once, so an archived or deleted parent costs no usage. Sibling forks of the same unindexed parent keep exactly one copy between them.

The source-shape skip now fires only for rows lacking the cumulative state a key needs. In the 0.144 shape the subagent's own turns also run under the parent's session id, so the old unconditional skip was discarding genuine work along with the replay.

**Model attribution.** `gpt-5.3-codex` is a real, selectable model, so its value cannot double as the "no signal yet" sentinel. Rows now carry an internal placeholder marker until the file's first model signal, and only marked rows are backfilled — an explicit mid-file switch to that model stays attributed to itself. Files with no model signal anywhere label their rows `unknown` at zero cost. `thread_settings_applied` joins `turn_context` as an early model source.

`base_instructions.provenance.model` from the issue report is implemented but marked unconfirmed: no observed log through 0.147.0 carries that key.

**Archived rollouts.** Both `sessions/` and `archived_sessions/` are scanned, in the live loaders and the store sync. Identical copies across the two roots collapse by event key rather than double-counting.

**Windowed reads.** A windowed stored session read only loads sessions touching the window, which could exclude every parent file while the child's restamped replay fell inside it. Fork parents are now looked up in the store unbounded by time, including durable rows whose files were deleted.

## Measured on 1009 local rollout files

| | rows | note |
|---|---|---|
| removed | 345 | replayed copies, all previously mislabeled `gpt-5.3-codex` |
| recovered | 2282 | subagent turns the old gate discarded |
| added | 147 | archived-only rollouts |

Genuine `gpt-5.3-codex` usage is untouched: 3315 → 2970 rows, exactly the 345 replays and nothing else.

Sessions and Overview agree exactly across parent-present, parent-deleted, and orphaned-sibling configurations, with no duplicate event keys. A file present in both rollout roots yields identical totals to either root alone.

## Upgrade note

Codex session rows rebuild once under parser version 2. Historical totals shift in **both** directions — down where replayed prefixes were double-counted, up where subagent turns were previously dropped — and may rise overall. No manual `tokdash db resync` needed.

## Left open

Not fixed here; #23 stays open for them:

- **Point 5** — a separate UTC aggregate for direct Codex Profile comparison. Codex Profile buckets by UTC while the dashboard uses the machine's local day, so the same date label covers different spans.
- **Point 6** — clearing deferred model breakdowns immediately on range change, so a table cannot briefly render the previous range under the new label.

Both are frontend/API work that does not touch the Codex parsing path.