### PR TITLE
Merge stored session rows in one pass instead of pairwise

### DIFF
--- a/src/tokdash/sessions.py
+++ b/src/tokdash/sessions.py
@@ -921,6 +921,76 @@ def _codex_unwindowed_parent_keys(
             if event_key:
                 keys.add(str(event_key))
     return parent_keys
+def _merge_raw_session_sequence(raws: list[Dict[str, Any]]) -> Dict[str, Any]:
+    """Left-fold ``raws`` exactly as repeated :func:`_merge_raw_session` would.
+
+    The pairwise fold rebuilds the whole accumulated session on every record: it
+    recomputes an identity key and takes a fresh copy for every turn already
+    merged. A session split across K files therefore costs O(K^2), and Claude
+    splits one session across every subagent transcript it spawned — hundreds of
+    files for a single session id, which is what made a cold Overview read spend
+    minutes re-keying the same turns.
+
+    This keeps that to one key and one copy per turn while reproducing the fold's
+    output verbatim, including the per-record sort: each pairwise merge renumbered
+    ``turn_index`` before the next one ran, and the next sort tie-breaks on that
+    renumbering, so the sort stays inside the loop.
+    """
+    if len(raws) == 1:
+        return raws[0]
+
+    # Metadata never reads turns, so fold it with the pairwise merge itself. That
+    # keeps title/project/review precedence — and the keys the merge drops —
+    # identical to the original without touching a single turn.
+    meta = {key: value for key, value in raws[0].items() if key != "turns"}
+    meta["turns"] = []
+    for raw in raws[1:]:
+        stub = {key: value for key, value in raw.items() if key != "turns"}
+        stub["turns"] = []
+        meta = _merge_raw_session(meta, stub)
+
+    ordered: list[Dict[str, Any]] = []
+    keys: list[tuple[Any, ...]] = []
+    # The sort inputs are carried alongside the turns rather than read back out of
+    # them per comparison: sorting tuples costs no Python-level key callback, and
+    # that callback was most of what remained after the re-keying went away.
+    stamps: list[int] = []
+    indices: list[int] = []
+    position: dict[tuple[Any, ...], int] = {}
+    for record_index, raw in enumerate(raws):
+        for turn in raw.get("turns", []):
+            key = _turn_identity_key(turn)
+            stamp = int(turn.get("timestamp_ms", 0) or 0)
+            at = position.get(key)
+            if at is None:
+                position[key] = len(ordered)
+                ordered.append(dict(turn))
+                keys.append(key)
+                stamps.append(stamp)
+                indices.append(int(turn.get("turn_index", 0) or 0))
+            elif stamp < stamps[at]:
+                # A later file carrying an earlier stamp for the same event wins,
+                # and keeps the position the first sighting claimed.
+                ordered[at] = dict(turn)
+                stamps[at] = stamp
+                indices[at] = int(turn.get("turn_index", 0) or 0)
+        if not record_index:
+            # The first record is the accumulator the fold starts from; it is not
+            # merged with itself, so it is neither sorted nor renumbered yet.
+            continue
+        order = sorted(zip(stamps, indices, range(len(ordered))))
+        ordered = [ordered[at] for _stamp, _index, at in order]
+        keys = [keys[at] for _stamp, _index, at in order]
+        stamps = [stamp for stamp, _index, _at in order]
+        indices = list(range(1, len(ordered) + 1))
+        for index, turn in enumerate(ordered, start=1):
+            turn["turn_index"] = index
+        position = {key: index for index, key in enumerate(keys)}
+
+    meta["turns"] = ordered
+    if not meta["display_name"]:
+        meta["display_name"] = _fallback_display_name(meta["session_id"], meta["project"])
+    return meta
 
 
 def _file_signature(path: Path) -> tuple[str, int, int]:
@@ -2871,12 +2941,13 @@ def _session_records_to_raw_sessions(tool: str, records: Iterable[Dict[str, Any]
     """Rebuild raw sessions from the per-file rows held in the persistent store.
 
     Every live loader that can see one session in several files (codex, claude,
-    pi_agent, kimi) merges with _merge_raw_session, so the cached path uses it
-    too. It is what prefers an explicit title over a fallback and dedups turns by
-    event identity; rebuilding the merge differently here is exactly how a cached
-    read starts disagreeing with a live one.
+    pi_agent, kimi) merges with _merge_raw_session, so the cached path merges the
+    same way — _merge_raw_session_sequence is that fold in one pass, not a second
+    set of rules. It is what prefers an explicit title over a fallback and dedups
+    turns by event identity; rebuilding the merge differently here is exactly how
+    a cached read starts disagreeing with a live one.
     """
-    sessions: Dict[str, Dict[str, Any]] = {}
+    grouped: Dict[str, list[Dict[str, Any]]] = {}
     for record in records:
         session_id = str(record.get("session_id") or "")
         if not session_id or not record.get("turns"):
@@ -2892,10 +2963,14 @@ def _session_records_to_raw_sessions(tool: str, records: Iterable[Dict[str, Any]
         # Rows written by older versions may carry a falsy project; _merge_raw_session
         # only defers to a sibling row's project when this one reads "unknown".
         raw["project"] = raw.get("project") or "unknown"
-        if session_id in sessions:
-            sessions[session_id] = _merge_raw_session(sessions[session_id], raw)
-        else:
-            sessions[session_id] = raw
+        grouped.setdefault(session_id, []).append(raw)
+
+    # Merge each session's rows in one pass. Folding them pairwise re-keyed and
+    # re-copied every turn already merged, which is quadratic in the number of
+    # files a session spans — see _merge_raw_session_sequence.
+    sessions: Dict[str, Dict[str, Any]] = {
+        session_id: _merge_raw_session_sequence(raws) for session_id, raws in grouped.items()
+    }
 
     if tool == "codex":
         # Codex-only pass; skip the keys_by_session build for every other tool.

--- a/tests/test_session_merge_batch.py
+++ b/tests/test_session_merge_batch.py
@@ -1,0 +1,141 @@
+"""The batched session merge must reproduce the pairwise fold exactly.
+
+One Claude session spans every subagent transcript it spawned, so rebuilding it
+from the store used to fold the rows pairwise and re-key every turn already
+merged — quadratic in the number of files. _merge_raw_session_sequence collapses
+that to one pass; these tests pin it to the fold it replaced, because the live
+loaders still fold pairwise and a cached read that merges differently is exactly
+how cached and live start disagreeing.
+"""
+import json
+
+from tokdash import sessions
+from tokdash.sessions import _merge_raw_session, _merge_raw_session_sequence
+
+
+def _fold(raws):
+    """The pairwise fold the batch merge replaced, kept here as the oracle."""
+    acc = raws[0]
+    for raw in raws[1:]:
+        acc = _merge_raw_session(acc, raw)
+    return acc
+
+
+def _turn(index, stamp, *, event=None, stream=None, tokens=10, cost=0.5):
+    turn = {
+        "turn_index": index,
+        "timestamp_ms": stamp,
+        "model": "claude-sonnet-4.5",
+        "tokens_in": tokens,
+        "tokens_cache": 0,
+        "tokens_out": 5,
+        "tokens_reasoning": 0,
+        "tokens": tokens + 5,
+        "cost": cost,
+    }
+    if event is not None:
+        turn["_event_key"] = event
+    if stream is not None:
+        turn["_stream_id"] = stream
+    return turn
+
+
+def _raw(session_id="s1", *, turns, name=None, project="proj", review=False, explicit=None):
+    raw = {
+        "tool": "claude",
+        "session_id": session_id,
+        "project": project,
+        "display_name": name,
+        "is_review_session": review,
+        "turns": turns,
+    }
+    if explicit is not None:
+        raw["_display_name_explicit"] = explicit
+    return raw
+
+
+def _canon(value):
+    return json.dumps(value, sort_keys=True, default=str)
+
+
+def test_single_raw_is_returned_unchanged():
+    raw = _raw(turns=[_turn(1, 1000, event="a")])
+    assert _merge_raw_session_sequence([raw]) is raw
+
+
+def test_matches_fold_for_many_files():
+    raws = [_raw(turns=[_turn(1, 1000 + i * 10, event=f"e{i}")]) for i in range(40)]
+    assert _canon(_merge_raw_session_sequence(raws)) == _canon(_fold(raws))
+
+
+def test_matches_fold_when_a_later_file_carries_an_earlier_stamp():
+    # Same event id, second sighting earlier: the earlier stamp wins in both paths.
+    raws = [
+        _raw(turns=[_turn(1, 5000, event="dup"), _turn(2, 6000, event="b")]),
+        _raw(turns=[_turn(1, 4000, event="dup")]),
+        _raw(turns=[_turn(1, 7000, event="dup")]),
+    ]
+    merged = _merge_raw_session_sequence(raws)
+    assert _canon(merged) == _canon(_fold(raws))
+    stamps = [turn["timestamp_ms"] for turn in merged["turns"] if turn.get("_event_key") == "dup"]
+    assert stamps == [4000]
+
+
+def test_matches_fold_for_field_identity_and_streams():
+    # No event key: identity falls back to fields, and _stream_id keeps two agents
+    # reporting the same usage in the same millisecond from collapsing into one.
+    raws = [
+        _raw(turns=[_turn(1, 2000, stream="main"), _turn(2, 2000, stream="sub")]),
+        _raw(turns=[_turn(1, 2000, stream="main"), _turn(2, 2000, stream="other")]),
+    ]
+    merged = _merge_raw_session_sequence(raws)
+    assert _canon(merged) == _canon(_fold(raws))
+    assert len(merged["turns"]) == 3
+
+
+def test_matches_fold_for_duplicate_stamps_across_files():
+    # Equal timestamps are where the fold's per-record renumbering decides order.
+    raws = [
+        _raw(turns=[_turn(3, 1000, event="a"), _turn(1, 1000, event="b")]),
+        _raw(turns=[_turn(2, 1000, event="c"), _turn(9, 1000, event="d")]),
+        _raw(turns=[_turn(1, 1000, event="e")]),
+    ]
+    merged = _merge_raw_session_sequence(raws)
+    assert _canon(merged) == _canon(_fold(raws))
+    assert [turn["turn_index"] for turn in merged["turns"]] == [1, 2, 3, 4, 5]
+
+
+def test_matches_fold_for_metadata_precedence():
+    raws = [
+        _raw(turns=[_turn(1, 1000, event="a")], name=None, project="unknown", review=False),
+        _raw(turns=[_turn(1, 2000, event="b")], name="Real Title", project="proj", review=True, explicit=True),
+        _raw(turns=[_turn(1, 3000, event="c")], name="Later", project="other", review=False),
+    ]
+    merged = _merge_raw_session_sequence(raws)
+    assert _canon(merged) == _canon(_fold(raws))
+    assert merged["is_review_session"] is True
+    assert merged["project"] == "proj"
+
+
+def test_each_turn_is_keyed_exactly_once(monkeypatch):
+    """The guard against the quadratic coming back.
+
+    The pairwise fold re-keyed every already-merged turn on every record, so this
+    count grew with the square of the file count. It must stay linear.
+    """
+    calls = {"n": 0}
+    original = sessions._turn_identity_key
+
+    def counting(turn):
+        calls["n"] += 1
+        return original(turn)
+
+    monkeypatch.setattr(sessions, "_turn_identity_key", counting)
+
+    files, per_file = 60, 3
+    raws = [
+        _raw(turns=[_turn(i, 1000 + f * 100 + i, event=f"e{f}-{i}") for i in range(1, per_file + 1)])
+        for f in range(files)
+    ]
+    _merge_raw_session_sequence(raws)
+    assert calls["n"] == files * per_file


### PR DESCRIPTION
## The problem

`_session_records_to_raw_sessions` folded a session's stored rows pairwise. Each `_merge_raw_session` call rebuilds the entire accumulated session — recomputing an identity key and taking a fresh copy for every turn already merged — so a session spanning K files costs O(K²).

Claude splits one session id across every subagent transcript it spawned. On this machine one session spans **486 files**, and 18 exceed 50, which is what made a cold Overview read spend minutes re-keying the same turns.

## The change

`_merge_raw_session_sequence()` performs the same left-fold in one pass: one identity key and one copy per turn.

Two details it preserves rather than optimizes away:

- **The per-record sort stays inside the loop.** Each pairwise merge renumbered `turn_index` before the next ran, and the next sort tie-breaks on that renumbering. Hoisting it changes output.
- **Sort inputs ride in parallel lists**, so sorting compares plain tuples with no Python key callback.

Metadata (title precedence, project, review flag, key dropping) still folds through `_merge_raw_session` itself with empty-turn stubs — no metadata field reads `turns`, so the rules are not reimplemented anywhere.

The live loaders still fold pairwise, so cached-vs-live parity holds by construction; `test_claude_session_cache_parity.py` passes.

## Equivalence

Verified against the pairwise fold as an oracle:

- **1794 real sessions** from the local 719 MB store, all five tools, deep-compared — 0 mismatches
- **6000 randomized adversarial trials** (colliding event keys, tied timestamps, missing `turn_index`, null stamps, mixed `_stream_id`) — 0 mismatches

`tests/test_session_merge_batch.py` adds 7 tests using the fold as an oracle: duplicate event keys, later-file-earlier-stamp, `_stream_id` separation, equal-timestamp ordering, metadata precedence, and a guard asserting each turn is keyed exactly once — which fails loudly if the quadratic returns.

## Measured

Fold in isolation, on the real store:

| tool | pairwise | batch | speedup | max files/session |
|---|---|---|---|---|
| claude | 9.55s | 2.41s | 4.0x | 486 |
| codex | 0.09s | 0.07s | 1.3x | 8 |

End-to-end `get_active_time_data('all')` drops from 31-35s to ~6s. This is effectively a Claude-side win; Codex sessions never fan out far enough to go quadratic.