### PR TITLE
Stop the Overview showing one range's data under another range's label

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
 - [API reference](reference/API.md) — the local HTTP API (FastAPI) for token usage, costs, and session data.
 - [Supported clients](reference/SUPPORTED_CLIENTS.md) — which coding tools Tokdash reads usage from and how detection works.
 - [History retention](reference/HISTORY_RETENTION.md) — why Tokdash's past months can shrink, and how to prevent it.
+- [Day boundaries](reference/DAY_BOUNDARIES.md) — Tokdash buckets by your local day; why a provider's own usage page shows a different number.
 
 ## development/ — maintainer workflows, release history, and design notes
 

--- a/docs/reference/DAY_BOUNDARIES.md
+++ b/docs/reference/DAY_BOUNDARIES.md
@@ -1,0 +1,49 @@
+# Day boundaries — why a provider's dashboard shows a different number
+
+Tokdash cuts every day at **your machine's local midnight**. Date ranges, the "Today"
+and "Yesterday" presets, the daily totals, and the activity heatmap all use the host
+timezone, read fresh on each request, so it follows DST.
+
+Timestamps are stored as epoch milliseconds — absolute instants, no timezone — and the
+local boundary is applied when they are bucketed. Nothing in the interface displays UTC.
+
+## Why a provider's own page disagrees
+
+Provider usage pages generally bucket by **UTC** midnight. OpenAI's Codex usage profile
+does. At UTC+1 that puts their day boundary at 01:00 your time; at UTC+8, 08:00. So work
+you do in that band is filed under one date by Tokdash and the neighbouring date by the
+provider.
+
+Concretely, at UTC+1, Tokdash's "16 Aug" spans:
+
+```
+2026-08-16 00:00 local  ..  2026-08-17 00:00 local
+= 2026-08-15 23:00 UTC  ..  2026-08-16 23:00 UTC
+```
+
+The provider's "16 Aug" spans `00:00 UTC .. 24:00 UTC`. Same underlying calls, different
+cuts. On one measured day this was a 7% difference in the daily total; the wider your
+offset from UTC, the wider the band that moves.
+
+## Two other reasons the numbers will not match
+
+**Coverage.** Tokdash reads the session logs on *this machine*. A provider's page is
+server-side and account-wide, so it also counts work from other machines you are signed
+in on, and from cloud tasks that never touch local disk. This gap cannot be closed
+locally, and it is unbounded.
+
+**Token definitions differ per provider.** Codex reports `total_tokens` as
+`input_tokens + output_tokens`, with reasoning tokens counted *inside* output. Tokdash
+carries reasoning as its own figure and adds it to the total, so its Codex token count
+runs slightly above the provider's — on the order of 0.1–0.5% for typical usage, more on
+reasoning-heavy days. Costs are unaffected.
+
+Because of these, aligning only the day boundary would not make the two agree. Tokdash
+does not offer a UTC view for that reason: it would produce a second number that still
+did not reconcile, with no way to tell which difference you were looking at.
+
+## What to do
+
+For a like-for-like check against a provider page, compare a **week or a month** rather
+than a single day. The boundary displacement is a fixed band at each end, so it washes
+out as the window grows, leaving only the coverage and definition differences above.

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -6068,8 +6068,19 @@
       const metaElement = document.getElementById('overviewActiveMeta');
       if (!valueElement || !metaElement) return;
       const data = overviewActiveTimeState.data;
+      valueElement.classList.remove('tokdash-loading-placeholder');
       if (!data) {
-        valueElement.textContent = '—';
+        // This card's request runs behind /api/usage, so it is still loading for a
+        // second or two after the rest of the row has answered. A dash there reads
+        // as "no agent time in this range" rather than "not back yet", so show the
+        // same shimmer every other deferred surface on this tab uses, and keep the
+        // dash for the states that really are an answer.
+        if (overviewActiveTimeState.status === 'loading') {
+          valueElement.classList.add('tokdash-loading-placeholder');
+          valueElement.innerHTML = `<span class="tokdash-loading-label" data-i18n="loading">${t('loading')}</span>`;
+        } else {
+          valueElement.textContent = '—';
+        }
         valueElement.title = '';
         renderDelta('overviewActiveDelta', null);
         metaElement.textContent = overviewActiveTimeState.status === 'error' ? t('loadFailed') : '';

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -783,6 +783,12 @@
 
     .tab-content { display: none; }
     .tab-content.active { display: block; }
+    /* A range change moves the date label before the new range's data arrives.
+       Dim the data region so the figures still on screen read as not-yet-this-range
+       rather than as an answer. The date control and refresh button sit outside the
+       tab panes, so they stay at full contrast. */
+    .tab-content.is-stale { opacity: .55; transition: opacity .12s ease; }
+    @media (prefers-reduced-motion: reduce) { .tab-content.is-stale { transition: none; } }
 
     /* Heatmap (GitHub-like) */
     /* Heatmap sizing via CSS variables (responsive) */
@@ -3270,6 +3276,10 @@
     let lastCombinedModels = [];
     let lastAppsBreakdown = null;
     let lastByTool = {};
+    // Which window key's data currently sits in the two deferred breakdowns, and a
+    // token that lets a superseded idle callback recognise itself and paint nothing.
+    let overviewBreakdownWindowKey = null;
+    let overviewRenderToken = 0;
     let activeSessionDetail = null;
     let activeDayDetail = null;
     let pricingDbLoaded = false;
@@ -5602,6 +5612,41 @@
       updateDashboard(null, dateFrom, dateTo, options);
     }
 
+    // Apps & Models and Combined Models are painted from an idle callback, so they
+    // outlive their range twice over: for the whole /api/usage fetch, and again for
+    // up to a frame after the KPI cards update. Reset both to the loading state the
+    // page already ships in its initial markup, so the cleared state is one the
+    // stylesheet and the translator both already handle.
+    function clearOverviewBreakdowns() {
+      const loading = `<span class="tokdash-loading-label" data-i18n="loading">${t('loading')}</span>`;
+      const apps = document.getElementById('appsBreakdown');
+      if (apps) apps.innerHTML = `<p class="tokdash-loading-placeholder text-center py-10" style="color: var(--color-muted);">${loading}</p>`;
+      const models = document.getElementById('allModelsTable');
+      if (models) models.innerHTML = `<tr><td colspan="8" class="tokdash-loading-placeholder text-center py-10" style="color: var(--color-muted);">${loading}</td></tr>`;
+      const info = document.getElementById('combinedModelsInfo');
+      if (info) info.textContent = '';
+      const toggle = document.getElementById('combinedModelsToggle');
+      if (toggle) toggle.style.display = 'none';
+      overviewBreakdownWindowKey = null;
+      // Callbacks queued by the render being cleared are now stale too. Nothing has
+      // rendered for the incoming range yet, so this is the only thing that can
+      // retire them before they repaint what was just cleared.
+      overviewRenderToken += 1;
+    }
+
+    // Two different states, deliberately not one flag. `pending` is a fetch actually
+    // running, which is what aria-busy means: hold off announcing, an update is coming.
+    // `stale` outlives it — a failed range change leaves another range's numbers under
+    // the label, worth dimming, but nothing is being modified and no update is coming,
+    // so asserting aria-busy there would tell assistive tech to wait forever.
+    function setOverviewState({ pending = false, stale = false } = {}) {
+      const region = document.getElementById('overview-content');
+      if (!region) return;
+      region.classList.toggle('is-stale', !!(pending || stale));
+      if (pending) region.setAttribute('aria-busy', 'true');
+      else region.removeAttribute('aria-busy');
+    }
+
     function renderOverviewTab(data) {
       if (!data) return;
       renderOverviewTokenTotal(data.total_tokens);
@@ -5631,12 +5676,22 @@
       lastCombinedModels = data.combined_models || [];
       lastAppsBreakdown = { apps: data.apps || null, openclawModels: data.openclaw_models || null };
 
+      // Every render bumps the token, so a callback queued for a range the user has
+      // already left paints nothing instead of briefly filling the cleared containers
+      // with data the label no longer names. Capture the key this data belongs to:
+      // on the error path below, that is deliberately the previous range's.
+      const breakdownToken = ++overviewRenderToken;
+      const paintedWindowKey = lastWindowKey;
       scheduleIdle(() => {
-        if (lastAppsBreakdown?.apps) {
-          updateAppsBreakdown(lastAppsBreakdown.apps, lastAppsBreakdown.openclawModels);
-        }
+        if (breakdownToken !== overviewRenderToken) return;
+        updateAppsBreakdown(lastAppsBreakdown?.apps || {}, lastAppsBreakdown?.openclawModels);
+        overviewBreakdownWindowKey = paintedWindowKey;
       });
-      scheduleIdle(() => updateCombinedModelsTable(lastCombinedModels));
+      scheduleIdle(() => {
+        if (breakdownToken !== overviewRenderToken) return;
+        updateCombinedModelsTable(lastCombinedModels);
+        overviewBreakdownWindowKey = paintedWindowKey;
+      });
       if (Array.isArray(statsCache.default)) {
         statsCache.default = reconcileTodayProfileContribution(
           statsCache.default,
@@ -5724,6 +5779,15 @@
     async function updateDashboard(customDays = null, dateFrom = null, dateTo = null, options = {}) {
       const forceRefresh = !!options.forceRefresh;
       const windowKey = windowKeyFor(customDays, dateFrom, dateTo);
+
+      // The date picker moved its label before this ran, so whatever is on screen now
+      // sits under a heading that does not name it. Drop the deferred breakdowns and
+      // mark the rest as pending. A same-range refresh is excluded: its content is
+      // still the right range's, and the refresh button reports that load itself.
+      if (windowKey !== overviewBreakdownWindowKey) {
+        clearOverviewBreakdowns();
+        if (lastUsageResponse) setOverviewState({ pending: true });
+      }
 
       if (updateInFlight) {
         // The date picker has already moved its label, so dropping this would
@@ -5846,6 +5910,13 @@
         updateIsManualRefresh = false;
         inFlightDashboardKey = null;
         inFlightResultDiscarded = false;
+        // A load that landed puts lastWindowKey on the range the label names, so the
+        // marking comes off. A failed range change does not: it restores the previous
+        // range's cards and tables rather than leaving a shimmer for a load that is
+        // over, and #lastUpdate turning into "Load failed" is one small line in the
+        // header. Stay marked until something actually lands, so those numbers are
+        // never presented as this range's answer.
+        setOverviewState({ stale: !!lastUsageResponse && lastWindowKey !== windowKey });
         renderRefreshButton();
         const queued = pendingDashboardRequest;
         pendingDashboardRequest = null;

--- a/tests/test_dashboard_queue_frontend.py
+++ b/tests/test_dashboard_queue_frontend.py
@@ -49,10 +49,11 @@ let lastUsageResponse = null;
 let lastSessionsResponses = null;
 let sessionsLoadedKey = null;
 let lastWindowKey = null;
+let overviewBreakdownWindowKey = null;
 let includeCodexReviewSessions = null;
 const overviewActiveTimeState = { status: 'idle', data: null, key: null, requestId: 0 };
 
-const log = { rendered: [], errors: [], alerts: [], refreshStates: [], activeCards: [], activeLoads: [] };
+const log = { rendered: [], errors: [], alerts: [], refreshStates: [], activeCards: [], activeLoads: [], stale: [] };
 const fetches = [];
 
 function deferred() {
@@ -74,6 +75,8 @@ function isOverviewActive() { return true; }
 function renderOverviewTab(data) { log.rendered.push(data && data.range); }
 function renderSessionsTab() {}
 function renderRefreshButton() {}
+function clearOverviewBreakdowns() { overviewBreakdownWindowKey = null; }
+function setOverviewState(state) { log.stale.push(!!(state && (state.pending || state.stale))); }
 function setRefreshUiState(state) { refreshUiState = state; log.refreshStates.push(state); }
 function setDashboardFetchStatus(error) { log.errors.push(String(error && error.message || error)); }
 function updateTimestamp() {}

--- a/tests/test_overview_active_time.py
+++ b/tests/test_overview_active_time.py
@@ -500,6 +500,83 @@ def test_the_card_shows_agent_time_and_its_delta():
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_the_card_says_loading_rather_than_answering_with_a_dash(tmp_path):
+    """The card's own request runs behind /api/usage, so it answers a beat later.
+
+    A dash in that gap reads as "no agent time in this range" — an answer the card
+    has not got yet. It shares the shimmer the rest of the tab's deferred surfaces
+    use, and keeps the dash for the states that really are an answer.
+    """
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    harness = tmp_path / "active-time-render.js"
+    harness.write_text(
+        """
+const nodes = {};
+function node(id) {
+  if (!nodes[id]) nodes[id] = {
+    id, textContent: '', innerHTML: '', title: '', style: {}, classes: new Set(),
+    classList: {
+      add: (c) => nodes[id].classes.add(c),
+      remove: (c) => nodes[id].classes.delete(c),
+      contains: (c) => nodes[id].classes.has(c),
+    },
+  };
+  return nodes[id];
+}
+const document = { getElementById: node };
+const overviewActiveTimeState = { status: 'idle', data: null, key: null, requestId: 0 };
+function t(key) { return key; }
+function renderDelta() {}
+function formatDuration(ms) { return `dur:${ms}`; }
+function formatToolName(name) { return name; }
+function fitKpiValue() {}
+"""
+        + _extract_js_function(source, "function renderOverviewActiveTime() {")
+        + """
+const out = {};
+const snapshot = () => ({
+  text: node('overviewActiveTime').textContent,
+  html: node('overviewActiveTime').innerHTML,
+  shimmer: node('overviewActiveTime').classes.has('tokdash-loading-placeholder'),
+  meta: node('overviewActiveMeta').textContent,
+});
+for (const status of ['loading', 'error', 'idle']) {
+  overviewActiveTimeState.status = status;
+  overviewActiveTimeState.data = null;
+  renderOverviewActiveTime();
+  out[status] = snapshot();
+}
+overviewActiveTimeState.status = 'ready';
+overviewActiveTimeState.data = { active_ms_sum: 42, unavailable_tools: [] };
+renderOverviewActiveTime();
+out.ready = snapshot();
+process.stdout.write(JSON.stringify(out));
+""",
+        encoding="utf-8",
+    )
+    out = json.loads(
+        subprocess.run(
+            ["node", str(harness)], check=True, capture_output=True, encoding="utf-8"
+        ).stdout
+    )
+
+    assert out["loading"]["shimmer"] is True, "a pending request must not read as a dash"
+    assert "tokdash-loading-label" in out["loading"]["html"]
+    assert 'data-i18n="loading"' in out["loading"]["html"], "and must survive a language switch"
+
+    # The states that really are an answer keep the dash.
+    assert out["error"]["shimmer"] is False
+    assert out["error"]["text"] == "\u2014"
+    assert out["error"]["meta"] == "loadFailed"
+    assert out["idle"]["shimmer"] is False
+    assert out["idle"]["text"] == "\u2014"
+
+    # And the shimmer is dropped once the figure lands, not left under the value.
+    assert out["ready"]["shimmer"] is False
+    assert out["ready"]["text"] == "dur:42"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
 def test_equal_sized_server_selections_get_different_keys(tmp_path):
     source = INDEX_HTML.read_text(encoding="utf-8")
     harness = tmp_path / "active-time-key.js"

--- a/tests/test_overview_breakdown_staleness_frontend.py
+++ b/tests/test_overview_breakdown_staleness_frontend.py
@@ -1,0 +1,525 @@
+"""The Overview's two deferred breakdowns must never sit under another range's label.
+
+The date picker writes its new label before the fetch starts, and Apps & Models and
+Combined Models are painted from an idle callback rather than from the render itself.
+So they can lag the range twice over: for the whole /api/usage round trip, and again
+for as long as the browser withholds an idle slot after the KPI cards update.
+
+String assertions cannot see any of that. These run the real clearing, staleness and
+render functions under node against a stub DOM and a hand-driven idle queue.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import tokdash
+
+INDEX_HTML = Path(tokdash.__file__).parent / "static" / "index.html"
+
+pytestmark = pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+
+
+def _extract_js_function(src: str, signature: str) -> str:
+    start = src.find(signature)
+    assert start >= 0, f"{signature} not found"
+    depth = 0
+    body_start = start + len(signature) - 1 if signature.endswith("{") else src.find("{", start)
+    for index in range(body_start, len(src)):
+        if src[index] == "{":
+            depth += 1
+        elif src[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : index + 1]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
+HARNESS = """
+// --- a DOM just deep enough for the functions under test ---------------------
+const nodes = {};
+function node(id) {
+  if (!nodes[id]) {
+    nodes[id] = {
+      id, textContent: '', innerHTML: '', style: {}, attrs: {}, classes: new Set(),
+      classList: {
+        toggle(name, on) { on ? nodes[id].classes.add(name) : nodes[id].classes.delete(name); },
+        contains(name) { return nodes[id].classes.has(name); },
+      },
+      setAttribute(name, value) { nodes[id].attrs[name] = value; },
+      removeAttribute(name) { delete nodes[id].attrs[name]; },
+    };
+  }
+  return nodes[id];
+}
+const document = { getElementById: (id) => node(id) };
+
+// Snapshot of what the two breakdown containers are showing right now.
+const breakdowns = () => ({
+  apps: node('appsBreakdown').innerHTML,
+  models: node('allModelsTable').innerHTML,
+  toggle: node('combinedModelsToggle').style.display,
+  info: node('combinedModelsInfo').textContent,
+});
+const overviewDimmed = () => node('overview-content').classes.has('is-stale');
+const overviewBusy = () => node('overview-content').attrs['aria-busy'] || null;
+
+// --- stand-ins for the rest of the page -------------------------------------
+let updateInFlight = false;
+let inFlightDashboardKey = null;
+let pendingDashboardRequest = null;
+let inFlightResultDiscarded = false;
+let updateIsManualRefresh = false;
+let refreshUiState = 'idle';
+let lastUsageResponse = null;
+let lastSessionsResponses = null;
+let sessionsLoadedKey = null;
+let lastWindowKey = null;
+let overviewBreakdownWindowKey = null;
+let overviewRenderToken = 0;
+let lastCombinedModels = [];
+let lastAppsBreakdown = null;
+let lastByTool = {};
+let includeCodexReviewSessions = null;
+let currentStartDate = null;
+let currentEndDate = null;
+const statsCache = { default: null };
+const overviewActiveTimeState = { status: 'idle', data: null, key: null, requestId: 0 };
+
+const log = { rendered: [], paints: [], stale: [], errors: [], alerts: [] };
+const fetches = [];
+
+// Idle callbacks are queued, never run on their own: the point of these tests is
+// what happens in the gap the browser is free to leave open.
+const idleQueue = [];
+function scheduleIdle(fn) { idleQueue.push(fn); }
+function runIdle() { idleQueue.splice(0).forEach((fn) => fn()); }
+
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+function fetchSelectedServers(url) {
+  const entry = { url, ...deferred() };
+  fetches.push(entry);
+  return entry.promise;
+}
+function fetchSessionsResponses() { return Promise.resolve({}); }
+function combineUsagePayloads(payloads) { return { ...payloads[0] }; }
+function selectedServers() { return [{ id: 'local' }]; }
+function isSessionsActive() { return false; }
+function isOverviewActive() { return true; }
+function renderSessionsTab() {}
+function renderRefreshButton() {}
+function setRefreshUiState(state) { refreshUiState = state; }
+function setDashboardFetchStatus(error) { log.errors.push(String(error && error.message || error)); }
+function updateTimestamp() {}
+function scheduleStatsWarm() {}
+function loadActivityInsights() { return Promise.resolve(); }
+function loadOverviewActiveTime() { return Promise.resolve(); }
+function renderOverviewActiveTime() {}
+function sleep() { return Promise.resolve(); }
+function alert(message) { log.alerts.push(String(message)); }
+function t(key) { return key; }
+
+// renderOverviewTab's own collaborators. The two breakdown painters write a marker
+// so a test can tell painted content from the cleared placeholder.
+function renderOverviewTokenTotal() {}
+function fitOverviewKpis() {}
+function formatCurrency(value) { return String(value); }
+function formatNumber(value) { return String(value); }
+function formatHitRate(value) { return String(value); }
+function formatTokenCount(value) { return String(value); }
+function updateComparisonDeltas() {}
+function updateToolChart() {}
+function updateModelChart() {}
+function updateToolsTable() {}
+function renderOverviewProfilePreview() {}
+function reconcileTodayProfileContribution(cached) { return cached; }
+function updateAppsBreakdown() {
+  log.paints.push('apps');
+  node('appsBreakdown').innerHTML = 'PAINTED:' + lastRenderedRange;
+}
+function updateCombinedModelsTable() {
+  log.paints.push('models');
+  node('allModelsTable').innerHTML = 'PAINTED:' + lastRenderedRange;
+}
+let lastRenderedRange = null;
+
+// --- the code under test ----------------------------------------------------
+__FUNCTIONS__
+
+// renderOverviewTab is extracted whole; wrap it only to record which range painted.
+const realRenderOverviewTab = renderOverviewTab;
+renderOverviewTab = function (data) {
+  lastRenderedRange = data && data.range;
+  log.rendered.push(lastRenderedRange);
+  return realRenderOverviewTab(data);
+};
+
+// --- driving ---------------------------------------------------------------
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+const pick = (range, options) => updateDashboard(null, range, range, options || {});
+
+function fetchFor(range) {
+  return fetches.find((entry) => entry.url.includes(`date_from=${range}`) && !entry.done);
+}
+function resolveRange(range) {
+  const entry = fetchFor(range);
+  if (!entry) throw new Error(`no in-flight request for ${range}`);
+  entry.done = true;
+  entry.resolve([{ server: { id: 'local' }, payload: { range } }]);
+}
+function rejectRange(range, message) {
+  const entry = fetchFor(range);
+  if (!entry) throw new Error(`no in-flight request for ${range}`);
+  entry.done = true;
+  entry.reject(new Error(message));
+}
+
+// One committed, fully painted range, so every scenario starts from a live page
+// rather than from the cold-load state where there is nothing to go stale.
+async function commit(range) {
+  pick(range);
+  await settle();
+  resolveRange(range);
+  await settle(); await settle();
+  runIdle();
+}
+
+async function main() {
+  const scenario = process.argv[2];
+  const out = {};
+
+  if (scenario === 'range-change-clears-before-the-fetch-lands') {
+    await commit('X');
+    out.afterX = breakdowns();
+    out.keyAfterX = overviewBreakdownWindowKey;
+
+    pick('Y');                       // label has already moved
+    await settle();
+    out.duringY = breakdowns();
+    out.dimmedDuringY = overviewDimmed();
+    out.busyDuringY = overviewBusy();
+    out.keyDuringY = overviewBreakdownWindowKey;
+
+    resolveRange('Y');
+    await settle(); await settle();
+    out.dimmedAfterY = overviewDimmed();
+    out.beforeIdle = breakdowns();   // cards are Y's; tables still say loading
+    runIdle();
+    out.afterIdle = breakdowns();
+    out.keyAfterY = overviewBreakdownWindowKey;
+  }
+
+  if (scenario === 'same-range-refresh-keeps-its-content') {
+    await commit('X');
+    log.stale.length = 0;
+
+    pick('X', { forceRefresh: true });
+    await settle();
+    out.duringRefresh = breakdowns();
+    out.dimmed = overviewDimmed();
+    out.stale = [...log.stale];
+    resolveRange('X');
+    await settle(); await settle();
+    runIdle();
+    out.after = breakdowns();
+  }
+
+  if (scenario === 'a-superseded-idle-callback-paints-nothing') {
+    await commit('X');
+    log.paints.length = 0;
+
+    // X reloads and commits, but the browser withholds its idle slot...
+    pick('X2');
+    await settle();
+    resolveRange('X2');
+    await settle(); await settle();
+    // ...and the user moves on before it arrives.
+    pick('Y');
+    await settle();
+    resolveRange('Y');
+    await settle(); await settle();
+
+    runIdle();                       // four callbacks queued, only Y's may paint
+    out.paints = log.paints;
+    out.breakdowns = breakdowns();
+    out.key = overviewBreakdownWindowKey;
+  }
+
+  if (scenario === 'queued-callbacks-die-when-the-range-changes') {
+    // X commits but the browser has not handed out an idle slot yet...
+    pick('X');
+    await settle();
+    resolveRange('X');
+    await settle(); await settle();
+    log.paints.length = 0;
+
+    // ...and the user moves on while X's callbacks are still queued. Y has not
+    // even come back yet, so nothing has bumped the token on Y's behalf.
+    pick('Y');
+    await settle();
+    out.duringY = breakdowns();
+    runIdle();
+    out.afterStaleIdle = breakdowns();
+    out.paints = [...log.paints];
+    out.key = overviewBreakdownWindowKey;
+
+    resolveRange('Y');
+    await settle(); await settle();
+    runIdle();
+    out.afterY = breakdowns();
+    out.keyAfterY = overviewBreakdownWindowKey;
+  }
+
+  if (scenario === 'back-to-the-in-flight-range') {
+    await commit('T');
+    pick('T2');                      // in flight
+    await settle();
+    pick('Y');                       // queued
+    await settle();
+    pick('T2');                      // back again; cancels the queue
+    await settle();
+    resolveRange('T2');
+    await settle(); await settle();
+    runIdle();
+    out.breakdowns = breakdowns();
+    out.key = overviewBreakdownWindowKey;
+    out.dimmed = overviewDimmed();
+    out.busy = overviewBusy();
+    out.fetchedY = fetches.some((entry) => entry.url.includes('date_from=Y'));
+  }
+
+  if (scenario === 'a-failed-range-change-stays-marked') {
+    await commit('X');
+    pick('Y');
+    await settle();
+    out.dimmedWhileLoading = overviewDimmed();
+    rejectRange('Y', 'boom');
+    await settle(); await settle();
+    runIdle();
+    out.dimmedAfterFailure = overviewDimmed();
+    out.busyAfterFailure = overviewBusy();
+    out.breakdownsAfterFailure = breakdowns();
+    out.errors = log.errors;
+    out.updateInFlight = updateInFlight;
+
+    // Recovering onto a range that does load must clear the marking again.
+    pick('Z');
+    await settle();
+    resolveRange('Z');
+    await settle(); await settle();
+    runIdle();
+    out.dimmedAfterRecovery = overviewDimmed();
+    out.breakdownsAfterRecovery = breakdowns();
+  }
+
+  if (scenario === 'a-failed-same-range-refresh-is-not-marked') {
+    await commit('X');
+    pick('X', { forceRefresh: true });
+    await settle();
+    out.dimmedWhileRefreshing = overviewDimmed();
+    rejectRange('X', 'boom');
+    await settle(); await settle();
+    runIdle();
+    out.dimmedAfterFailure = overviewDimmed();
+    out.breakdowns = breakdowns();
+    out.errors = log.errors;
+  }
+
+  if (scenario === 're-render-of-the-same-range-does-not-clear') {
+    await commit('X');
+    const before = breakdowns();
+    renderOverviewTab({ range: 'X' });   // what a tab switch or language change does
+    out.beforeIdle = breakdowns();
+    runIdle();
+    out.afterIdle = breakdowns();
+    out.unchangedWhileRerendering = JSON.stringify(before) === JSON.stringify(out.beforeIdle);
+    out.key = overviewBreakdownWindowKey;
+    out.dimmed = overviewDimmed();
+  }
+
+  process.stdout.write(JSON.stringify(out));
+}
+
+main();
+"""
+
+
+def _run(tmp_path: Path, scenario: str) -> dict:
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    functions = "\n".join(
+        _extract_js_function(source, signature)
+        for signature in (
+            "function windowKeyFor(customDays, dateFrom, dateTo) {",
+            "function activeTimeRequestKey(customDays, dateFrom, dateTo) {",
+            "function invalidateOverviewActiveTime(customDays, dateFrom, dateTo) {",
+            "function clearOverviewBreakdowns() {",
+            "function setOverviewState({ pending = false, stale = false } = {}) {",
+            "function renderOverviewTab(data) {",
+            "async function updateDashboard(customDays = null, dateFrom = null, dateTo = null, options = {}) {",
+        )
+    )
+    # `function` declarations cannot be reassigned under the wrapper above.
+    functions = functions.replace(
+        "function renderOverviewTab(data) {", "var renderOverviewTab = function (data) {", 1
+    )
+    harness = tmp_path / f"{scenario}.js"
+    harness.write_text(HARNESS.replace("__FUNCTIONS__", functions), encoding="utf-8")
+    result = subprocess.run(
+        ["node", str(harness), scenario],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    return json.loads(result.stdout)
+
+
+def _is_loading(markup: str) -> bool:
+    return "tokdash-loading-placeholder" in markup
+
+
+def test_a_range_change_clears_the_breakdowns_before_its_data_arrives(tmp_path):
+    """The label moves first, so the old rows must go with it, not with the response."""
+    out = _run(tmp_path, "range-change-clears-before-the-fetch-lands")
+
+    assert out["afterX"]["apps"] == "PAINTED:X"
+    assert out["keyAfterX"] == "X_X"
+
+    during = out["duringY"]
+    assert _is_loading(during["apps"]), "Apps & Models must not survive into Y's label"
+    assert _is_loading(during["models"]), "Combined Models must not survive into Y's label"
+    assert during["info"] == "", "the row count belonged to X"
+    assert during["toggle"] == "none", "so did the show-all toggle"
+    assert out["keyDuringY"] is None
+    assert out["dimmedDuringY"] is True
+    assert out["busyDuringY"] == "true", "a fetch really is in progress here"
+
+    # The cards commit on the response; the tables wait for their idle slot. That gap
+    # is the bug's original window — it must show loading, never X's rows.
+    assert out["dimmedAfterY"] is False
+    assert _is_loading(out["beforeIdle"]["apps"])
+    assert out["afterIdle"]["apps"] == "PAINTED:Y"
+    assert out["afterIdle"]["models"] == "PAINTED:Y"
+    assert out["keyAfterY"] == "Y_Y"
+
+
+def test_a_same_range_refresh_keeps_its_content(tmp_path):
+    """Refresh re-reads the range already on screen; blanking it would just flicker."""
+    out = _run(tmp_path, "same-range-refresh-keeps-its-content")
+
+    assert out["duringRefresh"]["apps"] == "PAINTED:X", "a same-range refresh must not clear"
+    assert out["duringRefresh"]["models"] == "PAINTED:X"
+    assert out["dimmed"] is False, "the refresh button reports this load itself"
+    assert out["stale"] == []
+    assert out["after"]["apps"] == "PAINTED:X"
+
+
+def test_a_superseded_idle_callback_paints_nothing(tmp_path):
+    """A callback queued for a range the user has left must not fill the cleared tables."""
+    out = _run(tmp_path, "a-superseded-idle-callback-paints-nothing")
+
+    assert out["paints"] == ["apps", "models"], "only the current range may paint"
+    assert out["breakdowns"]["apps"] == "PAINTED:Y"
+    assert out["breakdowns"]["models"] == "PAINTED:Y"
+    assert out["key"] == "Y_Y"
+
+
+def test_returning_to_the_in_flight_range_still_paints_it(tmp_path):
+    """T → Y → T cancels Y's request; the clearing must not strand T's tables empty."""
+    out = _run(tmp_path, "back-to-the-in-flight-range")
+
+    assert out["fetchedY"] is False, "Y was superseded before it ran"
+    assert out["breakdowns"]["apps"] == "PAINTED:T2"
+    assert out["breakdowns"]["models"] == "PAINTED:T2"
+    assert out["key"] == "T2_T2"
+    assert out["dimmed"] is False
+    assert out["busy"] is None
+
+
+def test_idle_callbacks_queued_before_the_range_moved_paint_nothing(tmp_path):
+    """The gap the clear cannot see: X committed, its tables not yet painted, then Y.
+
+    Nothing has rendered for Y at this point, so nothing has bumped the token on Y's
+    behalf. Only the clear itself can invalidate X's queued callbacks.
+    """
+    out = _run(tmp_path, "queued-callbacks-die-when-the-range-changes")
+
+    assert _is_loading(out["duringY"]["apps"]), "the clear runs when the range moves"
+    assert out["paints"] == [], "X's queued callbacks must not paint under Y's label"
+    assert _is_loading(out["afterStaleIdle"]["apps"]), "and must leave the loading state alone"
+    assert _is_loading(out["afterStaleIdle"]["models"])
+    assert out["key"] is None
+    # Y still paints normally once its own response lands.
+    assert out["afterY"]["apps"] == "PAINTED:Y"
+    assert out["keyAfterY"] == "Y_Y"
+
+
+def test_a_failed_range_change_stays_marked(tmp_path):
+    """A failed range change leaves another range's numbers under the new label.
+
+    The only other signal is #lastUpdate turning into "Load failed" — one small line
+    in the header. Restoring full contrast would present the previous range as this
+    one's answer, so the marking stays until a load actually lands.
+    """
+    out = _run(tmp_path, "a-failed-range-change-stays-marked")
+
+    assert out["dimmedWhileLoading"] is True
+    assert out["errors"] == ["boom"]
+    assert out["updateInFlight"] is False
+    assert out["dimmedAfterFailure"] is True, "what is on screen is still X's"
+    # aria-busy means an update is in progress. This one is over and failed, so the
+    # region must stop claiming to be busy even though it stays visually marked —
+    # otherwise assistive tech waits for an update that is never coming.
+    assert out["busyAfterFailure"] is None
+    # Restoring the previous range's rows is deliberate: a permanent loading shimmer
+    # for a load that already failed would be worse. They stay marked instead.
+    assert out["breakdownsAfterFailure"]["apps"] == "PAINTED:X"
+    assert out["dimmedAfterRecovery"] is False, "a load that lands clears the marking"
+    assert out["breakdownsAfterRecovery"]["apps"] == "PAINTED:Z"
+
+
+def test_a_failed_same_range_refresh_is_not_marked(tmp_path):
+    """The content still belongs to the range on the label, so nothing is misleading."""
+    out = _run(tmp_path, "a-failed-same-range-refresh-is-not-marked")
+
+    assert out["dimmedWhileRefreshing"] is False
+    assert out["dimmedAfterFailure"] is False
+    assert out["breakdowns"]["apps"] == "PAINTED:X"
+    assert out["errors"] == ["boom"]
+
+
+def test_re_rendering_the_same_range_does_not_clear(tmp_path):
+    """Tab switches and language changes re-render; they are not range changes."""
+    out = _run(tmp_path, "re-render-of-the-same-range-does-not-clear")
+
+    assert out["unchangedWhileRerendering"] is True, "a re-render must not blank the tables"
+    assert out["afterIdle"]["apps"] == "PAINTED:X"
+    assert out["key"] == "X_X"
+    assert out["dimmed"] is False
+
+
+def test_the_cleared_markup_matches_the_placeholder_the_page_ships(tmp_path):
+    """Clearing reuses the initial markup, so the two cannot drift apart."""
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    cleared = _extract_js_function(source, "function clearOverviewBreakdowns() {")
+
+    for shipped in (
+        '<p class="tokdash-loading-placeholder text-center py-10" style="color: var(--color-muted);">'
+        '<span class="tokdash-loading-label" data-i18n="loading">Loading…</span></p>',
+        '<td colspan="8" class="tokdash-loading-placeholder text-center py-10" style="color: var(--color-muted);">'
+        '<span class="tokdash-loading-label" data-i18n="loading">Loading…</span></td>',
+    ):
+        assert shipped in source, "the initial markup moved; update clearOverviewBreakdowns"
+
+    # Same classes, same colspan, and still translatable after being rewritten.
+    assert cleared.count("tokdash-loading-placeholder") == 2
+    assert 'data-i18n="loading"' in cleared
+    assert 'colspan="8"' in cleared
+    assert "style=\"color: var(--color-muted);\"" in cleared


### PR DESCRIPTION
Closes the last open point of #23 (point 6), and records why point 5 is not being built.

## Point 6 — deferred breakdowns outliving their range

The date picker writes its new label in `commitDateSelection` before any fetch starts, and Apps & Models / Combined Models are painted from `scheduleIdle` rather than from the render. So both tables could sit under a range they did not belong to twice over: for the whole `/api/usage` round trip, and again for up to the ~750 ms idle timeout after the KPI cards had already updated.

- `clearOverviewBreakdowns()` resets both to the loading placeholder the page already ships in its initial markup — same classes, same colspan, still carrying `data-i18n="loading"` so a language switch re-translates it.
- Clearing also bumps the render token, retiring idle callbacks queued by the outgoing range. Nothing has rendered for the incoming range at that point, so the token alone would still let one repaint what was just cleared.
- `setOverviewState({pending, stale})` dims the Overview data region while it is showing a window other than the one on the label. The date control, quick ranges and refresh button live outside the tab panes and stay at full contrast.
- The marking comes off when a load **lands**, not when one settles. A failed range change restores the previous range's cards and tables rather than leaving a shimmer for a load that is over, and "Load failed" in `#lastUpdate` is one small line in the header — so it stays dimmed until something loads. It keeps only the dim: `aria-busy` means an update is in progress, so continuing to assert it after a failure would leave assistive tech waiting for an update that is never coming.
- A same-range refresh keeps its content and is not dimmed; the refresh button reports that load itself.

## Agent Time card

Pre-existing on 1.8.1, found while testing this. The card is fetched from `/api/active-time` after `/api/usage` lands, so for 1–3 s after a range change the rest of the KPI row has answered and this one still shows the em dash it was blanked to — which reads as "no agent time in this range" rather than "not back yet". It was the one deferred surface on the Overview not using the shimmer the rest of the tab uses. Measured cold on both builds; the gap is the same either way.

## Point 5 — UTC aggregate, not building it

The ask was a UTC-day aggregate so Codex Profile buckets could be compared directly. Aligning the boundary would not make the two agree:

- the Profile is server-side and account-wide, so it counts cloud tasks and other machines that never touch local disk — unbounded, and not closable locally;
- Codex reports `total_tokens` as `input_tokens + output_tokens` with reasoning inside output, while Tokdash adds reasoning on top, so the totals differ by ~0.1–0.5%/day regardless of boundary.

A second number that still did not reconcile, with no way to tell which difference you were looking at, is worse than one honest number and an explanation. `docs/reference/DAY_BOUNDARIES.md` documents the local-day boundary and both other gaps instead.

## Tests

- `tests/test_overview_breakdown_staleness_frontend.py` (new) — runs the real `clearOverviewBreakdowns`, `setOverviewState`, `renderOverviewTab` and `updateDashboard` under node against a stub DOM and a hand-driven idle queue, so the gap the browser is free to leave open is directly observable. Nine cases including callbacks queued before the range moved, a failed range change staying marked and then recovering, a failed same-range refresh not being marked, and a guard that the cleared markup matches the shipped placeholder.
- `tests/test_overview_active_time.py` — new case driving the renderer across loading / error / idle / ready.
- `tests/test_dashboard_queue_frontend.py` — two stubs for the new calls; its existing cases pass unchanged.

1046 passed, 4 skipped. Also verified in headless Chromium against a real store: the clear, the dim at 0.55 opacity with `aria-busy`, a normal range change painting through, a failed range change holding the dim with `aria-busy` dropped, and recovery clearing it.