### PR TITLE
Add WorkBuddy usage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 | DeepSeek Harness | ✅ | ✅ |
 | Reasonix | ✅ | ✅ |
 | **ZCode** | ✅ | ✅ |
+| **WorkBuddy** | ✅ | — |
 
 See [Supported clients](docs/reference/SUPPORTED_CLIENTS.md) for local data paths, overrides, and source-specific accounting notes.
 
@@ -503,6 +504,8 @@ DeepSeek Harness (`dsh`) usage and sessions are read locally from `$DSH_HOME/ses
 
 Reasonix usage and sessions are read locally from `$REASONIX_HOME` (default `~/.reasonix`): per-request tokens from the daily `stats/YYYY-MM-DD.jsonl` logs, and session structure from `projects/*/sessions/*.jsonl`. Reasonix talks to whatever providers its `config.toml` names, so the `provider/model` pair in each row is attributed and priced through the normal pricing database; self-hosted models with no published rate count tokens at zero cost. Reasonix records usage per request and never stamps a session id on it, so Session Explorer rows show turns, project and timing without token counts — Overview and Stats carry the full totals.
 ZCode usage is read locally from `$ZCODE_HOME/cli/db/db.sqlite` (default `~/.zcode/cli/db/db.sqlite`; `ZCODE_HOME` follows ZCode's own setting). Each `model_usage` row is one model request, retries included, and the row's `model_id` is priced through the normal pricing database while `provider_id` (e.g. `builtin:zai-start-plan`) is kept as a label. ZCode's `input_tokens` counts cached and uncached prompt tokens together, so the cached share is split into its own bucket and billed at the cache rate, and reasoning tokens are displayed disjoint from output while still billing at the output rate. ZCode also appears in the Sessions tab: turns are read from the same database, billed per (turn, model) with the same rules, top-level sessions only, and a turn that produced no billable tokens still credits its measured time to the tool's active time. ZCode's Coding Plan quota is remote account data and is out of scope for the local parser.
+
+WorkBuddy usage is read locally from `~/.workbuddy-ai/projects/*/*.jsonl` transcripts (`WORKBUDDY_DATA_DIR` takes a comma-separated list of roots to point Tokdash at other stores, e.g. a Windows data dir from WSL). Each assistant message row is one model call; the cached share inside `prompt_tokens` is split into its own bucket and billed at the cache rate, and reasoning tokens are displayed disjoint from output while billing at the output rate. The model id is kept verbatim: explicit ids (e.g. gpt-5.5) price through the normal pricing database, while the Auto router alias (`default-model`) is absent from the pricing DB and costs 0.00. The per-turn `credit` value is stored as metadata only and does not affect cost. WorkBuddy does not appear in the Sessions tab.
 
 `tokdash setup` offers an optional quota step (per-provider network consent, default No, plus the poll interval), and `tokdash doctor` reports the quota state: master switch, per-provider consent, kill switch, effective interval and its source, last poll time, and the stored snapshot count.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -94,6 +94,7 @@
 | DeepSeek Harness | ✅ | ✅ |
 | Reasonix | ✅ | ✅ |
 | **ZCode** | ✅ | ✅ |
+| **WorkBuddy** | ✅ | — |
 
 本地数据路径、覆盖变量与各来源的计费说明见[已支持客户端](docs/reference/SUPPORTED_CLIENTS.md)。
 
@@ -490,6 +491,8 @@ DeepSeek Harness（`dsh`）的用量与会话从 `$DSH_HOME/sessions/*/*/session
 
 Reasonix 的用量与会话从 `$REASONIX_HOME`（默认 `~/.reasonix`）本地读取：逐次请求的 token 来自每日 `stats/YYYY-MM-DD.jsonl` 日志，会话结构来自 `projects/*/sessions/*.jsonl`。Reasonix 连接的是其 `config.toml` 中配置的任意供应商，因此每行的 `provider/model` 会照常归因并按现有价格库计价；没有公开价格的自建模型只统计 token，费用为 0。Reasonix 按请求记录用量，且不会写入会话 ID，所以会话浏览器中的行只有轮次、项目与时长，没有 token 数 —— 完整总量在概览与统计中。
 ZCode 的用量从 `$ZCODE_HOME/cli/db/db.sqlite`（默认 `~/.zcode/cli/db/db.sqlite`，`ZCODE_HOME` 跟随 ZCode 自身设置）本地读取。`model_usage` 表中每行是一次模型请求（含重试），该行的 `model_id` 照常按现有价格库计价，`provider_id`（如 `builtin:zai-start-plan`）只作标签。ZCode 的 `input_tokens` 把已缓存与未缓存的提示词 token 合在一起计数，因此缓存部分单独分桶、按缓存费率计费；reasoning token 与 output 分开显示，但按 output 费率计费。ZCode 也会出现在 Sessions 标签页：turn 从同一数据库读取，按 (turn, model) 用相同规则计费，只读顶层会话；没有可计费 token 的 turn 仍会将其测量时长计入该工具的活跃时间。ZCode Coding Plan 额度属于远程账户数据，不在本地解析范围内。
+
+WorkBuddy 的用量从 `~/.workbuddy-ai/projects/*/*.jsonl` 会话日志本地读取（`WORKBUDDY_DATA_DIR` 可指定逗号分隔的根目录列表，指向其他存储位置，例如 WSL 下的 Windows 数据目录）。每条 assistant 消息行对应一次模型调用；`prompt_tokens` 中包含缓存部分，缓存部分单独分桶、按缓存费率计费；reasoning token 与 output 分开显示，但按 output 费率计费。模型 ID 原样保留：显式模型 ID（如 gpt-5.5）照常按现有价格库计价，Auto 路由别名（`default-model`）不在价格库中，费用为 0.00。每轮的 `credit` 值仅作为元数据存储，不计入费用。WorkBuddy 不出现在 Sessions 标签页。
 
 `tokdash setup` 会提供一个可选的额度步骤（按服务商的网络授权，默认为否，以及轮询间隔），`tokdash doctor` 会报告额度状态：总开关、按服务商授权、终止开关、生效间隔及其来源、上次轮询时间，以及已保存的快照数量。
 

--- a/docs/reference/SUPPORTED_CLIENTS.md
+++ b/docs/reference/SUPPORTED_CLIENTS.md
@@ -37,6 +37,7 @@ Tokdash reads usage **locally** from each tool's own session/log files — nothi
 - **DeepSeek Harness**: `$DSH_HOME/sessions/<project-key>/<session-id>/session.jsonl.zstd` (or an uncompressed `session.jsonl`; `DSH_HOME` defaults to `~/.dsh`)
 - **Reasonix**: `$REASONIX_HOME/stats/YYYY-MM-DD.jsonl` for tokens and cost, and `$REASONIX_HOME/projects/*/sessions/*.jsonl` for Session Explorer (`REASONIX_HOME` defaults to `~/.reasonix`). Reasonix records usage per request rather than per session, so session rows carry turns and timing but no token counts; the totals in Overview and Stats are complete.
 - **ZCode**: `$ZCODE_HOME/cli/db/db.sqlite` (default `~/.zcode/cli/db/db.sqlite`, WAL mode; `ZCODE_HOME` follows ZCode's own setting). One `model_usage` row per model request; the cached share inside `input_tokens` is split out and billed at the cache rate. The Sessions tab reads `turn_usage` + `model_usage` from the same database (top-level sessions only; zero-token turns count as activity for active time).
+- **WorkBuddy**: `~/.workbuddy-ai/projects/*/*.jsonl` transcripts (`WORKBUDDY_DATA_DIR` override, comma-separated). One assistant message row per model call; the cached share inside `prompt_tokens` is split out and billed at the cache rate, reasoning is disjoint from output but billed at the output rate, and the per-turn `credit` is kept as metadata only. Auto router aliases (e.g. `default-model`) are absent from the pricing DB and cost 0.00. No Sessions tab.
 
 ---
 

--- a/src/tokdash/clientpaths.py
+++ b/src/tokdash/clientpaths.py
@@ -303,6 +303,32 @@ def reasonix_projects_dir() -> Path:
     return reasonix_home() / "projects"
 
 
+# --- WorkBuddy ----------------------------------------------------------------
+
+
+def workbuddy_roots() -> List[Path]:
+    """WorkBuddy data roots: ``$WORKBUDDY_DATA_DIR`` (comma-separated) else ``~/.workbuddy-ai``.
+
+    The native path is the same on macOS, Linux, and Windows. On WSL the user
+    points the override at the Windows store (``/mnt/c/Users/<user>/.workbuddy-ai``),
+    or at several roots at once, comma-separated.
+    """
+    explicit = os.environ.get("WORKBUDDY_DATA_DIR", "")
+    roots: List[Path] = []
+    for part in explicit.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        path = Path(part).expanduser()
+        if not path.is_absolute():
+            path = path.resolve()
+        if path not in roots:
+            roots.append(path)
+    if roots:
+        return roots
+    return [Path.home() / ".workbuddy-ai"]
+
+
 # --- OpenClaw -----------------------------------------------------------------
 
 

--- a/src/tokdash/sources/coding_tools.py
+++ b/src/tokdash/sources/coding_tools.py
@@ -3532,6 +3532,222 @@ class ReasonixParser(BaseParser):
         return out
 
 
+class WorkBuddyParser(BaseParser):
+    """Parse WorkBuddy (Tencent AI assistant) desktop transcripts.
+
+    WorkBuddy appends one JSON row per event to
+    ``~/.workbuddy-ai/projects/<cwd-slug>/<sessionId>.jsonl`` (same layout on
+    Windows, macOS, and Linux; ``$WORKBUDDY_DATA_DIR`` points the reader at
+    other stores, e.g. a Windows dir from WSL). Assistant message rows carry
+    the per-call usage in ``providerData``:
+
+      {"id": <chat.completion id>, "timestamp": <epoch ms>,
+       "type": "message", "role": "assistant",
+       "providerData": {"messageId": <id>, "model": <id or router alias>,
+                        "rawUsage": {OpenAI-style snake-case usage + credit},
+                        "usage": {camel-case mirror + details arrays}}}
+
+    ``rawUsage`` is the primary adapter; ``usage`` is used only when
+    ``rawUsage`` is absent. ``message.usage`` is deliberately never read: it
+    mixes conventions (``input_tokens`` includes the cached slice while
+    ``cache_read_input_tokens`` repeats it).
+
+    Normalized entry mapping (spec: docs/local/20260821_workbuddy_support/
+    FINDINGS.md, phase 1):
+      model      <- providerData.model VERBATIM (router aliases such as
+                    ``default-model`` are absent from the pricing DB and
+                    cost 0.00; PricingDatabase normalizes for lookup)
+      input      <- prompt minus cache (``prompt_cache_miss_tokens`` when
+                    present; the cache slice is inside prompt_tokens)
+      output     <- completion minus reasoning (reasoning is a subset of
+                    completion, OpenAI convention)
+      cacheRead  <- WorkBuddy UsageUtils read precedence, clamped to prompt
+      cacheWrite <- WorkBuddy write precedence (0 in all captured rows)
+      cost       <- get_cost(model, fresh, FULL completion, cached, write)
+      workbuddy_credit <- rawUsage.credit, per-turn credit, metadata only
+
+    Rows are parsed fail-soft: a bad line skips itself, never the file.
+    """
+
+    source_name = "workbuddy"
+    sync_capability = SourceSyncCapability(
+        mode="file_replace",
+        append_jsonl=True,
+        reason=(
+            "WorkBuddy transcripts are append-only JSONL and every usage row "
+            "carries a stable providerData.messageId, so entry_id is stable per call."
+        ),
+    )
+
+    def __init__(self, pricing_db: PricingDatabase):
+        super().__init__(pricing_db)
+        self.roots = clientpaths.workbuddy_roots()
+
+    @staticmethod
+    def _f(value: Any) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+    @classmethod
+    def _first_positive(cls, *values: Any) -> int:
+        """First value in the chain that is a positive integer, else 0."""
+        for value in values:
+            n = cls._i(value)
+            if n > 0:
+                return n
+        return 0
+
+    def _usage_from_provider_data(self, pd: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Normalize providerData.rawUsage (primary) or providerData.usage (fallback).
+
+        Returns None when neither carries usable (non-zero) usage.
+        """
+        ru = pd.get("rawUsage")
+        if isinstance(ru, dict) and ru:
+            prompt = self._i(ru.get("prompt_tokens"))
+            details = ru.get("prompt_tokens_details")
+            # Read chain: WorkBuddy UsageUtils precedence, exactly.
+            cached = self._first_positive(
+                ru.get("cache_read_input_tokens"),
+                ru.get("cacheReadInputTokens"),
+                details.get("cached_tokens") if isinstance(details, dict) else None,
+                ru.get("prompt_cache_hit_tokens"),
+            )
+            cached = min(cached, prompt)
+            write = self._first_positive(
+                ru.get("cache_creation_input_tokens"),
+                ru.get("cacheCreationInputTokens"),
+                ru.get("prompt_cache_write_tokens"),
+            )
+            missed = self._i(ru.get("prompt_cache_miss_tokens"))
+            completion = self._i(ru.get("completion_tokens"))
+            comp_details = ru.get("completion_tokens_details")
+            reasoning = self._i(
+                comp_details.get("reasoning_tokens") if isinstance(comp_details, dict) else None
+            ) or self._i(ru.get("completion_thinking_tokens"))
+            credit = self._f(ru.get("credit"))
+        else:
+            usage = pd.get("usage")
+            if not isinstance(usage, dict) or not usage:
+                return None
+            # Fallback schema: camel-case, cache/reasoning in details arrays,
+            # no cache-write column.
+            prompt = self._i(usage.get("inputTokens"))
+            cached = 0
+            for detail in usage.get("inputTokensDetails") or []:
+                if isinstance(detail, dict):
+                    cached += self._i(detail.get("cached_tokens"))
+            cached = min(cached, prompt)
+            write = 0
+            missed = 0
+            completion = self._i(usage.get("outputTokens"))
+            reasoning = 0
+            for detail in usage.get("outputTokensDetails") or []:
+                if isinstance(detail, dict):
+                    reasoning += self._i(detail.get("reasoning_tokens"))
+            credit = self._f(usage.get("credit"))
+
+        if prompt <= 0 and completion <= 0:
+            return None
+        model = str(pd.get("model") or pd.get("requestModelId") or "workbuddy-auto")
+        return {
+            "model": model,
+            "prompt": prompt,
+            "cached": cached,
+            "write": write,
+            "missed": missed,
+            "completion": completion,
+            "reasoning": reasoning,
+            "credit": credit,
+        }
+
+    def _build_entry(self, usage: Dict[str, Any], ts_ms: int, call_id: str) -> Dict[str, Any]:
+        prompt = usage["prompt"]
+        cached = usage["cached"]
+        write = usage["write"]
+        completion = usage["completion"]
+        reasoning = usage["reasoning"]
+        # The cache slice is inside prompt_tokens; prefer the explicit miss
+        # count when present, and never go negative.
+        fresh = max(0, usage["missed"] or (prompt - cached))
+        # Reasoning is a subset of completion and compute.py adds it on top of
+        # output, so it must be split out of output here.
+        output = max(0, completion - reasoning)
+        return {
+            "source": self.source_name,
+            "model": usage["model"],
+            "provider": "",
+            "input": fresh,
+            "output": output,
+            "cacheRead": cached,
+            "cacheWrite": write,
+            "reasoning": reasoning,
+            "cost": self.pricing_db.get_cost(usage["model"], fresh, completion, cached, write),
+            "workbuddy_credit": usage["credit"],
+            "entry_id": f"workbuddy:{call_id}",
+            "message_id": call_id,
+            "timestamp": int(ts_ms),
+        }
+
+    def _entry_from_row(self, record: Dict[str, Any], seen_call_ids: set) -> Optional[Dict[str, Any]]:
+        if record.get("type") != "message" or record.get("role") != "assistant":
+            return None
+        pd = record.get("providerData")
+        if not isinstance(pd, dict):
+            return None
+        usage = self._usage_from_provider_data(pd)
+        if usage is None:
+            return None
+        call_id = str(pd.get("messageId") or record.get("id") or "").strip()
+        ts_ms = self._i(record.get("timestamp"))
+        if not call_id or ts_ms <= 0:
+            return None
+        if call_id in seen_call_ids:
+            return None
+        seen_call_ids.add(call_id)
+        return self._build_entry(usage, ts_ms, call_id)
+
+    def _file_signatures(self) -> tuple:
+        def _scan() -> tuple:
+            sigs: List[Tuple[str, int, int]] = []
+            for root in self.roots:
+                sigs.extend(_glob_sigs(str(root / "projects" / "*" / "*.jsonl")))
+            return tuple(sorted(set(sigs)))
+
+        cache_key = "workbuddy:" + "|".join(str(r) for r in self.roots)
+        return _timed_sigs(cache_key, _scan)
+
+    def _parse_all(self) -> List[Dict[str, Any]]:
+        out: List[Dict[str, Any]] = []
+        seen_call_ids: set[str] = set()
+        for path_str, _, _ in self._file_signatures():
+            try:
+                handle = open(path_str, "r", encoding="utf-8")
+            except OSError:
+                continue
+            with handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                        entry = (
+                            self._entry_from_row(record, seen_call_ids)
+                            if isinstance(record, dict)
+                            else None
+                        )
+                    except Exception:
+                        logger.warning("workbuddy: skipping malformed row in %s", path_str)
+                        entry = None
+                    if entry is not None:
+                        out.append(entry)
+        out.sort(key=lambda item: int(item.get("timestamp", 0) or 0))
+        return out
+
+
 class CodingToolsUsageTracker:
     """Registry-driven tracker for coding clients."""
 
@@ -3559,6 +3775,7 @@ class CodingToolsUsageTracker:
             "zcode": ZCodeParser(self.pricing_db),
             "dsh": DSHParser(self.pricing_db),
             "reasonix": ReasonixParser(self.pricing_db),
+            "workbuddy": WorkBuddyParser(self.pricing_db),
         }
 
     def collect(self, since_date: Optional[datetime] = None, until_date: Optional[datetime] = None, sources: Optional[List[str]] = None):

--- a/src/tokdash/sources/coding_tools.py
+++ b/src/tokdash/sources/coding_tools.py
@@ -3562,8 +3562,10 @@ class WorkBuddyParser(BaseParser):
       output     <- completion minus reasoning (reasoning is a subset of
                     completion, OpenAI convention)
       cacheRead  <- WorkBuddy UsageUtils read precedence, clamped to prompt
-      cacheWrite <- WorkBuddy write precedence (0 in all captured rows)
-      cost       <- get_cost(model, fresh, FULL completion, cached, write)
+      cacheWrite <- 0: the vendor's write chain is extracted but unbilled
+                    until it is established whether prompt_tokens /
+                    prompt_cache_miss_tokens include the write slice
+      cost       <- get_cost(model, fresh, FULL completion, cached, 0)
       workbuddy_credit <- rawUsage.credit, per-turn credit, metadata only
 
     Rows are parsed fail-soft: a bad line skips itself, never the file.
@@ -3606,7 +3608,7 @@ class WorkBuddyParser(BaseParser):
         """
         ru = pd.get("rawUsage")
         if isinstance(ru, dict) and ru:
-            prompt = self._i(ru.get("prompt_tokens"))
+            prompt = max(0, self._i(ru.get("prompt_tokens")))
             details = ru.get("prompt_tokens_details")
             # Read chain: WorkBuddy UsageUtils precedence, exactly.
             cached = self._first_positive(
@@ -3615,14 +3617,15 @@ class WorkBuddyParser(BaseParser):
                 details.get("cached_tokens") if isinstance(details, dict) else None,
                 ru.get("prompt_cache_hit_tokens"),
             )
-            cached = min(cached, prompt)
+            # Write chain: extracted in WorkBuddy order, but deliberately
+            # unbilled (see _build_entry).
             write = self._first_positive(
                 ru.get("cache_creation_input_tokens"),
                 ru.get("cacheCreationInputTokens"),
                 ru.get("prompt_cache_write_tokens"),
             )
-            missed = self._i(ru.get("prompt_cache_miss_tokens"))
-            completion = self._i(ru.get("completion_tokens"))
+            missed = max(0, self._i(ru.get("prompt_cache_miss_tokens")))
+            completion = max(0, self._i(ru.get("completion_tokens")))
             comp_details = ru.get("completion_tokens_details")
             reasoning = self._i(
                 comp_details.get("reasoning_tokens") if isinstance(comp_details, dict) else None
@@ -3634,22 +3637,26 @@ class WorkBuddyParser(BaseParser):
                 return None
             # Fallback schema: camel-case, cache/reasoning in details arrays,
             # no cache-write column.
-            prompt = self._i(usage.get("inputTokens"))
+            prompt = max(0, self._i(usage.get("inputTokens")))
             cached = 0
             for detail in usage.get("inputTokensDetails") or []:
                 if isinstance(detail, dict):
-                    cached += self._i(detail.get("cached_tokens"))
-            cached = min(cached, prompt)
+                    cached += max(0, self._i(detail.get("cached_tokens")))
             write = 0
             missed = 0
-            completion = self._i(usage.get("outputTokens"))
+            completion = max(0, self._i(usage.get("outputTokens")))
             reasoning = 0
             for detail in usage.get("outputTokensDetails") or []:
                 if isinstance(detail, dict):
-                    reasoning += self._i(detail.get("reasoning_tokens"))
+                    reasoning += max(0, self._i(detail.get("reasoning_tokens")))
             credit = self._f(usage.get("credit"))
 
-        if prompt <= 0 and completion <= 0:
+        # Subset counters can never exceed their parent, no matter what the
+        # provider stamped.
+        cached = min(max(0, cached), prompt)
+        reasoning = min(max(0, reasoning), completion)
+
+        if prompt == 0 and completion == 0:
             return None
         model = str(pd.get("model") or pd.get("requestModelId") or "workbuddy-auto")
         return {
@@ -3666,7 +3673,6 @@ class WorkBuddyParser(BaseParser):
     def _build_entry(self, usage: Dict[str, Any], ts_ms: int, call_id: str) -> Dict[str, Any]:
         prompt = usage["prompt"]
         cached = usage["cached"]
-        write = usage["write"]
         completion = usage["completion"]
         reasoning = usage["reasoning"]
         # The cache slice is inside prompt_tokens; prefer the explicit miss
@@ -3675,6 +3681,10 @@ class WorkBuddyParser(BaseParser):
         # Reasoning is a subset of completion and compute.py adds it on top of
         # output, so it must be split out of output here.
         output = max(0, completion - reasoning)
+        # usage["write"] is extracted but deliberately unbilled: it is not
+        # yet established whether prompt_tokens / prompt_cache_miss_tokens
+        # include the write slice (every captured row has write = 0), and
+        # emitting it could double-count it. Open item: FINDINGS.md phase 1.
         return {
             "source": self.source_name,
             "model": usage["model"],
@@ -3682,9 +3692,9 @@ class WorkBuddyParser(BaseParser):
             "input": fresh,
             "output": output,
             "cacheRead": cached,
-            "cacheWrite": write,
+            "cacheWrite": 0,
             "reasoning": reasoning,
-            "cost": self.pricing_db.get_cost(usage["model"], fresh, completion, cached, write),
+            "cost": self.pricing_db.get_cost(usage["model"], fresh, completion, cached, 0),
             "workbuddy_credit": usage["credit"],
             "entry_id": f"workbuddy:{call_id}",
             "message_id": call_id,

--- a/src/tokdash/sources/coding_tools.py
+++ b/src/tokdash/sources/coding_tools.py
@@ -3580,6 +3580,11 @@ class WorkBuddyParser(BaseParser):
             "carries a stable providerData.messageId, so entry_id is stable per call."
         ),
     )
+    # 1: assistant message rows keyed by the provider call id; cache-inclusive
+    #    prompt split into fresh input / cacheRead, reasoning split out for
+    #    display while billing uses the full completion, cache writes held at 0
+    #    until the vendor's write-slice semantics are verified.
+    persistent_parser_version = 1
 
     def __init__(self, pricing_db: PricingDatabase):
         super().__init__(pricing_db)
@@ -3695,6 +3700,13 @@ class WorkBuddyParser(BaseParser):
             "cacheWrite": 0,
             "reasoning": reasoning,
             "cost": self.pricing_db.get_cost(usage["model"], fresh, completion, cached, 0),
+            "_billing": usage_billing_pricing(
+                [usage["model"]],
+                input_tokens=fresh,
+                output_tokens=completion,
+                cache_read=cached,
+                cache_write=0,
+            ),
             "workbuddy_credit": usage["credit"],
             "entry_id": f"workbuddy:{call_id}",
             "message_id": call_id,

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -5157,6 +5157,7 @@
       dsh: { icon: '/static/icons/agents/dsh.svg', color: '#4D6BFE', fallback: 'D' },
       reasonix: { icon: '/static/icons/agents/reasonix.svg', color: '#0153E5', fallback: 'R' },
       zcode: { icon: '/static/icons/agents/zcode.png', color: '#111213', fallback: 'Z', darkInvert: true },
+      workbuddy: { color: '#0CC8A3', fallback: 'W' },
     });
     const toolBrandIconPromises = new Map();
 
@@ -5289,6 +5290,7 @@
         dsh: 'DeepSeek Harness',
         reasonix: 'Reasonix',
         zcode: 'ZCode',
+        workbuddy: 'WorkBuddy',
         cursor: 'Cursor',
       };
       if (mapping[key]) return mapping[key];

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -859,6 +859,8 @@ def test_coding_tool_parsers_declare_sync_capabilities():
     assert modes["copilot_cli"] == "source_replace"
     assert tracker.parsers["gemini_cli"].sync_capability.append_jsonl is True
     assert tracker.parsers["kimi"].sync_capability.append_jsonl is True
+    assert modes["workbuddy"] == "file_replace"
+    assert tracker.parsers["workbuddy"].sync_capability.append_jsonl is True
     assert tracker.parsers["opencode"].sync_capability.session_store is False
 
 

--- a/tests/test_workbuddy_parser.py
+++ b/tests/test_workbuddy_parser.py
@@ -435,12 +435,12 @@ def test_workbuddy_cache_precedence_and_clamping(monkeypatch, tmp_path):
         _assistant_row("r5", 1787314800005, "default-model",
                        raw_usage=ru(1000, cache_read_input_tokens=111,
                                     prompt_cache_hit_tokens=999)),
-        # Write chain.
-        _assistant_row("w1", 1787314800006, "default-model",
+        # Write chain: nonzero fields are extracted but must not be billed.
+        _assistant_row("w1", 1787314800006, "gpt-5.5",
                        raw_usage=ru(1000, cache_creation_input_tokens=55)),
-        _assistant_row("w2", 1787314800007, "default-model",
+        _assistant_row("w2", 1787314800007, "gpt-5.5",
                        raw_usage=ru(1000, cacheCreationInputTokens=66)),
-        _assistant_row("w3", 1787314800008, "default-model",
+        _assistant_row("w3", 1787314800008, "gpt-5.5",
                        raw_usage=ru(1000, prompt_cache_write_tokens=77)),
         # Clamps: cached cannot exceed prompt, fresh cannot go negative.
         _assistant_row("c1", 1787314800009, "default-model",
@@ -459,11 +459,78 @@ def test_workbuddy_cache_precedence_and_clamping(monkeypatch, tmp_path):
     assert entries["workbuddy:r5"]["cacheRead"] == 111
     # No miss column: fresh falls back to prompt - cached.
     assert entries["workbuddy:r1"]["input"] == 1000 - 111
-    assert entries["workbuddy:w1"]["cacheWrite"] == 55
-    assert entries["workbuddy:w2"]["cacheWrite"] == 66
-    assert entries["workbuddy:w3"]["cacheWrite"] == 77
+    # Nonzero write fields are extracted but not billed until the vendor's
+    # write-slice semantics are verified (FINDINGS.md open item).
+    for rid, write in (("w1", 55), ("w2", 66), ("w3", 77)):
+        e = entries[f"workbuddy:{rid}"]
+        assert e["cacheWrite"] == 0
+        assert e["cost"] == PricingDatabase().get_cost("gpt-5.5", 1000, 10, 0, 0)
+        assert e["cost"] != PricingDatabase().get_cost("gpt-5.5", 1000, 10, 0, write)
+
+    # The write chain is still extracted in WorkBuddy order.
+    def norm(**fields):
+        return parser._usage_from_provider_data({"rawUsage": ru(1000, **fields)})
+
+    assert norm(cache_creation_input_tokens=55)["write"] == 55
+    assert norm(cacheCreationInputTokens=66)["write"] == 66
+    assert norm(prompt_cache_write_tokens=77)["write"] == 77
+    assert norm(cache_creation_input_tokens=55,
+                cacheCreationInputTokens=66)["write"] == 55
     assert entries["workbuddy:c1"]["cacheRead"] == 100
     assert entries["workbuddy:c1"]["input"] == 0
+
+
+def test_workbuddy_adversarial_counters_clamp(monkeypatch, tmp_path):
+    """Negative/inconsistent provider counters must not yield negative
+    buckets or inflate totals."""
+    def ru(prompt, completion, **fields):
+        base = {
+            "prompt_tokens": prompt,
+            "completion_tokens": completion,
+            "total_tokens": prompt + completion,
+            "credit": 0,
+        }
+        base.update(fields)
+        return base
+
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    root = home / ".workbuddy-ai"
+    rows = [
+        # Negative prompt: cached clamps to 0, nothing goes negative.
+        _assistant_row("n1", 1787314900001, "default-model",
+                       raw_usage=ru(-50, 10, prompt_cache_hit_tokens=10)),
+        # Negative miss: falls back to prompt - cached instead of forcing 0.
+        _assistant_row("n2", 1787314900002, "default-model",
+                       raw_usage=ru(100, 10, prompt_cache_hit_tokens=40,
+                                    prompt_cache_miss_tokens=-5)),
+        # Reasoning above completion: clamped to completion, output 0.
+        _assistant_row("n3", 1787314900003, "default-model",
+                       raw_usage=ru(100, 10,
+                                    completion_tokens_details={"reasoning_tokens": 300})),
+        # Negative reasoning: treated as absent, output unaffected.
+        _assistant_row("n4", 1787314900004, "default-model",
+                       raw_usage=ru(100, 100,
+                                    completion_tokens_details={"reasoning_tokens": -50})),
+    ]
+    _write_transcript(root, "slug", "s1", rows)
+
+    parser = WorkBuddyParser(PricingDatabase())
+    entries = _collect(parser)
+
+    for e in entries.values():
+        for key in ("input", "output", "cacheRead", "cacheWrite", "reasoning"):
+            assert e[key] >= 0
+
+    assert entries["workbuddy:n1"]["input"] == 0
+    assert entries["workbuddy:n1"]["cacheRead"] == 0
+    assert entries["workbuddy:n1"]["output"] == 10
+    assert entries["workbuddy:n2"]["input"] == 60  # 100 - 40; negative miss ignored
+    assert entries["workbuddy:n2"]["output"] == 10
+    assert entries["workbuddy:n3"]["reasoning"] == 10
+    assert entries["workbuddy:n3"]["output"] == 0
+    assert entries["workbuddy:n4"]["reasoning"] == 0
+    assert entries["workbuddy:n4"]["output"] == 100
 
 
 def test_workbuddy_model_verbatim_and_pricing(monkeypatch, tmp_path):

--- a/tests/test_workbuddy_parser.py
+++ b/tests/test_workbuddy_parser.py
@@ -6,11 +6,20 @@ coding modes).
 """
 
 import json
+import sqlite3
 from pathlib import Path
 
+import pytest
+
+import tokdash.compute as compute
 from tokdash.compute import _collect_parser_tail
 from tokdash.pricing import PricingDatabase
-from tokdash.sources.coding_tools import WorkBuddyParser
+from tokdash.sources.coding_tools import (
+    BaseParser,
+    CodingToolsUsageTracker,
+    WorkBuddyParser,
+    _sig_cache,
+)
 
 
 def _isolate_home(monkeypatch, tmp_path):
@@ -104,6 +113,62 @@ def _write_transcript(root: Path, slug: str, session_id: str, rows) -> Path:
 
 def _collect(parser: WorkBuddyParser):
     return {e["entry_id"]: e for e in parser.collect(None, None)}
+
+
+def _reset_caches():
+    _sig_cache.clear()
+    BaseParser._entry_cache.clear()
+
+
+def _write_pricing(data_dir: Path, model: str, *, input_rate: float,
+                   output_rate: float, cache_read_rate: float) -> None:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "pricing_db.json").write_text(
+        json.dumps({
+            "version": "workbuddy-test",
+            "aliases": {},
+            "models": {
+                model: {
+                    "input": input_rate,
+                    "output": output_rate,
+                    "cache_read": cache_read_rate,
+                    "cache_write": input_rate,
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+
+
+def _workbuddy_only_tracker() -> CodingToolsUsageTracker:
+    tracker = CodingToolsUsageTracker()
+    tracker.parsers = {"workbuddy": tracker.parsers["workbuddy"]}
+    return tracker
+
+
+def _private_keys(value):
+    if isinstance(value, dict):
+        found = [key for key in value if key.startswith("_")]
+        for child in value.values():
+            found.extend(_private_keys(child))
+        return found
+    if isinstance(value, list):
+        found = []
+        for child in value:
+            found.extend(_private_keys(child))
+        return found
+    return []
+
+
+def test_workbuddy_declares_persistent_parser_identity(monkeypatch, tmp_path):
+    _isolate_home(monkeypatch, tmp_path)
+    parser = WorkBuddyParser(PricingDatabase())
+
+    assert parser.persistent_parser_version == 1
+    signature = parser.persistent_parser_signature()
+    assert signature["object"].endswith("WorkBuddyParser")
+    assert signature["version"] == 1
+    assert signature["entry_format"] >= 1
 
 
 def test_workbuddy_windows_fixture(monkeypatch, tmp_path):
@@ -384,6 +449,147 @@ def test_workbuddy_reasoning_split_billed_as_completion(monkeypatch, tmp_path):
     assert e["cacheRead"] == 400
     assert e["input"] + e["cacheRead"] + e["output"] + e["reasoning"] == 1000 + 500
     assert e["cost"] == PricingDatabase().get_cost("gpt-5.5", 600, 500, 400, 0)
+    assert e["_billing"] == {
+        "kind": "pricing",
+        "models": ["gpt-5.5"],
+        "input": 600,
+        "output": 500,  # full completion, including the reasoning slice
+        "cache_read": 400,
+        "cache_write": 0,
+    }
+
+
+def test_workbuddy_pricing_change_reprices_without_parsing_logs(monkeypatch, tmp_path):
+    home = _isolate_home(monkeypatch, tmp_path)
+    data_dir = tmp_path / "tokdash-data"
+    monkeypatch.setenv("TOKDASH_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("TOKDASH_USAGE_DB", "1")
+    monkeypatch.setenv("TOKDASH_USAGE_DB_DURABLE", "1")
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    model = "workbuddy-priced-test"
+    _write_pricing(
+        data_dir,
+        model,
+        input_rate=1.0,
+        output_rate=2.0,
+        cache_read_rate=0.1,
+    )
+    transcript = _write_transcript(
+        home / ".workbuddy-ai",
+        "slug",
+        "s1",
+        [_assistant_row(
+            "priced-call",
+            1787314800000,
+            model,
+            raw_usage=_raw_usage(1000, 500, 400, 600, reasoning=200),
+        )],
+    )
+
+    parse_calls = 0
+    original = WorkBuddyParser._parse_all
+
+    def counting_parse(parser):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original(parser)
+
+    monkeypatch.setattr(WorkBuddyParser, "_parse_all", counting_parse)
+    _reset_caches()
+    store, _sources = compute._sync_usage_store(_workbuddy_only_tracker())
+    before = store.aggregate_entries(sources=["workbuddy"])["total_cost"]
+    assert parse_calls == 1
+    assert before == pytest.approx((600 * 1.0 + 500 * 2.0 + 400 * 0.1) / 1_000_000)
+
+    # The durable row must reprice even after its source log disappears.
+    transcript.unlink()
+    _write_pricing(
+        data_dir,
+        model,
+        input_rate=3.0,
+        output_rate=5.0,
+        cache_read_rate=0.2,
+    )
+    _reset_caches()
+    store, _sources = compute._sync_usage_store(_workbuddy_only_tracker())
+    after = store.aggregate_entries(sources=["workbuddy"])["total_cost"]
+
+    assert parse_calls == 1, "a pricing edit must reprice the stored bill, not reread logs"
+    assert after == pytest.approx((600 * 3.0 + 500 * 5.0 + 400 * 0.2) / 1_000_000)
+    assert after != before
+
+
+def test_workbuddy_billing_provenance_never_reaches_api_or_export_output(
+    monkeypatch, tmp_path
+):
+    home = _isolate_home(monkeypatch, tmp_path)
+    data_dir = tmp_path / "tokdash-data"
+    monkeypatch.setenv("TOKDASH_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("TOKDASH_USAGE_DB", "1")
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    model = "workbuddy-private-test"
+    _write_pricing(
+        data_dir,
+        model,
+        input_rate=1.0,
+        output_rate=2.0,
+        cache_read_rate=0.1,
+    )
+    _write_transcript(
+        home / ".workbuddy-ai",
+        "slug",
+        "s1",
+        [_assistant_row(
+            "private-call",
+            1787314800000,
+            model,
+            raw_usage=_raw_usage(1000, 500, 400, 600, reasoning=200),
+        )],
+    )
+
+    original_tracker = CodingToolsUsageTracker
+
+    def tracker_factory():
+        tracker = original_tracker()
+        tracker.parsers = {"workbuddy": tracker.parsers["workbuddy"]}
+        return tracker
+
+    monkeypatch.setattr(compute, "CodingToolsUsageTracker", tracker_factory)
+    _reset_caches()
+    store, _sources = compute._sync_usage_store(tracker_factory())
+    persisted = store.query_entries(sources=["workbuddy"])
+    assert [entry["source"] for entry in persisted] == ["workbuddy"]
+    assert not _private_keys(persisted)
+
+    stored_entries = compute.run_local_coding_tools_json([])["entries"]
+    assert [entry["source"] for entry in stored_entries] == ["workbuddy"]
+    assert not _private_keys(stored_entries)
+
+    # /api/tools aggregates through get_tools_data; `tokdash export` calls
+    # compute_usage. Neither public payload may carry the private record.
+    assert not _private_keys(compute.get_tools_data("all"))
+    assert not _private_keys(compute.compute_usage("all"))
+
+    with sqlite3.connect(store.path) as conn:
+        raw_json, billing_json = conn.execute(
+            "SELECT raw_json, billing_json FROM usage_entries WHERE source = 'workbuddy'"
+        ).fetchone()
+    assert "_billing" not in json.loads(raw_json)
+    assert json.loads(billing_json) == {
+        "kind": "pricing",
+        "models": [model],
+        "input": 600,
+        "output": 500,
+        "cache_read": 400,
+        "cache_write": 0,
+    }
+
+    # The non-persistent fallback path is public too.
+    monkeypatch.setenv("TOKDASH_USAGE_DB", "0")
+    _reset_caches()
+    live_entries = compute.run_local_coding_tools_json([])["entries"]
+    assert [entry["source"] for entry in live_entries] == ["workbuddy"]
+    assert not _private_keys(live_entries)
 
 
 def test_workbuddy_reasoning_thinking_fallback(monkeypatch, tmp_path):

--- a/tests/test_workbuddy_parser.py
+++ b/tests/test_workbuddy_parser.py
@@ -1,0 +1,522 @@
+"""WorkBuddy transcript parser tests (phase 1 spec).
+
+Fixtures are the verbatim captured rows from
+docs/local/20260821_workbuddy_support/evidence (Windows + macOS, working +
+coding modes).
+"""
+
+import json
+from pathlib import Path
+
+from tokdash.compute import _collect_parser_tail
+from tokdash.pricing import PricingDatabase
+from tokdash.sources.coding_tools import WorkBuddyParser
+
+
+def _isolate_home(monkeypatch, tmp_path):
+    """Keep tests hermetic (and Windows-safe) by faking the user home dir."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: home)
+    return home
+
+
+def _raw_usage(prompt, completion, cached, missed, credit=0.0, reasoning=0, write=0,
+               cache_read=0, cache_creation=0, include_miss=True):
+    """Verbatim-shape rawUsage block (field set from the captured transcripts)."""
+    return {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": prompt + completion,
+        "prompt_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 0,
+            "rejected_prediction_tokens": 0,
+            "cached_tokens": cached,
+        },
+        "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": reasoning,
+            "rejected_prediction_tokens": 0,
+            "cached_tokens": 0,
+        },
+        "prompt_cache_hit_tokens": cached,
+        "prompt_cache_write_tokens": write,
+        "cache_read_input_tokens": cache_read,
+        "cache_creation_input_tokens": cache_creation,
+        "completion_thinking_tokens": 0,
+        "credit": credit,
+        "cached_tokens": 0,
+        **({"prompt_cache_miss_tokens": missed} if include_miss else {}),
+    }
+
+
+def _fallback_usage(prompt, completion, cached, reasoning=0):
+    """Captured camel-case providerData.usage schema (no cache-write column)."""
+    return {
+        "requests": 1,
+        "inputTokens": prompt,
+        "outputTokens": completion,
+        "totalTokens": prompt + completion,
+        "inputTokensDetails": [{"cached_tokens": cached}] if cached else [],
+        "outputTokensDetails": [{"reasoning_tokens": reasoning}] if reasoning else [],
+    }
+
+
+def _assistant_row(message_id, ts, model, raw_usage=None, usage=None,
+                   omit_message_id=False, omit_id=False):
+    pd = {
+        "model": model,
+        "requestModelId": model,
+        "requestModelName": "Auto",
+        "agent": "cli",
+    }
+    if not omit_message_id:
+        pd["messageId"] = message_id
+    if raw_usage is not None:
+        pd["rawUsage"] = raw_usage
+    if usage is not None:
+        pd["usage"] = usage
+    row = {
+        "timestamp": ts,
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "providerData": pd,
+        "sessionId": "d2f054aa-6d2a-4953-acc6-485f1d9f7c9a",
+    }
+    if not omit_id:
+        row["id"] = message_id
+    return row
+
+
+def _write_transcript(root: Path, slug: str, session_id: str, rows) -> Path:
+    """Write rows (dicts, or raw strings for malformed-line cases) to a transcript."""
+    project_dir = root / "projects" / slug
+    project_dir.mkdir(parents=True)
+    path = project_dir / f"{session_id}.jsonl"
+    lines = [row if isinstance(row, str) else json.dumps(row) for row in rows]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _collect(parser: WorkBuddyParser):
+    return {e["entry_id"]: e for e in parser.collect(None, None)}
+
+
+def test_workbuddy_windows_fixture(monkeypatch, tmp_path):
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    root = home / ".workbuddy-ai"
+    rows = [
+        # Non-usage rows from the real transcript (must be ignored).
+        {
+            "id": "5ff45aa6-f284-49d6-af0b-4c2bcf142cc2",
+            "timestamp": 1787267148990,
+            "type": "message",
+            "role": "user",
+            "content": [],
+            "providerData": {"agent": "cli"},
+            "sessionId": "d2f054aa-6d2a-4953-acc6-485f1d9f7c9a",
+            "cwd": "c:\\Users\\H1937\\WorkBuddy AI\\2026-08-21-00-05-48",
+        },
+        {
+            "id": "snapshot-1",
+            "timestamp": 1787267160000,
+            "type": "file-history-snapshot",
+            "isSnapshotUpdate": False,
+            "snapshot": {},
+            "cwd": "c:\\Users\\H1937\\WorkBuddy AI",
+        },
+        {
+            "timestamp": 1787267160500,
+            "type": "ai-title",
+            "aiTitle": "test",
+            "sessionId": "d2f054aa-6d2a-4953-acc6-485f1d9f7c9a",
+            "cwd": "c:\\Users\\H1937\\WorkBuddy AI",
+        },
+        # Verbatim Windows capture: 34417 / 128 / cached 12288 / miss 22129.
+        _assistant_row(
+            "f0eb23d31e314b25919902f51b49a282",
+            1787267160894,
+            "default-model",
+            raw_usage=_raw_usage(34417, 128, 12288, 22129, credit=2.12),
+        ),
+    ]
+    _write_transcript(
+        root,
+        "c-Users-H1937-WorkBuddy AI-2026-08-21-00-05-48",
+        "d2f054aa-6d2a-4953-acc6-485f1d9f7c9a",
+        rows,
+    )
+
+    parser = WorkBuddyParser(PricingDatabase())
+    entries = _collect(parser)
+
+    assert len(entries) == 1
+    e = entries["workbuddy:f0eb23d31e314b25919902f51b49a282"]
+    assert e["source"] == "workbuddy"
+    assert e["model"] == "default-model"
+    assert e["provider"] == ""
+    assert e["input"] == 22129  # prompt_cache_miss_tokens
+    assert e["output"] == 128
+    assert e["cacheRead"] == 12288
+    assert e["cacheWrite"] == 0
+    assert e["reasoning"] == 0
+    assert e["cost"] == 0.0  # router alias is absent from the pricing DB
+    assert e["workbuddy_credit"] == 2.12
+    assert e["timestamp"] == 1787267160894
+
+
+def test_workbuddy_macos_coding_fixture(monkeypatch, tmp_path):
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    root = home / ".workbuddy-ai"
+    # Verbatim macOS coding-mode capture: 32309 / 759 / cached 28160 / miss 4149.
+    _write_transcript(
+        root,
+        "Users-margaret-WorkBuddy AI-2026-08-21-13-20-34",
+        "a2f52b49-26d3-492e-80b1-d260f64e9f3c",
+        [
+            _assistant_row(
+                "75680327bc0744c0bce77b9d4bd3b9cc",
+                1787314852053,
+                "default-model",
+                raw_usage=_raw_usage(32309, 759, 28160, 4149, credit=1.13),
+            ),
+        ],
+    )
+
+    parser = WorkBuddyParser(PricingDatabase())
+    entries = _collect(parser)
+
+    assert len(entries) == 1
+    e = entries["workbuddy:75680327bc0744c0bce77b9d4bd3b9cc"]
+    assert e["input"] == 4149
+    assert e["output"] == 759
+    assert e["cacheRead"] == 28160
+    assert e["cost"] == 0.0
+    assert e["workbuddy_credit"] == 1.13
+    assert e["timestamp"] == 1787314852053
+
+
+def test_workbuddy_working_and_coding_modes_parse_identically(monkeypatch, tmp_path):
+    """Working and coding mode rows are shape-identical; one code path for both."""
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    root = home / ".workbuddy-ai"
+    # Verbatim macOS working-mode capture: 32311 / 204 / cached 9984 / miss 22327.
+    _write_transcript(
+        root,
+        "Users-margaret-WorkBuddy AI-2026-08-21-13-20-18",
+        "c1a1a972-29b4-491a-ae36-ba13ac528727",
+        [
+            _assistant_row(
+                "fce3e9f476b4421097972553e5dfcc18",
+                1787314833130,
+                "default-model",
+                raw_usage=_raw_usage(32311, 204, 9984, 22327, credit=2.11),
+            ),
+        ],
+    )
+    _write_transcript(
+        root,
+        "Users-margaret-WorkBuddy AI-2026-08-21-13-20-34",
+        "a2f52b49-26d3-492e-80b1-d260f64e9f3c",
+        [
+            _assistant_row(
+                "75680327bc0744c0bce77b9d4bd3b9cc",
+                1787314852053,
+                "default-model",
+                raw_usage=_raw_usage(32309, 759, 28160, 4149, credit=1.13),
+            ),
+        ],
+    )
+
+    parser = WorkBuddyParser(PricingDatabase())
+    entries = _collect(parser)
+
+    assert len(entries) == 2
+    working = entries["workbuddy:fce3e9f476b4421097972553e5dfcc18"]
+    coding = entries["workbuddy:75680327bc0744c0bce77b9d4bd3b9cc"]
+    assert working["input"] == 22327
+    assert working["output"] == 204
+    assert working["cacheRead"] == 9984
+    assert coding["input"] == 4149
+    assert coding["output"] == 759
+    assert coding["cacheRead"] == 28160
+    assert set(working.keys()) == set(coding.keys())
+
+
+def test_workbuddy_malformed_rows_skip_without_dropping_file(monkeypatch, tmp_path):
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    root = home / ".workbuddy-ai"
+    good_id = "d" * 32
+    rows = [
+        '{"broken": ',  # bad JSON
+        "",  # blank line
+        _assistant_row(
+            "a" * 32,
+            1787314800000,
+            "default-model",
+            raw_usage=_raw_usage(100, 10, 0, 100),
+            omit_message_id=True,
+            omit_id=True,
+        ),  # no stable identity
+        _assistant_row(
+            "b" * 32,
+            0,
+            "default-model",
+            raw_usage=_raw_usage(100, 10, 0, 100),
+        ),  # zero timestamp
+        _assistant_row(
+            "c" * 32,
+            1787314800001,
+            "default-model",
+            raw_usage=_raw_usage(0, 0, 0, 0),
+        ),  # zero usage
+        _assistant_row(
+            good_id,
+            1787314800002,
+            "default-model",
+            raw_usage=_raw_usage(500, 50, 200, 300, credit=0.5),
+        ),
+    ]
+    _write_transcript(root, "slug", "s1", rows)
+
+    parser = WorkBuddyParser(PricingDatabase())
+    entries = _collect(parser)
+
+    assert list(entries) == [f"workbuddy:{good_id}"]
+    assert entries[f"workbuddy:{good_id}"]["input"] == 300
+
+
+def test_workbuddy_multi_root_discovery(monkeypatch, tmp_path):
+    home = _isolate_home(monkeypatch, tmp_path)
+    root_a = home / "wb-a"
+    root_b = home / "wb-b"
+    _write_transcript(
+        root_a,
+        "slug-a",
+        "s1",
+        [_assistant_row("a" * 32, 1787314800000, "default-model",
+                        raw_usage=_raw_usage(1000, 100, 400, 600, credit=1.0))],
+    )
+    _write_transcript(
+        root_b,
+        "slug-b",
+        "s2",
+        [_assistant_row("b" * 32, 1787314800001, "default-model",
+                        raw_usage=_raw_usage(2000, 200, 0, 2000, credit=2.0))],
+    )
+    monkeypatch.setenv("WORKBUDDY_DATA_DIR", f"{root_a} , {root_b}")
+
+    parser = WorkBuddyParser(PricingDatabase())
+    entries = _collect(parser)
+
+    assert set(entries) == {f"workbuddy:{'a' * 32}", f"workbuddy:{'b' * 32}"}
+    assert entries[f"workbuddy:{'a' * 32}"]["input"] == 600
+    assert entries[f"workbuddy:{'b' * 32}"]["input"] == 2000
+
+
+def test_workbuddy_fallback_usage_schema(monkeypatch, tmp_path):
+    """rawUsage absent: providerData.usage (camel-case + details arrays) is used,
+    with the same totals as the primary adapter on the same numbers."""
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    root = home / ".workbuddy-ai"
+    _write_transcript(
+        root,
+        "slug",
+        "s1",
+        [
+            _assistant_row(
+                "f0eb23d31e314b25919902f51b49a282",
+                1787267160894,
+                "default-model",
+                usage=_fallback_usage(34417, 128, 12288),
+            ),
+        ],
+    )
+
+    parser = WorkBuddyParser(PricingDatabase())
+    entries = _collect(parser)
+
+    assert len(entries) == 1
+    e = entries["workbuddy:f0eb23d31e314b25919902f51b49a282"]
+    assert e["input"] == 22129  # prompt - cached (no miss column in fallback)
+    assert e["output"] == 128
+    assert e["cacheRead"] == 12288
+    assert e["cacheWrite"] == 0
+    assert e["reasoning"] == 0
+    assert e["cost"] == 0.0
+    assert e["workbuddy_credit"] == 0.0
+
+
+def test_workbuddy_reasoning_split_billed_as_completion(monkeypatch, tmp_path):
+    """Nonzero reasoning: output excludes it and the full completion is priced.
+
+    With zero cache writes the headline total equals
+    fresh + cacheRead + completion == prompt + completion (prompt already
+    includes the cached slice, so cache must not be added on top).
+    """
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    root = home / ".workbuddy-ai"
+    _write_transcript(
+        root,
+        "slug",
+        "s1",
+        [_assistant_row("e" * 32, 1787314800000, "gpt-5.5",
+                        raw_usage=_raw_usage(1000, 500, 400, 600, reasoning=200))],
+    )
+
+    parser = WorkBuddyParser(PricingDatabase())
+    entries = _collect(parser)
+
+    e = entries[f"workbuddy:{'e' * 32}"]
+    assert e["input"] == 600
+    assert e["output"] == 300
+    assert e["reasoning"] == 200
+    assert e["cacheRead"] == 400
+    assert e["input"] + e["cacheRead"] + e["output"] + e["reasoning"] == 1000 + 500
+    assert e["cost"] == PricingDatabase().get_cost("gpt-5.5", 600, 500, 400, 0)
+
+
+def test_workbuddy_reasoning_thinking_fallback(monkeypatch, tmp_path):
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    root = home / ".workbuddy-ai"
+    ru = _raw_usage(100, 100, 0, 100)
+    ru["completion_thinking_tokens"] = 77  # details.reasoning_tokens stays 0
+    _write_transcript(
+        root,
+        "slug",
+        "s1",
+        [_assistant_row("t" * 32, 1787314800000, "default-model", raw_usage=ru)],
+    )
+
+    parser = WorkBuddyParser(PricingDatabase())
+    entries = _collect(parser)
+
+    e = entries[f"workbuddy:{'t' * 32}"]
+    assert e["reasoning"] == 77
+    assert e["output"] == 23
+
+
+def test_workbuddy_cache_precedence_and_clamping(monkeypatch, tmp_path):
+    def ru(prompt, **fields):
+        base = {
+            "prompt_tokens": prompt,
+            "completion_tokens": 10,
+            "total_tokens": prompt + 10,
+            "credit": 0,
+        }
+        base.update(fields)
+        return base
+
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    root = home / ".workbuddy-ai"
+    rows = [
+        # Read chain, one field at a time (WorkBuddy UsageUtils order).
+        _assistant_row("r1", 1787314800001, "default-model",
+                       raw_usage=ru(1000, cache_read_input_tokens=111)),
+        _assistant_row("r2", 1787314800002, "default-model",
+                       raw_usage=ru(1000, cacheReadInputTokens=222)),
+        _assistant_row("r3", 1787314800003, "default-model",
+                       raw_usage=ru(1000, prompt_tokens_details={"cached_tokens": 333})),
+        _assistant_row("r4", 1787314800004, "default-model",
+                       raw_usage=ru(1000, prompt_cache_hit_tokens=444)),
+        # Precedence: earlier chain position wins.
+        _assistant_row("r5", 1787314800005, "default-model",
+                       raw_usage=ru(1000, cache_read_input_tokens=111,
+                                    prompt_cache_hit_tokens=999)),
+        # Write chain.
+        _assistant_row("w1", 1787314800006, "default-model",
+                       raw_usage=ru(1000, cache_creation_input_tokens=55)),
+        _assistant_row("w2", 1787314800007, "default-model",
+                       raw_usage=ru(1000, cacheCreationInputTokens=66)),
+        _assistant_row("w3", 1787314800008, "default-model",
+                       raw_usage=ru(1000, prompt_cache_write_tokens=77)),
+        # Clamps: cached cannot exceed prompt, fresh cannot go negative.
+        _assistant_row("c1", 1787314800009, "default-model",
+                       raw_usage=ru(100, prompt_cache_hit_tokens=150,
+                                    prompt_cache_miss_tokens=0)),
+    ]
+    _write_transcript(root, "slug", "s1", rows)
+
+    parser = WorkBuddyParser(PricingDatabase())
+    entries = _collect(parser)
+
+    assert entries["workbuddy:r1"]["cacheRead"] == 111
+    assert entries["workbuddy:r2"]["cacheRead"] == 222
+    assert entries["workbuddy:r3"]["cacheRead"] == 333
+    assert entries["workbuddy:r4"]["cacheRead"] == 444
+    assert entries["workbuddy:r5"]["cacheRead"] == 111
+    # No miss column: fresh falls back to prompt - cached.
+    assert entries["workbuddy:r1"]["input"] == 1000 - 111
+    assert entries["workbuddy:w1"]["cacheWrite"] == 55
+    assert entries["workbuddy:w2"]["cacheWrite"] == 66
+    assert entries["workbuddy:w3"]["cacheWrite"] == 77
+    assert entries["workbuddy:c1"]["cacheRead"] == 100
+    assert entries["workbuddy:c1"]["input"] == 0
+
+
+def test_workbuddy_model_verbatim_and_pricing(monkeypatch, tmp_path):
+    """Router alias: counted, costs 0.00. Explicit id: priced, kept verbatim."""
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    root = home / ".workbuddy-ai"
+    rows = [
+        _assistant_row("a" * 32, 1787314800000, "default-model",
+                       raw_usage=_raw_usage(1000, 100, 0, 1000)),
+        _assistant_row("b" * 32, 1787314800001, "gpt-5.5",
+                       raw_usage=_raw_usage(1000, 100, 0, 1000)),
+    ]
+    _write_transcript(root, "slug", "s1", rows)
+
+    parser = WorkBuddyParser(PricingDatabase())
+    entries = _collect(parser)
+
+    alias = entries[f"workbuddy:{'a' * 32}"]
+    explicit = entries[f"workbuddy:{'b' * 32}"]
+    assert alias["model"] == "default-model"
+    assert alias["cost"] == 0.0
+    assert alias["input"] == 1000
+    assert explicit["model"] == "gpt-5.5"
+    assert explicit["cost"] > 0.0
+
+
+def test_workbuddy_append_tail_ingests_only_new_rows(monkeypatch, tmp_path):
+    """Persistent append sync path: appended rows in an otherwise-unchanged
+    file are parsed from the tail offset, deduped by entry_id downstream."""
+    home = _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("WORKBUDDY_DATA_DIR", raising=False)
+    root = home / ".workbuddy-ai"
+    first = _assistant_row("a" * 32, 1787314800000, "default-model",
+                           raw_usage=_raw_usage(1000, 100, 0, 1000, credit=1.0))
+    path = _write_transcript(root, "slug", "s1", [first])
+
+    parser = WorkBuddyParser(PricingDatabase())
+    assert [e["entry_id"] for e in parser._parse_all()] == [f"workbuddy:{'a' * 32}"]
+    start_offset = path.stat().st_size
+
+    second = _assistant_row("b" * 32, 1787314800001, "default-model",
+                            raw_usage=_raw_usage(2000, 200, 0, 2000, credit=2.0))
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(second) + "\n")
+
+    file_sig = (str(path), path.stat().st_mtime_ns, path.stat().st_size)
+    tail_entries, safe_offset = _collect_parser_tail(parser, file_sig, start_offset)
+
+    assert [e["entry_id"] for e in tail_entries] == [f"workbuddy:{'b' * 32}"]
+    assert safe_offset == path.stat().st_size
+    # Full reparse sees both rows exactly once each.
+    assert [e["entry_id"] for e in parser._parse_all()] == [
+        f"workbuddy:{'a' * 32}",
+        f"workbuddy:{'b' * 32}",
+    ]


### PR DESCRIPTION
## Summary

- parse WorkBuddy desktop transcript usage from native and configured data roots
- keep prompt, cache-read, visible output, and reasoning accounting disjoint
- integrate with the persistent usage cache using parser and billing provenance identities
- add dashboard branding, support documentation, and regression coverage

## Verification

- `PYTHONPATH=src /home/howard/anaconda3/bin/python -m pytest -q tests/test_workbuddy_parser.py tests/test_usage_cache_identity.py tests/test_usage_store.py` — 130 passed
- full suite reported on the reviewed branch — 1283 passed, 4 skipped
- `git diff --check main...HEAD`
- conflict-free merge tree against current `origin/main`