### PR TITLE
Fail fast when the usage DB schema is newer than this build

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,13 @@ Persistent usage DB (default on):
 
 Tokdash maintains a local SQLite index at `~/.tokdash/usage.sqlite3` by default. It stores parsed token rows and Codex/Claude/Kimi/DeepSeek Harness/Reasonix session summaries so repeated dashboard and API reads can use indexed SQL instead of reparsing every source log. Source logs remain the source of truth; the DB is a local performance index, and Tokdash falls back to live parsing if it is disabled or unavailable.
 
-Cached session rows are price-neutral: they hold each turn's billing inputs (model, fresh input, cache reads and writes, output), and cost is calculated when they are read, with whatever pricing that process has loaded. Editing a rate therefore reprices instantly instead of rereading gigabytes of logs, and two Tokdash versions sharing one database — an installed service and a checkout, say — do not invalidate each other's rows over pricing. Parser and source-file changes still reparse normally. Rows written before this (including any kept by `TOKDASH_USAGE_DB_DURABLE` after their log is gone) reprice from their stored totals, which reproduces the same figure but cannot separate a Claude or Kimi cache write from fresh input; only a reparse of those logs can restore that distinction. Codex bills under `provider/model` and stores the bare name, so its older rows are reparsed once instead of reused.
+Cached session rows are price-neutral: they hold each turn's billing inputs (model, fresh input, cache reads and writes, output), and cost is calculated when they are read, with whatever pricing that process has loaded. Editing a rate therefore reprices instantly instead of rereading gigabytes of logs, and two Tokdash versions sharing one database do not invalidate each other's rows over pricing. Sharing is only safe while both builds support the same database schema, though: schema migrations run forward only, so once the newer build migrates the file the older one refuses to open it until it is upgraded, and every cached read fails until the versions match. `tokdash doctor` reports the schema on disk alongside the one the running build supports. Parser and source-file changes still reparse normally. Rows written before this (including any kept by `TOKDASH_USAGE_DB_DURABLE` after their log is gone) reprice from their stored totals, which reproduces the same figure but cannot separate a Claude or Kimi cache write from fresh input; only a reparse of those logs can restore that distinction. Codex bills under `provider/model` and stores the bare name, so its older rows are reparsed once instead of reused.
+
+Run a checkout against its own data directory so it never migrates the installed service's database:
+
+```bash
+TOKDASH_DATA_DIR=output/dev-data PYTHONPATH=src python3 main.py
+```
 
 - `TOKDASH_USAGE_DB` (default: `1`) — set to `0`, `false`, `no`, or `off` to disable the persistent usage DB
 - `TOKDASH_DATA_DIR` (default: `~/.tokdash`) — base directory for Tokdash local state

--- a/README_CN.md
+++ b/README_CN.md
@@ -435,7 +435,13 @@ Tokdash 默认**只监听 localhost**。
 
 Tokdash 默认会在 `~/.tokdash/usage.sqlite3` 维护一个本地 SQLite 索引。它保存解析后的 token 行以及 Codex/Claude/Kimi/DeepSeek Harness/Reasonix 会话摘要，让仪表盘和 API 的重复读取可以走索引 SQL，而不是每次重新解析所有源日志。源日志仍然是事实来源；这个 DB 是本地性能索引，禁用或不可用时 Tokdash 会回退到实时解析。
 
-缓存的会话行不含价格：它们只保存每轮的计费输入（模型、新增输入、缓存读取与写入、输出），费用在读取时按当前进程加载的价格计算。因此修改价格会立即重算，而不需要重新读取数 GB 日志；共用同一个数据库的两个 Tokdash 版本（例如已安装的服务与源码检出）也不会因价格不同而互相作废对方的行。解析器变更与源文件变更仍会照常触发重新解析。此前写入的行（包括 `TOKDASH_USAGE_DB_DURABLE` 在源日志消失后保留的行）会按存储的合计值重算，结果一致，但无法再区分 Claude/Kimi 的缓存写入与新增输入；只有重新解析这些日志才能恢复该区分。Codex 按 `provider/model` 计费但只存裸模型名，因此它的旧行不会被复用，而是重新解析一次。
+缓存的会话行不含价格：它们只保存每轮的计费输入（模型、新增输入、缓存读取与写入、输出），费用在读取时按当前进程加载的价格计算。因此修改价格会立即重算，而不需要重新读取数 GB 日志；共用同一个数据库的两个 Tokdash 版本也不会因价格不同而互相作废对方的行。但只有在两个版本支持同一 DB schema 时共用才安全：schema 迁移只能向前，一旦较新的版本迁移了该文件，较旧的版本在升级前就无法再打开它，期间所有缓存读取都会失败。`tokdash doctor` 会同时报告磁盘上的 schema 与当前构建支持的 schema。解析器变更与源文件变更仍会照常触发重新解析。此前写入的行（包括 `TOKDASH_USAGE_DB_DURABLE` 在源日志消失后保留的行）会按存储的合计值重算，结果一致，但无法再区分 Claude/Kimi 的缓存写入与新增输入；只有重新解析这些日志才能恢复该区分。Codex 按 `provider/model` 计费但只存裸模型名，因此它的旧行不会被复用，而是重新解析一次。
+
+源码检出请使用独立的数据目录运行，避免迁移已安装服务所用的数据库：
+
+```bash
+TOKDASH_DATA_DIR=output/dev-data PYTHONPATH=src python3 main.py
+```
 
 - `TOKDASH_USAGE_DB`（默认：`1`）——设为 `0`、`false`、`no` 或 `off` 可禁用持久化使用量 DB
 - `TOKDASH_DATA_DIR`（默认：`~/.tokdash`）——Tokdash 本地状态目录

--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -76,13 +76,21 @@ tell "this is Tokdash" rather than trusting a generic `{"status":"ok"}` any app 
 Local version/provenance. `install_method` is read from the setup manifest
 (`<data_dir>/install.json`) when present, else `null`.
 
+`usage_db_schema_supported` is the usage-database schema version this build can
+read — a compile-time constant, not a read of the database, so this route stays
+as cheap as `/health`. Comparing it across two Tokdash processes that share a
+data directory is how a version skew is spotted without opening the file;
+migrations run forward only, so the older build cannot read a database the newer
+one has migrated. `tokdash doctor` reports the schema actually stored on disk.
+
 **Response**
 ```json
 {
   "service": "tokdash",
   "runtime_version": "1.0.7",
   "install_method": "pipx",
-  "update_check_enabled": false
+  "update_check_enabled": false,
+  "usage_db_schema_supported": 9
 }
 ```
 

--- a/src/tokdash/api.py
+++ b/src/tokdash/api.py
@@ -34,6 +34,8 @@ from .assets import (
 )
 from .compute import compute_stats, compute_usage_with_comparison, get_openclaw_data, get_tools_data
 from .dateutil import parse_date_range
+from .usage_store import SCHEMA_VERSION as USAGE_DB_SCHEMA_VERSION
+from .usage_store import UsageDatabaseSchemaTooNewError
 from .sessions import (
     SESSION_TOOLS,
     get_active_time_data,
@@ -976,6 +978,11 @@ def get_usage(
             force_refresh=refresh,
             include_cache_metadata=True,
         )
+    except UsageDatabaseSchemaTooNewError as e:
+        # 500, not 503: 503 is the dashboard retry signal, and a database
+        # written by a newer build never becomes readable on retry. Fail fast
+        # and carry the remediation in the detail.
+        raise HTTPException(status_code=500, detail=str(e))
     except CacheBackpressureError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
@@ -992,6 +999,11 @@ def get_openclaw(period: str = "today") -> Dict[str, Any]:
 
     try:
         return _cached_route("/api/openclaw", _pricing_cache_key(f"openclaw_{period}"), fetch)
+    except UsageDatabaseSchemaTooNewError as e:
+        # 500, not 503: 503 is the dashboard retry signal, and a database
+        # written by a newer build never becomes readable on retry. Fail fast
+        # and carry the remediation in the detail.
+        raise HTTPException(status_code=500, detail=str(e))
     except CacheBackpressureError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
@@ -1010,6 +1022,11 @@ def get_tools(period: str = "today") -> Dict[str, Any]:
             return data
 
         return _cached_route("/api/tools", _pricing_cache_key(f"tools_{period}"), fetch)
+    except UsageDatabaseSchemaTooNewError as e:
+        # 500, not 503: 503 is the dashboard retry signal, and a database
+        # written by a newer build never becomes readable on retry. Fail fast
+        # and carry the remediation in the detail.
+        raise HTTPException(status_code=500, detail=str(e))
     except CacheBackpressureError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
@@ -1027,6 +1044,11 @@ def get_quota() -> Dict[str, Any]:
         from .sources.quota import quota_state
 
         return _cached_route("/api/quota", "quota_state", quota_state)
+    except UsageDatabaseSchemaTooNewError as e:
+        # 500, not 503: 503 is the dashboard retry signal, and a database
+        # written by a newer build never becomes readable on retry. Fail fast
+        # and carry the remediation in the detail.
+        raise HTTPException(status_code=500, detail=str(e))
     except CacheBackpressureError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
@@ -1159,6 +1181,13 @@ def refresh_quota() -> Dict[str, Any]:
         snapshots = collect_enabled_snapshots(include_network=True, store=store)
         remember_current_snapshots(snapshots)
         inserted = store.insert_quota_snapshots(snapshots) if store is not None else 0
+    except UsageDatabaseSchemaTooNewError as e:
+        # Release the reservation first (same reason as below), then convert. A bare
+        # `raise` reaches FastAPI as a generic 500 whose body is "Internal Server
+        # Error", so the dashboard renders "HTTP 500" and the remediation this error
+        # exists to carry is lost on exactly the route a user hits when retrying.
+        _abort_quota_refresh()
+        raise HTTPException(status_code=500, detail=str(e))
     except Exception:
         # A failed refresh must not burn the cooldown slot: release the reservation so
         # the user can retry immediately instead of being locked out for 60 s by a 500.
@@ -1177,6 +1206,11 @@ def get_codex_sessions(period: str = "today", include_review_sessions: Optional[
             cache_key,
             lambda: get_codex_sessions_data(period, include_review_sessions=include_review_sessions),
         )
+    except UsageDatabaseSchemaTooNewError as e:
+        # 500, not 503: 503 is the dashboard retry signal, and a database
+        # written by a newer build never becomes readable on retry. Fail fast
+        # and carry the remediation in the detail.
+        raise HTTPException(status_code=500, detail=str(e))
     except CacheBackpressureError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
@@ -1221,6 +1255,11 @@ def get_sessions(
                 include_review_sessions=include_review_sessions,
             ),
         )
+    except UsageDatabaseSchemaTooNewError as e:
+        # 500, not 503: 503 is the dashboard retry signal, and a database
+        # written by a newer build never becomes readable on retry. Fail fast
+        # and carry the remediation in the detail.
+        raise HTTPException(status_code=500, detail=str(e))
     except CacheBackpressureError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except ValueError as e:
@@ -1258,6 +1297,11 @@ def get_active_time(
             ),
             force_refresh=refresh,
         )
+    except UsageDatabaseSchemaTooNewError as e:
+        # 500, not 503: 503 is the dashboard retry signal, and a database
+        # written by a newer build never becomes readable on retry. Fail fast
+        # and carry the remediation in the detail.
+        raise HTTPException(status_code=500, detail=str(e))
     except CacheBackpressureError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except ValueError as e:
@@ -1349,6 +1393,11 @@ async def serve_service_worker(request: Request):
 def get_stats(year: Optional[int] = None) -> Dict[str, Any]:
     try:
         return _cached_route("/api/stats", _pricing_cache_key(f"stats_{year}"), lambda: compute_stats(year))
+    except UsageDatabaseSchemaTooNewError as e:
+        # 500, not 503: 503 is the dashboard retry signal, and a database
+        # written by a newer build never becomes readable on retry. Fail fast
+        # and carry the remediation in the detail.
+        raise HTTPException(status_code=500, detail=str(e))
     except CacheBackpressureError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
@@ -1364,6 +1413,11 @@ def get_activity_insights(refresh: bool = False) -> dict[str, Any]:
             get_codex_activity_insights,
             force_refresh=refresh,
         )
+    except UsageDatabaseSchemaTooNewError as e:
+        # 500, not 503: 503 is the dashboard retry signal, and a database
+        # written by a newer build never becomes readable on retry. Fail fast
+        # and carry the remediation in the detail.
+        raise HTTPException(status_code=500, detail=str(e))
     except CacheBackpressureError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:  # noqa: BLE001 - isolate parser/index failures from other routes
@@ -1404,6 +1458,11 @@ async def get_version() -> Dict[str, Any]:
         "runtime_version": __version__,
         "install_method": manifest.get("install_method"),
         "update_check_enabled": _update_check_enabled(),
+        # The usage-DB schema this build can read. A constant, not a DB read, so
+        # this route stays as cheap as /health — comparing it against another
+        # process's value is how a version skew is spotted without opening the
+        # database. `tokdash doctor` reports what the file on disk actually holds.
+        "usage_db_schema_supported": USAGE_DB_SCHEMA_VERSION,
     }
 
 

--- a/src/tokdash/compute.py
+++ b/src/tokdash/compute.py
@@ -17,6 +17,7 @@ from .sources.openclaw import get_usage_for_range as get_session_usage_range
 from .sources.openclaw import get_usage_for_year as get_session_usage_year
 from .sources.coding_tools import CodingToolsUsageTracker
 from .usage_store import (
+    UsageDatabaseSchemaTooNewError,
     UsageEntryStore,
     build_source_signature,
     persistent_pricing_signature,
@@ -159,6 +160,10 @@ def _sync_usage_store(tracker: CodingToolsUsageTracker) -> tuple[UsageEntryStore
     # under; a sync that lands after another process has moved the database on
     # drops the stored identity rather than committing costs under someone
     # else's (see UsageEntryStore._drop_stale_pricing_identity).
+    # This connect also doubles as the too-new-schema guard for every path below:
+    # it runs BEFORE the parsers enumerate their source files, so a mismatched
+    # database costs one open here rather than a full discovery scan per request.
+    # Keep it ahead of the loop -- moving it after would reintroduce that scan.
     store.apply_pricing(pricing, tracker.pricing_db)
     for name in selected:
         parser = tracker.parsers[name]
@@ -357,6 +362,10 @@ def run_local_coding_tools_json(period_args: list[str]) -> Dict[str, Any]:
             entries.extend(_collect_live_coding_entries(tracker, since, until, _usage_store_live_sources(tracker)))
             entries.sort(key=lambda e: int(e.get("timestamp", 0) or 0))
             return {"entries": entries}
+        except UsageDatabaseSchemaTooNewError:
+            # A newer database is terminal for this build; reparsing the logs
+            # instead would hide the skew behind a permanent full-history reparse.
+            raise
         except Exception:
             # The persistent DB is a cache. If it is corrupt or temporarily
             # unavailable, preserve current behavior by falling back to the live
@@ -682,6 +691,11 @@ def get_tools_data_for_range(since: Optional[datetime], until: Optional[datetime
                 # "unavailable" instead of a zero that reads as "no usage".
                 result["source_errors"] = [e["source"] for e in tracker.source_errors]
                 return result
+            except UsageDatabaseSchemaTooNewError:
+                # Fail-open covers a sick cache, not an unreadable one: a newer
+                # schema never heals on retry, so degrading here would reparse the
+                # full history on every request.
+                raise
             except Exception:
                 # Keep the DB fail-open: serving correctness should not depend on
                 # cache health while this backend is still evolving.
@@ -712,6 +726,8 @@ def get_tools_contributions_for_range(since: Optional[datetime], until: Optional
                 live_entries = _collect_live_coding_entries(tracker, since, until, _usage_store_live_sources(tracker))
                 live_days = _contributions_from_entries(live_entries)
                 return _merge_contribution_days([store_days, live_days])
+            except UsageDatabaseSchemaTooNewError:
+                raise
             except Exception:
                 pass
         tracker.collect(since, until)

--- a/src/tokdash/onboard/engine.py
+++ b/src/tokdash/onboard/engine.py
@@ -805,6 +805,9 @@ def cmd_doctor(opts: Options) -> int:
     service_info = _doctor_service(man, detection)
     _append_service_issues(issues, man, service_info, detection)
 
+    usage_db = _doctor_usage_db()
+    _append_usage_db_issues(issues, usage_db)
+
     from .. import __version__
 
     report = {
@@ -824,6 +827,7 @@ def cmd_doctor(opts: Options) -> int:
         "port": detection["port"],
         "update_check": _doctor_update_check(),
         "quota": _doctor_quota(),
+        "usage_db": usage_db,
         "issues": issues,
     }
 
@@ -926,6 +930,80 @@ def _doctor_update_check() -> Dict[str, Any]:
     from .. import __version__
 
     return {"enabled": True, **updatecheck.check(__version__)}
+
+
+def _doctor_usage_db() -> Dict[str, Any]:
+    """Usage-database schema state for `tokdash doctor`.
+
+    Deliberately does NOT open the database through ``UsageEntryStore``: that path
+    migrates on connect, and doctor has to be able to *report* a database written
+    by a newer build without touching it. A read-only URI connection and a single
+    ``meta`` lookup keep this diagnostic side-effect free.
+    """
+    try:
+        import sqlite3
+        from contextlib import closing
+
+        from ..clientpaths import usage_db_path
+        from ..usage_store import (
+            SCHEMA_VERSION,
+            persistent_usage_db_enabled,
+            read_stored_schema_version,
+        )
+    except Exception:
+        return {"available": False}
+
+    path = usage_db_path()
+    info: Dict[str, Any] = {
+        "available": True,
+        "enabled": persistent_usage_db_enabled(),
+        "supported_schema": int(SCHEMA_VERSION),
+        "path": str(path),
+        "present": path.exists(),
+    }
+    if not info["present"]:
+        return info
+    try:
+        # as_uri() percent-escapes the path and emits the drive-letter form
+        # Windows needs. Interpolating into "file:{path}" instead lets a `?`, `#`
+        # or `%` in a data dir terminate the path early and silently open a
+        # *different* file (or none), which a diagnostic must never do.
+        uri = path.resolve().as_uri() + "?mode=ro"
+        with closing(sqlite3.connect(uri, uri=True, timeout=5)) as conn:
+            conn.row_factory = sqlite3.Row
+            info["stored_schema"] = read_stored_schema_version(conn)
+    except Exception as exc:
+        info["error"] = str(exc)
+    return info
+
+
+def _append_usage_db_issues(issues: List[str], usage_db: Dict[str, Any]) -> None:
+    if not usage_db.get("available") or not usage_db.get("enabled"):
+        # TOKDASH_USAGE_DB=0: nothing reads the file, so its schema cannot affect
+        # a single request. Reporting it would fail doctor over a dormant file.
+        return
+    if not usage_db.get("present"):
+        return
+    if usage_db.get("error"):
+        # Enabled but unreadable is a real fault: every cached read goes through
+        # this file. Printing "unreadable" while doctor still exits 0 is exactly
+        # the silent degradation this whole change exists to remove.
+        issues.append(
+            f"usage database at {usage_db.get('path')} could not be inspected: "
+            f"{usage_db['error']}"
+        )
+        return
+    stored = usage_db.get("stored_schema")
+    supported = usage_db.get("supported_schema")
+    if stored is None or supported is None:
+        return
+    if int(stored) > int(supported):
+        issues.append(
+            f"usage database schema {stored} is newer than this build supports "
+            f"({supported}) — every cached read fails until the versions match. "
+            "Run `tokdash update`, then restart any other Tokdash process using "
+            f"{usage_db.get('path') or 'this data directory'}."
+        )
 
 
 def _doctor_quota() -> Dict[str, Any]:
@@ -1747,6 +1825,19 @@ def _print_doctor_human(r: Dict[str, Any]) -> None:
         snaps = q.get("snapshots")
         last_str = "never" if not last else time.strftime("%Y-%m-%d %H:%M", time.localtime(int(last)))
         print(f"  Quota data:   {snaps if snaps is not None else '—'} snapshots, last poll {last_str}")
+    db = r.get("usage_db", {})
+    if db.get("available"):
+        supported = db.get("supported_schema")
+        if not db.get("enabled"):
+            print(f"  Usage DB:     disabled (TOKDASH_USAGE_DB), this build reads schema {supported}")
+        elif not db.get("present"):
+            print(f"  Usage DB:     not created yet (this build writes schema {supported})")
+        elif db.get("error"):
+            print(f"  Usage DB:     unreadable ({db['error']})")
+        else:
+            stored = db.get("stored_schema")
+            shown = "pre-versioned" if stored is None else f"schema {stored}"
+            print(f"  Usage DB:     {shown} (this build supports {supported})")
     for issue in r["issues"]:
         print(f"  {_warn('⚠')} {issue}")
 

--- a/src/tokdash/sessions.py
+++ b/src/tokdash/sessions.py
@@ -42,7 +42,13 @@ from .sources.dsh_log import (
     dsh_file_signatures,
     fold_dsh_usage_samples,
 )
-from .usage_store import UsageEntryStore, parser_code_signature, persistent_usage_db_enabled
+from .usage_store import (
+    UsageDatabaseSchemaTooNewError,
+    UsageEntryStore,
+    parser_code_signature,
+    persistent_usage_db_enabled,
+    raise_if_usage_db_incompatible,
+)
 
 
 SESSION_TOOLS = ("codex", "claude", "opencode", "pi_agent", "mimo", "kimi", "dsh", "reasonix", "zcode")
@@ -1664,6 +1670,10 @@ def _codex_session_parser_signature() -> dict[str, Any]:
 
 
 def get_codex_activity_insights() -> dict[str, Any]:
+    # Ahead of _codex_file_signatures(): that walk is the expensive half of this
+    # call, and a too-new database throws its result away.
+    if persistent_usage_db_enabled():
+        raise_if_usage_db_incompatible()
     signatures = _codex_file_signatures()
     pricing_sig = _pricing_signature()
     if not persistent_usage_db_enabled():
@@ -3838,6 +3848,11 @@ def _raw_sessions_for_tool(
     if key in {"codex", "claude", "kimi", "dsh", "reasonix"} and persistent_usage_db_enabled():
         try:
             return _stored_sessions_for_tool(key, since_ms=since_ms, until_ms=until_ms)
+        except UsageDatabaseSchemaTooNewError:
+            # Terminal, not transient. Falling back would reparse every source log
+            # on every request for as long as the version skew lasts, which is
+            # vastly worse than surfacing the error once.
+            raise
         except Exception:
             logger.warning(
                 "tokdash persistent session cache failed tool=%s; falling back to source files",
@@ -3926,6 +3941,9 @@ def _stored_sessions_for_tool(
     until_ms: Optional[int] = None,
 ) -> Dict[str, Dict[str, Any]]:
     store = UsageEntryStore()
+    # Before any signature scan: every branch below enumerates that tool's whole
+    # session tree, and on a too-new database all of it is wasted.
+    store.check_compatible()
     if tool == "codex":
         signatures = _codex_file_signatures()
         pricing_sig = _pricing_signature()

--- a/src/tokdash/sources/openclaw.py
+++ b/src/tokdash/sources/openclaw.py
@@ -12,10 +12,12 @@ try:
     from ..pricing import PricingDatabase
     from ..usage_store import (
         USAGE_ENTRY_FORMAT_VERSION,
+        UsageDatabaseSchemaTooNewError,
         UsageEntryStore,
         build_source_signature,
         persistent_pricing_signature,
         persistent_usage_db_enabled,
+        raise_if_usage_db_incompatible,
         usage_billing_pricing,
     )
 except ImportError:  # pragma: no cover
@@ -23,6 +25,14 @@ except ImportError:  # pragma: no cover
     from clientpaths import openclaw_agent_sessions_glob
     from pricing import PricingDatabase
     USAGE_ENTRY_FORMAT_VERSION = 1  # type: ignore
+
+    class UsageDatabaseSchemaTooNewError(RuntimeError):  # type: ignore
+        """Stand-in so the fail-fast `except` clauses below stay valid.
+
+        This branch has no store (``UsageEntryStore is None``), so the guarded
+        cache paths never run and this is never raised.
+        """
+
     UsageEntryStore = None  # type: ignore
     build_source_signature = None  # type: ignore
     persistent_pricing_signature = None  # type: ignore
@@ -30,6 +40,10 @@ except ImportError:  # pragma: no cover
 
     def persistent_usage_db_enabled() -> bool:  # type: ignore
         return False
+
+    def raise_if_usage_db_incompatible(db_path=None) -> None:  # type: ignore
+        """No-op: this branch has no store, so there is no database to guard."""
+        return None
 
 
 def _cache_hit_rate(tokens_in: Any, tokens_cache: Any) -> Optional[float]:
@@ -313,6 +327,11 @@ def _collect_normalized_entries(
         try:
             store = _sync_openclaw_store(session_dirs, pricing_db)
             return store.query_entries(sources=["openclaw"], since=since_date, until=until_date)
+        except UsageDatabaseSchemaTooNewError:
+            # Terminal: retrying or rereading the session logs cannot make a newer
+            # database readable, and doing so on every request is what turns a
+            # version skew into a pinned server.
+            raise
         except Exception:
             pass
 
@@ -336,6 +355,9 @@ def _openclaw_parser_signature() -> dict:
 
 
 def _sync_openclaw_store(session_dirs: list[str], pricing_db: PricingDatabase) -> UsageEntryStore:
+    # First, before _session_files()/_signature() glob and stat the session tree:
+    # on a too-new database that discovery is pure waste, repeated per request.
+    raise_if_usage_db_incompatible()
     files = _session_files(session_dirs)
     sig = _signature(files)
     store = UsageEntryStore()
@@ -490,6 +512,8 @@ def get_session_usage(
     if persistent_usage_db_enabled() and UsageEntryStore is not None:
         try:
             return _openclaw_usage_from_store(_sync_openclaw_store(session_dirs, pricing_db), since_date, until_date)
+        except UsageDatabaseSchemaTooNewError:
+            raise
         except Exception:
             pass
 

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -4808,19 +4808,35 @@
       }
     }
 
-    async function fetchSelectedServers(path, options = {}, retryOptions = {}) {
-      const servers = selectedServers();
-      const settled = await Promise.allSettled(servers.map((server) => fetchJsonWithRetry(server, path, options, retryOptions)));
+    // Shared settlement policy for ANY per-server fan-out: record each server's
+    // health, refresh the indicator, and keep the first real rejection so a total
+    // failure can report what the server actually said rather than a generic
+    // loadFailed. Both this module's loader and the Quota tab's own fan-out go
+    // through here — they diverged once, and the Quota page silently dropped the
+    // usage-DB `tokdash update` remediation for as long as they did.
+    function collectServerResults(servers, settled) {
       const successes = [];
+      let firstError = null;
       settled.forEach((result, index) => {
         const server = servers[index];
         const ok = result.status === 'fulfilled';
         serverRuntimeStatus.set(server.id, { ok, error: ok ? null : result.reason, checkedAt: Date.now() });
-        if (ok) successes.push({ server, payload: result.value });
+        if (ok) successes.push({ server, value: result.value });
+        else if (!firstError) firstError = result.reason;
       });
       renderServerSettings();
       updateServerIndicator();
-      return successes;
+      return { successes, firstError };
+    }
+
+    async function fetchSelectedServers(path, options = {}, retryOptions = {}) {
+      const servers = selectedServers();
+      const settled = await Promise.allSettled(servers.map((server) => fetchJsonWithRetry(server, path, options, retryOptions)));
+      const { successes, firstError } = collectServerResults(servers, settled);
+      // Partial success is unchanged: the rows that worked are returned and the
+      // failed servers stay flagged on the indicator.
+      if (!successes.length && firstError) throw firstError;
+      return successes.map(({ server, value }) => ({ server, payload: value }));
     }
 
     function updateServerIndicator() {
@@ -4858,7 +4874,9 @@
         const state = serverRuntimeStatus.get(server.id);
         status.className = 'server-health-dot';
         status.dataset.state = state ? (state.ok ? 'ok' : 'error') : 'idle';
-        status.title = state ? t(state.ok ? 'serverStatusOk' : 'serverStatusError') : t('serverStatusIdle');
+        const statusTitle = state ? t(state.ok ? 'serverStatusOk' : 'serverStatusError') : t('serverStatusIdle');
+        const statusDetail = (state && !state.ok && typeof state.error?.message === 'string') ? state.error.message.trim() : '';
+        status.title = statusDetail ? `${statusTitle}: ${statusDetail}` : statusTitle;
         status.setAttribute('aria-label', status.title);
         const checkbox = document.createElement('input');
         checkbox.type = 'checkbox'; checkbox.className = 'server-select'; checkbox.checked = selectedIds.has(server.id);
@@ -4989,10 +5007,20 @@
       document.getElementById('addServerBtn')?.addEventListener('click', storeServerFromForm);
     }
 
+    function dashboardFetchStatusText(error) {
+      // 503 is the transient-overload signal and already has its own wording.
+      if (error?.status === 503) return t('temporaryOverload');
+      // Anything else carries a server-authored, actionable detail (a usage-DB
+      // schema mismatch says to run `tokdash update`). Dropping it for a bare
+      // "load failed" is what left users with no way to act on the outage.
+      const detail = typeof error?.message === 'string' ? error.message.trim() : '';
+      return detail ? `${t('loadFailed')}: ${detail}` : t('loadFailed');
+    }
+
     function setDashboardFetchStatus(error) {
       const lastUpdate = document.getElementById('lastUpdate');
       if (!lastUpdate) return;
-      lastUpdate.textContent = error?.status === 503 ? t('temporaryOverload') : t('loadFailed');
+      lastUpdate.textContent = dashboardFetchStatusText(error);
     }
 
     function syncCodexReviewToggle() {
@@ -7513,10 +7541,33 @@
     // it is redundant with the per-bar "Updated x min ago" shown on each provider card.
     let quotaActionStatusResetTimer = null;
 
-    function setQuotaActionStatus(state) {
-      const el = selectedServers().length > 1
+    function quotaStatusElement() {
+      return selectedServers().length > 1
         ? document.getElementById('quotaGlobalStatusLine')
         : document.getElementById('quotaStatusLine');
+    }
+
+    // A failed quota LOAD is not a transient write ack: it must not auto-clear, or
+    // the remediation vanishes a second after it appears. Pass null to clear it
+    // once a load succeeds.
+    function setQuotaFetchStatus(error) {
+      const el = quotaStatusElement();
+      if (!el) return;
+      if (quotaActionStatusResetTimer) {
+        clearTimeout(quotaActionStatusResetTimer);
+        quotaActionStatusResetTimer = null;
+      }
+      if (!error) {
+        el.style.color = 'var(--color-muted)';
+        el.textContent = '';
+        return;
+      }
+      el.style.color = '#DC2626';
+      el.textContent = dashboardFetchStatusText(error);
+    }
+
+    function setQuotaActionStatus(state) {
+      const el = quotaStatusElement();
       if (!el) return;
       if (quotaActionStatusResetTimer) {
         clearTimeout(quotaActionStatusResetTimer);
@@ -8406,9 +8457,12 @@
         const historyPath = `/api/quota/history?granularity=${encodeURIComponent(granularity)}${start ? `&start=${start}` : ''}`;
         const servers = selectedServers();
         const settled = await Promise.allSettled(servers.map(async (server) => ({ server, payload: await fetchJsonWithRetry(server, '/api/quota'), history: await fetchJsonWithRetry(server, historyPath) })));
-        const rows = settled.filter((result) => result.status === 'fulfilled').map((result) => result.value);
-        settled.forEach((result, index) => serverRuntimeStatus.set(servers[index].id, { ok: result.status === 'fulfilled', error: result.status === 'rejected' ? result.reason : null, checkedAt: Date.now() }));
-        if (!rows.length) throw new Error(t('loadFailed'));
+        const { successes, firstError } = collectServerResults(servers, settled);
+        // Preserve the original rejection so a usage-DB schema mismatch reaches the
+        // status line instead of being flattened into loadFailed.
+        if (!successes.length) throw firstError || new Error(t('loadFailed'));
+        const rows = successes.map(({ value }) => value);
+        setQuotaFetchStatus(null);
         const multi = servers.length > 1;
         positionQuotaGlobalControls(multi);
         setQuotaSingleServerLayout(multi);
@@ -8428,13 +8482,19 @@
           renderQuotaProviderCards(payload);
           renderQuotaCharts(history);
         }
+        return true;
       } catch (error) {
         console.error('Error loading quota:', error);
+        setQuotaFetchStatus(error);
         if (lastQuotaServerRows.length <= 1) {
           if (lastQuotaPayload) renderQuotaSettings(lastQuotaPayload);
           if (lastQuotaPayload) renderQuotaProviderCards(lastQuotaPayload);
           if (lastQuotaHistory) renderQuotaCharts(lastQuotaHistory);
         }
+        // Reported rather than rethrown: callers that follow a write with a reload
+        // must not acknowledge "saved" over an active fetch error (which would also
+        // schedule its removal), but a failed reload is not a failed write either.
+        return false;
       }
     }
 
@@ -8442,8 +8502,7 @@
       setQuotaActionStatus('saving');
       try {
         await postJsonWithCsrf(server, '/api/quota/consent', { [key]: true });
-        await loadQuota({ force: true });
-        setQuotaActionStatus('saved');
+        if (await loadQuota({ force: true })) setQuotaActionStatus('saved');
       } catch (error) {
         setQuotaActionStatus(error?.status === 403 ? 'readonly' : 'error');
       }
@@ -8453,8 +8512,7 @@
       setQuotaActionStatus('saving');
       try {
         await postJsonWithCsrf(server, '/api/quota/consent', { credential_scan: !!enabled });
-        await loadQuota({ force: true });
-        setQuotaActionStatus('saved');
+        if (await loadQuota({ force: true })) setQuotaActionStatus('saved');
       } catch (error) {
         setQuotaActionStatus(error?.status === 403 ? 'readonly' : 'error');
       }
@@ -8464,8 +8522,7 @@
       setQuotaActionStatus('saving');
       try {
         await postJsonWithCsrf(server, '/api/quota/settings', { enabled: !!enabled });
-        await loadQuota({ force: true });
-        setQuotaActionStatus('saved');
+        if (await loadQuota({ force: true })) setQuotaActionStatus('saved');
       } catch (error) {
         setQuotaActionStatus(error?.status === 403 ? 'readonly' : 'error');
       }
@@ -8475,8 +8532,7 @@
       setQuotaActionStatus('saving');
       try {
         await postJsonWithCsrf(server, '/api/quota/settings', { poll_interval_minutes: Number(minutes) });
-        await loadQuota({ force: true });
-        setQuotaActionStatus('saved');
+        if (await loadQuota({ force: true })) setQuotaActionStatus('saved');
       } catch (error) {
         setQuotaActionStatus(error?.status === 403 ? 'readonly' : 'error');
       }
@@ -8499,8 +8555,8 @@
         const settled = await Promise.allSettled(selectedServers().map((server) => fetchJsonWithRetry(server, '/api/quota/refresh', { cache: 'no-store' })));
         const rejected = settled.find((result) => result.status === 'rejected');
         if (rejected && settled.every((result) => result.status === 'rejected')) throw rejected.reason;
-        await loadQuota({ force: true });
-        setRefreshUiState('updated', { resetAfterMs: 1800 });
+        const reloaded = await loadQuota({ force: true });
+        setRefreshUiState(reloaded ? 'updated' : 'failed', { resetAfterMs: reloaded ? 1800 : 2600 });
       } catch (error) {
         if (error?.status === 429) {
           await loadQuota({ force: true }).catch(() => {});
@@ -8508,6 +8564,11 @@
           return;
         }
         setRefreshUiState(error?.status === 503 ? 'busy' : 'failed', { resetAfterMs: 2600 });
+        // The button state carries no detail and resets after 2.6s. 503 already has
+        // its own transient 'busy' state, so leaving a persistent banner for it would
+        // be noise -- but a non-transient failure (a usage-DB schema mismatch) must
+        // leave its remediation on screen until a load succeeds.
+        if (error?.status !== 503) setQuotaFetchStatus(error);
       }
     }
 

--- a/src/tokdash/usage_store.py
+++ b/src/tokdash/usage_store.py
@@ -20,6 +20,83 @@ from .pricing import PricingDatabase
 SCHEMA_VERSION = 9
 SIGNATURE_VERSION = 3
 
+
+class UsageDatabaseSchemaTooNewError(RuntimeError):
+    """The usage database was written by a newer Tokdash than this build.
+
+    Terminal for this process, not a transient cache fault: migrations only run
+    forward, so no amount of retrying makes a newer database readable. Every
+    cache fallback re-raises this before degrading to the source-log parsers —
+    treating it as "the cache is sick, reread the logs" turns one stale process
+    into a full-history reparse on *every* request, which is how a single
+    version skew pinned a live server at multi-GB RSS until it was restarted.
+
+    Carries the operator-actionable facts: which database, what it holds, and
+    what this build supports.
+    """
+
+    def __init__(self, *, path: Any, found: int, supported: int) -> None:
+        self.path = Path(str(path))
+        self.found = int(found)
+        self.supported = int(supported)
+        super().__init__(
+            f"usage database schema {self.found} at {self.path} is newer than "
+            f"this Tokdash supports (<= {self.supported}); run `tokdash update` "
+            "and restart any other Tokdash processes using this data directory"
+        )
+
+
+def read_stored_schema_version(conn: sqlite3.Connection) -> Optional[int]:
+    """Schema version recorded in ``meta``, or None if this DB predates it.
+
+    None covers both a brand-new (tableless) file and a legacy database with no
+    ``schema_version`` row; both are migrated forward normally.
+    """
+    if conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'meta'"
+    ).fetchone() is None:
+        return None
+    row = conn.execute("SELECT value FROM meta WHERE key = 'schema_version'").fetchone()
+    if row is None:
+        return None
+    try:
+        return int(row["value"])
+    except (TypeError, ValueError):
+        return None
+
+
+def raise_if_usage_db_incompatible(db_path: Optional[Path] = None) -> None:
+    """Cheap pre-flight: refuse a too-new database before any source discovery.
+
+    The full ``_connect`` path already rejects one, but callers reach it only
+    after enumerating their source files — a recursive scan of thousands of
+    session logs. Since the failure is deliberately not cached, every request
+    would repeat that scan and hold a compute slot just to fail again. This runs
+    first: a read-only open and one ``meta`` lookup, no DDL and no migration.
+
+    Silent on anything else. A missing, corrupt or unopenable file is not this
+    function's call to make — the normal connect path reports it, and the
+    ordinary cache fallbacks still cover it.
+    """
+    path = Path(db_path) if db_path is not None else usage_db_path()
+    if not path.exists():
+        return
+    try:
+        conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True, timeout=5)
+    except (sqlite3.Error, ValueError, OSError):
+        return
+    try:
+        conn.row_factory = sqlite3.Row
+        found = read_stored_schema_version(conn)
+    except sqlite3.Error:
+        return
+    finally:
+        conn.close()
+    if found is not None and found > SCHEMA_VERSION:
+        raise UsageDatabaseSchemaTooNewError(
+            path=path, found=found, supported=SCHEMA_VERSION
+        )
+
 # What a persistent usage row must carry to be priceable without rereading its
 # source log: the `_billing` provenance record built by the parsers below and
 # stored in usage_entries.billing_json. Every persistent usage-parser signature
@@ -780,7 +857,26 @@ class UsageEntryStore:
         version = conn.execute("SELECT value FROM meta WHERE key = 'schema_version'").fetchone()
         return version is not None and int(version["value"]) == SCHEMA_VERSION
 
+    def check_compatible(self) -> None:
+        """Public pre-flight guard: see :func:`raise_if_usage_db_incompatible`.
+
+        Call this before enumerating source files, not after.
+        """
+        raise_if_usage_db_incompatible(self.path)
+
+    def _raise_if_schema_too_new(self, conn: sqlite3.Connection) -> None:
+        found = read_stored_schema_version(conn)
+        if found is not None and found > SCHEMA_VERSION:
+            raise UsageDatabaseSchemaTooNewError(
+                path=self.path, found=found, supported=SCHEMA_VERSION
+            )
+
     def _ensure_schema(self, conn: sqlite3.Connection) -> None:
+        # Refuse a newer database BEFORE touching it. Everything below this line
+        # mutates: journal_mode flips the file into WAL, the DDL adds tables, and
+        # the migration chain rewrites rows. None of that is safe against a layout
+        # written by a build we do not know, and none of it is reversible.
+        self._raise_if_schema_too_new(conn)
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA synchronous=NORMAL")
         conn.executescript(
@@ -918,8 +1014,14 @@ class UsageEntryStore:
         )
         row = conn.execute("SELECT value FROM meta WHERE key = 'schema_version'").fetchone()
         current = int(row["value"]) if row else 0
+        # Re-checked under the DDL above: another process may have migrated this
+        # database forward between our pre-mutation check and here. The DDL is all
+        # CREATE ... IF NOT EXISTS / additive ALTERs, so reaching this point on a
+        # newer file has not corrupted it — but the migration chain below would.
         if current > SCHEMA_VERSION:
-            raise RuntimeError(f"unsupported usage DB schema {current}; expected <= {SCHEMA_VERSION}")
+            raise UsageDatabaseSchemaTooNewError(
+                path=self.path, found=current, supported=SCHEMA_VERSION
+            )
         if current < 8:
             # Legacy rows predate billing provenance. Their cost was computed
             # under pricing this build cannot identify, so it is preserved as a

--- a/tests/test_usage_db_schema_frontend.py
+++ b/tests/test_usage_db_schema_frontend.py
@@ -1,0 +1,631 @@
+"""The usage-DB schema remediation must survive the trip to the dashboard.
+
+The backend fails fast with an actionable message ("run `tokdash update`"), but
+that only helps if the UI shows it. Previously `fetchSelectedServers` swallowed
+every rejection and returned [], and each caller substituted a generic
+`loadFailed` -- so a user saw "不可用：Local / 数据加载失败" and had nothing to act
+on. These tests pin the message end to end through the two frontend seams.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import tokdash
+
+INDEX_HTML = Path(tokdash.__file__).parent / "static" / "index.html"
+
+# What the backend actually puts in the HTTP 500 body (api.py -> str(exc)).
+SCHEMA_DETAIL = (
+    "usage database schema 11 at /home/u/.tokdash/usage.sqlite3 is newer than "
+    "this Tokdash supports (<= 9); run `tokdash update` and restart any other "
+    "Tokdash processes using this data directory"
+)
+
+needs_node = pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+
+
+def _extract_js_function(src: str, signature: str) -> str:
+    """Slice one function out of index.html, parameter defaults included.
+
+    The naive "count braces from the first `{`" approach used elsewhere in the
+    suite stops at the first default-value object literal -- `fetchSelectedServers`
+    declares `options = {}`, so the scan would open and close on the parameter
+    list and return a stub. The parameter list is therefore skipped by matching
+    parentheses first, and only then is the body brace-matched.
+    """
+    start = src.find(signature)
+    assert start >= 0, f"{signature} not found"
+
+    index = src.index("(", start)
+    depth = 0
+    while index < len(src):
+        if src[index] == "(":
+            depth += 1
+        elif src[index] == ")":
+            depth -= 1
+            if depth == 0:
+                break
+        index += 1
+    else:  # pragma: no cover - malformed source
+        raise AssertionError(f"unterminated parameter list: {signature}")
+
+    depth = 0
+    for index in range(src.index("{", index), len(src)):
+        if src[index] == "{":
+            depth += 1
+        elif src[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : index + 1]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
+def _functions() -> str:
+    src = INDEX_HTML.read_text(encoding="utf-8")
+    return "\n".join(
+        [
+            _extract_js_function(src, "function collectServerResults("),
+            _extract_js_function(src, "async function fetchSelectedServers("),
+            _extract_js_function(src, "function dashboardFetchStatusText("),
+        ]
+    )
+
+
+# Stubs for everything the two extracted functions touch. `t()` returns the key
+# so an assertion can tell "the i18n key was used" from "the detail was kept".
+HARNESS_PREAMBLE = """
+const scenario = JSON.parse(process.argv[2]);
+const serverRuntimeStatus = new Map();
+let renderCalls = 0;
+let indicatorCalls = 0;
+function renderServerSettings() { renderCalls += 1; }
+function updateServerIndicator() { indicatorCalls += 1; }
+function t(key) { return key; }
+function selectedServers() { return scenario.servers.map((s) => ({ id: s.id, label: s.label })); }
+function makeError(spec) {
+  const error = new Error(spec.message);
+  if (spec.status !== undefined && spec.status !== null) error.status = spec.status;
+  return error;
+}
+async function fetchJsonWithRetry(server) {
+  const spec = scenario.servers.find((s) => s.id === server.id);
+  if (spec.fails) throw makeError(spec);
+  return spec.payload;
+}
+"""
+
+
+def _run_node(tmp_path: Path, body: str, scenario: dict):
+    harness = tmp_path / "harness.js"
+    harness.write_text(_functions() + HARNESS_PREAMBLE + body, encoding="utf-8")
+    result = subprocess.run(
+        ["node", str(harness), json.dumps(scenario)],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    return json.loads(result.stdout)
+
+
+FETCH_BODY = """
+(async () => {
+  const out = {};
+  try {
+    const rows = await fetchSelectedServers('/api/usage?period=today');
+    out.threw = false;
+    out.rows = rows.map((row) => ({ id: row.server.id, payload: row.payload }));
+  } catch (error) {
+    out.threw = true;
+    out.message = error.message;
+    out.status = error.status === undefined ? null : error.status;
+    out.statusText = dashboardFetchStatusText(error);
+  }
+  out.failedTooltips = [...serverRuntimeStatus.entries()]
+    .filter(([, state]) => !state.ok)
+    .map(([id, state]) => ({ id, message: state.error ? state.error.message : null }));
+  process.stdout.write(JSON.stringify(out));
+})();
+"""
+
+
+@needs_node
+def test_sole_server_failure_propagates_the_schema_message(tmp_path: Path) -> None:
+    out = _run_node(
+        tmp_path,
+        FETCH_BODY,
+        {"servers": [{"id": "local", "label": "Local", "fails": True, "status": 500, "message": SCHEMA_DETAIL}]},
+    )
+    assert out["threw"] is True
+    # The ORIGINAL rejection, not a substituted generic error.
+    assert out["message"] == SCHEMA_DETAIL
+    assert out["status"] == 500
+    # ...and it reaches the status line the user actually reads.
+    assert "tokdash update" in out["statusText"]
+    assert "loadFailed" in out["statusText"]
+
+
+@needs_node
+def test_all_servers_failing_propagates_the_first_rejection(tmp_path: Path) -> None:
+    out = _run_node(
+        tmp_path,
+        FETCH_BODY,
+        {
+            "servers": [
+                {"id": "local", "label": "Local", "fails": True, "status": 500, "message": SCHEMA_DETAIL},
+                {"id": "remote", "label": "Remote", "fails": True, "status": 500, "message": "something else"},
+            ]
+        },
+    )
+    assert out["threw"] is True
+    assert out["message"] == SCHEMA_DETAIL
+    # Every failed server keeps its own reason for the per-server tooltip.
+    assert {row["id"] for row in out["failedTooltips"]} == {"local", "remote"}
+    assert any("tokdash update" in (row["message"] or "") for row in out["failedTooltips"])
+
+
+@needs_node
+def test_partial_success_still_returns_rows_and_does_not_throw(tmp_path: Path) -> None:
+    """One healthy server must keep the dashboard rendering, as before."""
+    out = _run_node(
+        tmp_path,
+        FETCH_BODY,
+        {
+            "servers": [
+                {"id": "local", "label": "Local", "fails": True, "status": 500, "message": SCHEMA_DETAIL},
+                {"id": "remote", "label": "Remote", "fails": False, "payload": {"total_cost": 1.5}},
+            ]
+        },
+    )
+    assert out["threw"] is False
+    assert [row["id"] for row in out["rows"]] == ["remote"]
+    assert out["rows"][0]["payload"] == {"total_cost": 1.5}
+    # The broken server is still flagged, with its reason retained.
+    assert out["failedTooltips"] == [{"id": "local", "message": SCHEMA_DETAIL}]
+
+
+@needs_node
+def test_no_servers_selected_returns_empty_without_throwing(tmp_path: Path) -> None:
+    out = _run_node(tmp_path, FETCH_BODY, {"servers": []})
+    assert out["threw"] is False and out["rows"] == []
+
+
+STATUS_BODY = """
+process.stdout.write(JSON.stringify(
+  scenario.cases.map((spec) => dashboardFetchStatusText(makeError(spec)))
+));
+"""
+
+
+@needs_node
+def test_status_text_keeps_detail_but_not_for_503(tmp_path: Path) -> None:
+    out = _run_node(
+        tmp_path,
+        STATUS_BODY,
+        {
+            "cases": [
+                {"status": 500, "message": SCHEMA_DETAIL},
+                {"status": 503, "message": "Too many cold requests; retry shortly"},
+                {"status": None, "message": ""},
+            ]
+        },
+    )
+    schema_text, overload_text, empty_text = out
+    assert "tokdash update" in schema_text
+    # 503 is the transient signal: it keeps its own wording and gains no detail.
+    assert overload_text == "temporaryOverload"
+    assert "retry shortly" not in overload_text
+    # No message to show falls back to the plain key, with no dangling separator.
+    assert empty_text == "loadFailed"
+
+
+@needs_node
+def test_status_line_is_rendered_from_the_shared_helper() -> None:
+    """setDashboardFetchStatus must not keep its own copy of the message policy."""
+    src = INDEX_HTML.read_text(encoding="utf-8")
+    setter = _extract_js_function(src, "function setDashboardFetchStatus(")
+    assert "dashboardFetchStatusText(error)" in setter
+    assert "temporaryOverload" not in setter
+
+
+# --- Quota tab ---------------------------------------------------------------
+# The Quota tab runs its own Promise.allSettled instead of fetchSelectedServers,
+# so fixing the shared loader did not fix it. These tests drive the REAL loadQuota
+# against stubs rather than re-implementing its settlement logic.
+
+QUOTA_PREAMBLE = """
+const scenario = JSON.parse(process.argv[2]);
+const serverRuntimeStatus = new Map();
+let lastQuotaServerRows = [];
+let lastQuotaPayload = null;
+let lastQuotaHistory = null;
+let quotaLoaded = false;
+let quotaActionStatusResetTimer = null;
+const quotaUtilizationCharts = new Map();
+const quotaConsumptionCharts = new Map();
+let renderCalls = 0;
+let indicatorCalls = 0;
+const rendered = [];
+
+function makeEl() {
+  return {
+    style: {}, textContent: '', dataset: {}, children: [],
+    removeAttribute() {}, setAttribute() {}, appendChild() {}, insertBefore() {}, remove() {},
+    querySelector() { return makeEl(); }, querySelectorAll() { return []; },
+  };
+}
+const elements = {};
+const document = { getElementById: (id) => (elements[id] = elements[id] || makeEl()) };
+
+function t(key) { return key; }
+function renderServerSettings() { renderCalls += 1; }
+function updateServerIndicator() { indicatorCalls += 1; }
+function selectedServers() { return scenario.servers.map((s) => ({ id: s.id, label: s.label })); }
+function currentQuotaRange() { return '24h'; }
+function quotaRangeSeconds() { return 86400; }
+function positionQuotaGlobalControls() {}
+function setQuotaSingleServerLayout() {}
+function ensureQuotaServerBlocks() { return makeEl(); }
+function renderQuotaServerBlock(server) { rendered.push(server.id); }
+function renderQuotaSettings() {}
+function renderQuotaProviderCards() {}
+function renderQuotaCharts() {}
+function makeError(spec) {
+  const error = new Error(spec.message);
+  if (spec.status !== undefined && spec.status !== null) error.status = spec.status;
+  return error;
+}
+async function fetchJsonWithRetry(server) {
+  const spec = scenario.servers.find((s) => s.id === server.id);
+  if (spec.fails) throw makeError(spec);
+  return spec.payload;
+}
+
+(async () => {
+  await loadQuota();
+  const statusEl = quotaStatusElement();
+  process.stdout.write(JSON.stringify({
+    statusText: statusEl.textContent,
+    statusColor: statusEl.style.color || null,
+    indicatorCalls,
+    renderCalls,
+    rows: lastQuotaServerRows.map((row) => row.server.id),
+    quotaLoaded,
+    failed: [...serverRuntimeStatus.entries()]
+      .filter(([, state]) => !state.ok)
+      .map(([id, state]) => ({ id, message: state.error ? state.error.message : null })),
+  }));
+})();
+"""
+
+
+def _run_quota(tmp_path: Path, scenario: dict):
+    src = INDEX_HTML.read_text(encoding="utf-8")
+    functions = "\n".join(
+        [
+            _extract_js_function(src, "function collectServerResults("),
+            _extract_js_function(src, "function dashboardFetchStatusText("),
+            _extract_js_function(src, "function quotaStatusElement("),
+            _extract_js_function(src, "function setQuotaFetchStatus("),
+            _extract_js_function(src, "async function loadQuota("),
+        ]
+    )
+    harness = tmp_path / "quota.js"
+    harness.write_text(functions + QUOTA_PREAMBLE, encoding="utf-8")
+    result = subprocess.run(
+        ["node", str(harness), json.dumps(scenario)],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    return json.loads(result.stdout)
+
+
+@needs_node
+def test_quota_total_failure_shows_the_schema_remediation(tmp_path: Path) -> None:
+    out = _run_quota(
+        tmp_path,
+        {"servers": [{"id": "local", "label": "Local", "fails": True, "status": 500, "message": SCHEMA_DETAIL}]},
+    )
+    # Previously this path threw a generic loadFailed and only console.error'd it,
+    # leaving the Quota tab blank with no remediation on screen.
+    assert "tokdash update" in out["statusText"]
+    assert out["statusColor"] == "#DC2626"
+    # The indicator must be refreshed after serverRuntimeStatus is updated.
+    assert out["indicatorCalls"] >= 1 and out["renderCalls"] >= 1
+    assert out["failed"] == [{"id": "local", "message": SCHEMA_DETAIL}]
+    assert out["quotaLoaded"] is False
+
+
+@needs_node
+def test_quota_total_failure_keeps_the_first_rejection(tmp_path: Path) -> None:
+    out = _run_quota(
+        tmp_path,
+        {
+            "servers": [
+                {"id": "local", "label": "Local", "fails": True, "status": 500, "message": SCHEMA_DETAIL},
+                {"id": "remote", "label": "Remote", "fails": True, "status": 500, "message": "unrelated failure"},
+            ]
+        },
+    )
+    assert "tokdash update" in out["statusText"]
+    assert {row["id"] for row in out["failed"]} == {"local", "remote"}
+
+
+@needs_node
+def test_quota_partial_success_still_renders_and_clears_status(tmp_path: Path) -> None:
+    out = _run_quota(
+        tmp_path,
+        {
+            "servers": [
+                {"id": "local", "label": "Local", "fails": True, "status": 500, "message": SCHEMA_DETAIL},
+                {"id": "remote", "label": "Remote", "fails": False, "payload": {"enabled": True}},
+            ]
+        },
+    )
+    assert out["rows"] == ["remote"]
+    assert out["quotaLoaded"] is True
+    # A healthy server means no blocking error banner...
+    assert out["statusText"] == ""
+    # ...but the broken one is still flagged with its reason for the tooltip.
+    assert out["failed"] == [{"id": "local", "message": SCHEMA_DETAIL}]
+
+
+@needs_node
+def test_quota_success_clears_a_stale_error(tmp_path: Path) -> None:
+    out = _run_quota(
+        tmp_path,
+        {"servers": [{"id": "local", "label": "Local", "fails": False, "payload": {"enabled": True}}]},
+    )
+    assert out["rows"] == ["local"] and out["quotaLoaded"] is True
+    assert out["statusText"] == "" and out["failed"] == []
+
+
+def test_quota_path_has_no_private_settlement_logic() -> None:
+    """loadQuota must not grow a second copy of the settlement policy."""
+    src = INDEX_HTML.read_text(encoding="utf-8")
+    load_quota = _extract_js_function(src, "async function loadQuota(")
+    assert "collectServerResults(servers, settled)" in load_quota
+    assert "setQuotaFetchStatus" in load_quota
+    # The old private bookkeeping is gone: no direct status writes, no bare
+    # loadFailed substituted for a real rejection.
+    assert "serverRuntimeStatus.set(" not in load_quota
+    assert "throw new Error(t('loadFailed'))" not in load_quota
+
+
+REFRESH_PREAMBLE = """
+const scenario = JSON.parse(process.argv[2]);
+let updateInFlight = false;
+let refreshUiState = 'idle';
+let quotaActionStatusResetTimer = null;
+const refreshStates = [];
+function setRefreshUiState(state) { refreshStates.push(state); }
+function startRefreshCooldown() { refreshStates.push('cooldown'); }
+function parseCooldownSeconds() { return 1; }
+function makeEl() { return { style: {}, textContent: '' }; }
+const elements = {};
+const document = { getElementById: (id) => (elements[id] = elements[id] || makeEl()) };
+function t(key) { return key; }
+function selectedServers() { return scenario.servers.map((s) => ({ id: s.id, label: s.label })); }
+function makeError(spec) {
+  const error = new Error(spec.message);
+  if (spec.status !== undefined && spec.status !== null) error.status = spec.status;
+  return error;
+}
+async function fetchJsonWithRetry(server) {
+  const spec = scenario.servers.find((s) => s.id === server.id);
+  if (spec.fails) throw makeError(spec);
+  return { ok: true };
+}
+let loadQuotaCalls = 0;
+async function loadQuota() { loadQuotaCalls += 1; return scenario.reloadOk !== false; }
+
+(async () => {
+  await refreshQuotaViaGlobalButton();
+  const el = quotaStatusElement();
+  process.stdout.write(JSON.stringify({
+    statusText: el.textContent,
+    refreshStates,
+    loadQuotaCalls,
+  }));
+})();
+"""
+
+
+def _run_refresh(tmp_path: Path, scenario: dict):
+    src = INDEX_HTML.read_text(encoding="utf-8")
+    functions = "\n".join(
+        [
+            _extract_js_function(src, "function dashboardFetchStatusText("),
+            _extract_js_function(src, "function quotaStatusElement("),
+            _extract_js_function(src, "function setQuotaFetchStatus("),
+            _extract_js_function(src, "async function refreshQuotaViaGlobalButton("),
+        ]
+    )
+    harness = tmp_path / "refresh.js"
+    harness.write_text(functions + REFRESH_PREAMBLE, encoding="utf-8")
+    result = subprocess.run(
+        ["node", str(harness), json.dumps(scenario)],
+        check=True, capture_output=True, encoding="utf-8",
+    )
+    return json.loads(result.stdout)
+
+
+@needs_node
+def test_quota_refresh_button_surfaces_the_schema_remediation(tmp_path: Path) -> None:
+    """A failed explicit refresh must leave the remediation on screen.
+
+    The button state alone says only "failed" and resets after 2.6s.
+    """
+    out = _run_refresh(
+        tmp_path,
+        {"servers": [{"id": "local", "label": "Local", "fails": True, "status": 500, "message": SCHEMA_DETAIL}]},
+    )
+    assert "tokdash update" in out["statusText"]
+    assert "failed" in out["refreshStates"]
+    assert out["loadQuotaCalls"] == 0
+
+
+@needs_node
+def test_quota_refresh_button_leaves_no_banner_for_503(tmp_path: Path) -> None:
+    """503 is transient and already has its own 'busy' button state."""
+    out = _run_refresh(
+        tmp_path,
+        {"servers": [{"id": "local", "label": "Local", "fails": True, "status": 503, "message": "Too many cold requests"}]},
+    )
+    assert out["statusText"] == ""
+    assert "busy" in out["refreshStates"]
+
+
+# --- settings write + reload -------------------------------------------------
+# A settings POST is followed by a forced reload. When the POST succeeds but the
+# reload fails, acknowledging "saved" both overwrote the red fetch error and
+# scheduled its removal -- so the remediation flashed and vanished.
+
+WRITE_PREAMBLE = """
+const scenario = JSON.parse(process.argv[2]);
+const serverRuntimeStatus = new Map();
+const LOCAL_SERVER = { id: 'local', label: 'Local' };
+let lastQuotaServerRows = [];
+let lastQuotaPayload = null;
+let lastQuotaHistory = null;
+let quotaLoaded = false;
+let quotaActionStatusResetTimer = null;
+const quotaUtilizationCharts = new Map();
+const quotaConsumptionCharts = new Map();
+let postCalls = 0;
+
+function makeEl() {
+  return {
+    style: {}, textContent: '', dataset: {}, children: [],
+    removeAttribute() {}, setAttribute() {}, appendChild() {}, insertBefore() {}, remove() {},
+    querySelector() { return makeEl(); }, querySelectorAll() { return []; },
+  };
+}
+const elements = {};
+const document = { getElementById: (id) => (elements[id] = elements[id] || makeEl()) };
+
+function t(key) { return key; }
+function renderServerSettings() {}
+function updateServerIndicator() {}
+function selectedServers() { return [LOCAL_SERVER]; }
+function currentQuotaRange() { return '24h'; }
+function quotaRangeSeconds() { return 86400; }
+function positionQuotaGlobalControls() {}
+function setQuotaSingleServerLayout() {}
+function ensureQuotaServerBlocks() { return makeEl(); }
+function renderQuotaServerBlock() {}
+function renderQuotaSettings() {}
+function renderQuotaProviderCards() {}
+function renderQuotaCharts() {}
+async function postJsonWithCsrf() { postCalls += 1; return { ok: true }; }
+async function fetchJsonWithRetry() {
+  if (scenario.reloadFails) {
+    const error = new Error(scenario.message);
+    error.status = 500;
+    throw error;
+  }
+  return { enabled: true };
+}
+
+(async () => {
+  await setQuotaEnabled(true);
+  process.stdout.write(JSON.stringify({
+    statusText: quotaStatusElement().textContent,
+    statusColor: quotaStatusElement().style.color || null,
+    postCalls,
+    quotaLoaded,
+  }));
+  process.exit(0);
+})();
+"""
+
+
+def _run_write(tmp_path: Path, scenario: dict):
+    src = INDEX_HTML.read_text(encoding="utf-8")
+    functions = "\n".join(
+        [
+            _extract_js_function(src, "function collectServerResults("),
+            _extract_js_function(src, "function dashboardFetchStatusText("),
+            _extract_js_function(src, "function quotaStatusElement("),
+            _extract_js_function(src, "function setQuotaFetchStatus("),
+            _extract_js_function(src, "function setQuotaActionStatus("),
+            _extract_js_function(src, "async function loadQuota("),
+            _extract_js_function(src, "async function setQuotaEnabled("),
+        ]
+    )
+    harness = tmp_path / "write.js"
+    harness.write_text(functions + WRITE_PREAMBLE, encoding="utf-8")
+    result = subprocess.run(
+        ["node", str(harness), json.dumps(scenario)],
+        check=True, capture_output=True, encoding="utf-8",
+    )
+    return json.loads(result.stdout)
+
+
+@needs_node
+def test_successful_write_with_failed_reload_keeps_the_fetch_error(tmp_path: Path) -> None:
+    out = _run_write(tmp_path, {"reloadFails": True, "message": SCHEMA_DETAIL})
+    assert out["postCalls"] == 1, "the settings write itself must still be sent"
+    # The remediation survives instead of being replaced by a write ack.
+    assert "tokdash update" in out["statusText"]
+    assert out["statusColor"] == "#DC2626"
+    assert "quotaActionSaved" not in out["statusText"]
+    assert out["quotaLoaded"] is False
+
+
+@needs_node
+def test_successful_write_with_successful_reload_still_acknowledges(tmp_path: Path) -> None:
+    """The fix must not cost users their normal "Saved" confirmation."""
+    out = _run_write(tmp_path, {"reloadFails": False, "message": ""})
+    assert out["postCalls"] == 1
+    assert out["statusText"] == "quotaActionSaved"
+    assert out["quotaLoaded"] is True
+
+
+def test_all_quota_write_paths_gate_their_acknowledgment() -> None:
+    """All four settings writers must gate 'saved' on the reload result."""
+    src = INDEX_HTML.read_text(encoding="utf-8")
+    writers = [
+        "async function enableQuotaProvider(",
+        "async function setQuotaCredentialScan(",
+        "async function setQuotaEnabled(",
+        "async function setQuotaInterval(",
+    ]
+    for signature in writers:
+        body = _extract_js_function(src, signature)
+        assert "if (await loadQuota({ force: true })) setQuotaActionStatus('saved');" in body, signature
+        # The ungated sequence must not come back.
+        assert "await loadQuota({ force: true });\n        setQuotaActionStatus('saved');" not in body
+
+
+@needs_node
+def test_quota_refresh_does_not_claim_updated_when_the_reload_failed(tmp_path: Path) -> None:
+    """The provider refresh can succeed while the reload that follows it fails.
+
+    Reporting 'updated' there would contradict the error banner loadQuota just set.
+    """
+    out = _run_refresh(
+        tmp_path,
+        {
+            "reloadOk": False,
+            "servers": [{"id": "local", "label": "Local", "fails": False}],
+        },
+    )
+    assert out["loadQuotaCalls"] == 1
+    assert "failed" in out["refreshStates"] and "updated" not in out["refreshStates"]
+
+
+@needs_node
+def test_quota_refresh_reports_updated_when_the_reload_succeeds(tmp_path: Path) -> None:
+    out = _run_refresh(
+        tmp_path,
+        {"servers": [{"id": "local", "label": "Local", "fails": False}]},
+    )
+    assert out["loadQuotaCalls"] == 1
+    assert "updated" in out["refreshStates"] and "failed" not in out["refreshStates"]

--- a/tests/test_usage_db_schema_too_new.py
+++ b/tests/test_usage_db_schema_too_new.py
@@ -1,0 +1,484 @@
+"""A usage DB written by a newer Tokdash must fail fast, never reparse.
+
+Regression cover for the incident where a schema-9 database met a build that
+only supported schema 7: every cache read raised, every caller treated that as
+"the cache is sick" and fell back to the raw session parsers, and the server
+reparsed the full on-disk history on *every* request until it was restarted.
+
+The contract these tests pin down:
+  - the too-new database is rejected before anything mutates it;
+  - no raw Codex/Claude/Kimi/OpenClaw parser is ever reached;
+  - the API fails fast with an actionable message (and not with the 503 the
+    dashboard retries);
+  - `tokdash doctor` reports it;
+  - /health is unaffected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+
+from pathlib import Path
+
+import pytest
+
+import tokdash.compute as compute_module
+import tokdash.sessions as sessions_module
+import tokdash.sources.openclaw as openclaw_module
+from tokdash.clientpaths import usage_db_path
+from tokdash.usage_store import (
+    SCHEMA_VERSION,
+    UsageDatabaseSchemaTooNewError,
+    UsageEntryStore,
+)
+
+FUTURE_SCHEMA = SCHEMA_VERSION + 2
+
+
+def _make_future_schema_db(path: Path) -> None:
+    """A minimal database that claims a schema this build cannot read.
+
+    Only ``meta`` exists, so any DDL or migration this build runs is visible as
+    an extra table -- which is what the no-mutation assertions key on.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        conn.execute(
+            "INSERT INTO meta(key, value) VALUES ('schema_version', ?)",
+            (str(FUTURE_SCHEMA),),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _tables(path: Path) -> set[str]:
+    conn = sqlite3.connect(str(path))
+    try:
+        return {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        }
+    finally:
+        conn.close()
+
+
+def _journal_mode(path: Path) -> str:
+    conn = sqlite3.connect(str(path))
+    try:
+        return str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def future_db() -> Path:
+    path = usage_db_path()
+    _make_future_schema_db(path)
+    return path
+
+
+def test_rejected_before_any_schema_mutation(future_db: Path) -> None:
+    before_tables = _tables(future_db)
+    before_journal = _journal_mode(future_db)
+    assert before_tables == {"meta"}
+
+    with pytest.raises(UsageDatabaseSchemaTooNewError) as excinfo:
+        UsageEntryStore()._connect()
+
+    assert excinfo.value.found == FUTURE_SCHEMA
+    assert excinfo.value.supported == SCHEMA_VERSION
+    # No DDL, no WAL flip, no migration: the file is byte-for-byte as we left it.
+    assert _tables(future_db) == before_tables
+    assert _journal_mode(future_db) == before_journal
+    assert str(future_db) in str(excinfo.value)
+
+
+def test_error_message_is_actionable(future_db: Path) -> None:
+    with pytest.raises(UsageDatabaseSchemaTooNewError) as excinfo:
+        UsageEntryStore()._connect()
+    message = str(excinfo.value)
+    assert "tokdash update" in message
+    assert str(FUTURE_SCHEMA) in message and str(SCHEMA_VERSION) in message
+
+
+@pytest.mark.parametrize("tool", ["codex", "claude", "kimi", "dsh", "reasonix"])
+def test_session_paths_never_reach_raw_parsers(future_db: Path, monkeypatch, tool: str) -> None:
+    for loader in ("_codex_sessions", "_claude_sessions", "_kimi_sessions", "_dsh_sessions", "_reasonix_sessions"):
+        monkeypatch.setattr(
+            sessions_module,
+            loader,
+            lambda *a, **k: pytest.fail("raw session parser ran on a too-new usage DB"),
+        )
+    with pytest.raises(UsageDatabaseSchemaTooNewError):
+        sessions_module._raw_sessions_for_tool(tool)
+
+
+def test_openclaw_paths_never_reach_raw_parsers(future_db: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        openclaw_module,
+        "_collect_entries",
+        lambda *a, **k: pytest.fail("raw OpenClaw parser ran on a too-new usage DB"),
+    )
+    with pytest.raises(UsageDatabaseSchemaTooNewError):
+        openclaw_module._collect_normalized_entries([], openclaw_module.PricingDatabase())
+
+
+def test_coding_tools_path_never_falls_back_to_live_collect(future_db: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        compute_module.CodingToolsUsageTracker,
+        "collect",
+        lambda *a, **k: pytest.fail("live tracker.collect ran on a too-new usage DB"),
+    )
+    with pytest.raises(UsageDatabaseSchemaTooNewError):
+        compute_module.run_local_coding_tools_json([])
+
+
+def test_mismatch_is_rechecked_not_latched(future_db: Path) -> None:
+    """The failure must not be cached for the process's lifetime.
+
+    Marking the store permanently unusable would be cheap but wrong: replacing
+    the database (an upgrade, a `tokdash db resync`, a restore) has to start
+    working again without a restart. The check is two queries, so it is re-run.
+    """
+    store = UsageEntryStore()
+    for _ in range(3):
+        with pytest.raises(UsageDatabaseSchemaTooNewError):
+            store._connect()
+
+    future_db.unlink()
+    # Same store instance, same path: a readable database must now go through.
+    store._connect().close()
+    assert "usage_entries" in _tables(future_db)
+
+
+def test_doctor_reports_the_mismatch(future_db: Path) -> None:
+    from tokdash.onboard.engine import _append_usage_db_issues, _doctor_usage_db
+
+    info = _doctor_usage_db()
+    assert info["stored_schema"] == FUTURE_SCHEMA
+    assert info["supported_schema"] == SCHEMA_VERSION
+
+    issues: list[str] = []
+    _append_usage_db_issues(issues, info)
+    assert len(issues) == 1
+    assert "tokdash update" in issues[0]
+
+
+def test_doctor_is_read_only(future_db: Path) -> None:
+    """Doctor must be able to report a too-new DB without migrating it."""
+    from tokdash.onboard.engine import _doctor_usage_db
+
+    before_tables, before_journal = _tables(future_db), _journal_mode(future_db)
+    _doctor_usage_db()
+    assert _tables(future_db) == before_tables
+    assert _journal_mode(future_db) == before_journal
+
+
+def test_doctor_clean_on_a_current_database() -> None:
+    from tokdash.onboard.engine import _append_usage_db_issues, _doctor_usage_db
+
+    UsageEntryStore()._connect().close()
+    info = _doctor_usage_db()
+    assert info["stored_schema"] == SCHEMA_VERSION
+    issues: list[str] = []
+    _append_usage_db_issues(issues, info)
+    assert issues == []
+
+
+class TestApiSurface:
+    """Handlers are called directly, never through TestClient/ASGITransport.
+
+    The routes below are sync `def` handlers, and this repo documents a
+    sync-handler deadlock under TestClient (see test_write_protection.py); the
+    compute semaphore this change interacts with makes that pattern especially
+    prone to hanging. test_api_smoke.py's convention is followed instead: call
+    the handler, catch HTTPException, and asyncio.run the async ones.
+    """
+
+    @staticmethod
+    def _api():
+        pytest.importorskip("fastapi")
+        import tokdash.api as api
+
+        api._clear_cache()
+        return api
+
+    def test_usage_route_fails_fast_and_actionably(self, future_db: Path) -> None:
+        api = self._api()
+        with pytest.raises(api.HTTPException) as excinfo:
+            api.get_usage(period="today")
+        # 503 is the dashboard's retry signal; a too-new DB never recovers on
+        # retry, so it must NOT be reported as one.
+        assert excinfo.value.status_code == 500
+        detail = str(excinfo.value.detail)
+        assert "tokdash update" in detail
+        assert str(FUTURE_SCHEMA) in detail
+
+    def test_health_is_unaffected(self, future_db: Path) -> None:
+        api = self._api()
+        payload = asyncio.run(api.health_check())
+        assert payload["service"] == "tokdash"
+
+    def test_version_reports_supported_schema(self, future_db: Path) -> None:
+        api = self._api()
+        payload = asyncio.run(api.get_version())
+        assert payload["usage_db_schema_supported"] == SCHEMA_VERSION
+
+
+# A data dir whose name carries characters that break a naive
+# "file:{path}?mode=ro" string: `#` starts the fragment, `%` opens an escape
+# sequence, and the space needs escaping too. Deliberately no `?` -- Windows
+# forbids it in filenames and CI runs on windows-latest; the POSIX-only test
+# below covers that character separately.
+SPECIAL_DIR_NAME = "data #% dir"
+POSIX_SPECIAL_DIR_NAME = "data ?#% dir"
+
+
+def test_read_only_uri_is_escaped_and_has_one_query_string(tmp_path: Path) -> None:
+    special = tmp_path / SPECIAL_DIR_NAME
+    special.mkdir()
+    db = special / "usage.sqlite3"
+    db.touch()
+
+    uri = db.resolve().as_uri() + "?mode=ro"
+
+    # file:/// covers POSIX and the Windows drive-letter form alike.
+    assert uri.startswith("file:///")
+    # Reserved characters are percent-escaped, so exactly one `?` survives -- the
+    # one that introduces mode=ro.
+    assert uri.count("?") == 1
+    assert uri.endswith("?mode=ro")
+    assert "#" not in uri
+    assert " " not in uri
+
+
+def test_doctor_reads_a_database_under_a_reserved_character_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from tokdash.onboard.engine import _doctor_usage_db
+
+    special = tmp_path / SPECIAL_DIR_NAME
+    special.mkdir()
+    db = special / "usage.sqlite3"
+    monkeypatch.setenv("TOKDASH_USAGE_DB_PATH", str(db))
+    _make_future_schema_db(db)
+
+    info = _doctor_usage_db()
+
+    assert info.get("error") is None
+    assert info["present"] is True
+    assert info["stored_schema"] == FUTURE_SCHEMA
+    assert info["path"] == str(db)
+
+
+def test_doctor_ignores_schema_when_the_database_is_disabled(
+    future_db: Path, monkeypatch
+) -> None:
+    """TOKDASH_USAGE_DB=0 means nothing reads the file; it cannot break a request."""
+    from tokdash.onboard.engine import _append_usage_db_issues, _doctor_usage_db
+
+    monkeypatch.setenv("TOKDASH_USAGE_DB", "0")
+    info = _doctor_usage_db()
+    assert info["enabled"] is False
+    assert info["stored_schema"] == FUTURE_SCHEMA
+
+    issues: list[str] = []
+    _append_usage_db_issues(issues, info)
+    assert issues == []
+
+
+def test_doctor_flags_an_enabled_but_unreadable_database() -> None:
+    """Enabled and unreadable must fail doctor, not print a note and exit 0."""
+    from tokdash.onboard.engine import _append_usage_db_issues, _doctor_usage_db
+
+    db = usage_db_path()
+    db.parent.mkdir(parents=True, exist_ok=True)
+    db.write_bytes(b"this is definitely not a sqlite database")
+
+    info = _doctor_usage_db()
+    assert info["enabled"] is True
+    assert info["present"] is True
+    assert info.get("error")
+
+    issues: list[str] = []
+    _append_usage_db_issues(issues, info)
+    assert len(issues) == 1
+    assert str(db) in issues[0]
+
+
+def test_doctor_command_fails_end_to_end_on_a_too_new_database(
+    future_db: Path, capsys
+) -> None:
+    """The issue must reach cmd_doctor's report, ok flag and exit code."""
+    import json as _json
+
+    from tokdash import cli
+    from tokdash.onboard.engine import run_lifecycle
+
+    capsys.readouterr()
+    args = cli.build_parser("tokdash").parse_args(["doctor", "--json"])
+    rc = run_lifecycle(args)
+    payload = _json.loads(capsys.readouterr().out)
+
+    assert payload["usage_db"]["stored_schema"] == FUTURE_SCHEMA
+    assert payload["usage_db"]["supported_schema"] == SCHEMA_VERSION
+    assert any("tokdash update" in issue for issue in payload["issues"])
+    assert payload["ok"] is False and rc != 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows forbids '?' in filenames")
+def test_doctor_reads_a_path_containing_a_question_mark(tmp_path: Path, monkeypatch) -> None:
+    """`?` is the character that truncated the naive f-string URI. POSIX only."""
+    from tokdash.onboard.engine import _doctor_usage_db
+
+    special = tmp_path / POSIX_SPECIAL_DIR_NAME
+    special.mkdir()
+    db = special / "usage.sqlite3"
+    monkeypatch.setenv("TOKDASH_USAGE_DB_PATH", str(db))
+    _make_future_schema_db(db)
+
+    uri = db.resolve().as_uri() + "?mode=ro"
+    assert uri.count("?") == 1
+
+    info = _doctor_usage_db()
+    assert info.get("error") is None
+    assert info["stored_schema"] == FUTURE_SCHEMA
+
+
+# --- pre-flight: the guard must run BEFORE any source discovery ------------------
+
+
+def _forbid_discovery(monkeypatch) -> None:
+    """Make every signature/discovery scan fail loudly if it is reached."""
+    def boom(name):
+        def _fail(*_a, **_k):
+            pytest.fail(f"{name} ran before the usage-DB compatibility check")
+        return _fail
+
+    for fn in (
+        "_codex_file_signatures",
+        "_kimi_session_signatures",
+        "_dsh_session_signatures",
+        "_reasonix_session_signatures",
+        "_iter_file_signatures",
+    ):
+        monkeypatch.setattr(sessions_module, fn, boom(f"sessions.{fn}"))
+    for fn in ("_session_files", "_signature"):
+        monkeypatch.setattr(openclaw_module, fn, boom(f"openclaw.{fn}"))
+
+
+@pytest.mark.parametrize("tool", ["codex", "claude", "kimi", "dsh", "reasonix"])
+def test_stored_sessions_checks_schema_before_discovery(
+    future_db: Path, monkeypatch, tool: str
+) -> None:
+    _forbid_discovery(monkeypatch)
+    with pytest.raises(UsageDatabaseSchemaTooNewError):
+        sessions_module._stored_sessions_for_tool(tool)
+
+
+def test_activity_insights_checks_schema_before_discovery(
+    future_db: Path, monkeypatch
+) -> None:
+    _forbid_discovery(monkeypatch)
+    with pytest.raises(UsageDatabaseSchemaTooNewError):
+        sessions_module.get_codex_activity_insights()
+
+
+def test_openclaw_sync_checks_schema_before_discovery(future_db: Path, monkeypatch) -> None:
+    _forbid_discovery(monkeypatch)
+    with pytest.raises(UsageDatabaseSchemaTooNewError):
+        openclaw_module._sync_openclaw_store([], openclaw_module.PricingDatabase())
+
+
+def test_preflight_is_silent_on_a_compatible_database() -> None:
+    """The guard must not disturb the normal path, nor create the file."""
+    from tokdash.usage_store import raise_if_usage_db_incompatible
+
+    raise_if_usage_db_incompatible()  # absent file: no error, no creation
+    assert not usage_db_path().exists()
+
+    UsageEntryStore()._connect().close()
+    raise_if_usage_db_incompatible()  # current schema: still silent
+
+
+def test_preflight_stays_silent_on_a_corrupt_database() -> None:
+    """Corruption is the fallback paths' business, not the fail-fast guard's."""
+    from tokdash.usage_store import raise_if_usage_db_incompatible
+
+    db = usage_db_path()
+    db.parent.mkdir(parents=True, exist_ok=True)
+    db.write_bytes(b"not a sqlite database")
+    raise_if_usage_db_incompatible()
+
+
+@pytest.fixture
+def clean_quota_cooldown():
+    """Isolate the module-global quota refresh cooldown between tests."""
+    pytest.importorskip("fastapi")
+    import tokdash.api as api
+
+    saved = (api._quota_last_refresh_monotonic, api._quota_prev_refresh_monotonic)
+    api._quota_last_refresh_monotonic = 0.0
+    api._quota_prev_refresh_monotonic = 0.0
+    yield api
+    api._quota_last_refresh_monotonic, api._quota_prev_refresh_monotonic = saved
+
+
+def test_quota_refresh_converts_the_typed_error_to_an_actionable_500(
+    future_db: Path, clean_quota_cooldown
+) -> None:
+    """A bare `raise` here reaches FastAPI as a detail-free 500.
+
+    /api/quota/refresh does not go through _cached_route, so it never had the
+    typed handler. The dashboard rendered "HTTP 500" -- the remediation existed
+    but never left the process.
+    """
+    api = clean_quota_cooldown
+    with pytest.raises(api.HTTPException) as excinfo:
+        api.refresh_quota()
+
+    assert excinfo.value.status_code == 500
+    detail = str(excinfo.value.detail)
+    assert "tokdash update" in detail
+    assert str(FUTURE_SCHEMA) in detail and str(SCHEMA_VERSION) in detail
+
+
+def test_quota_refresh_failure_still_releases_the_cooldown(
+    future_db: Path, clean_quota_cooldown
+) -> None:
+    """Converting the error must not skip the reservation rollback."""
+    api = clean_quota_cooldown
+    with pytest.raises(api.HTTPException):
+        api.refresh_quota()
+
+    # 0.0 means the slot was free and is now reserved by this probe -- i.e. the
+    # failed refresh did not burn the user's 60s window.
+    assert api._try_begin_quota_refresh() == 0.0
+    api._abort_quota_refresh()
+
+
+def test_every_store_backed_route_reports_the_remediation() -> None:
+    """No route may let the typed error escape as a detail-free 500.
+
+    /api/quota/refresh was missed because it does not use _cached_route; this
+    guards the whole surface rather than that one route.
+    """
+    import re
+
+    source = (Path(__import__("tokdash").__file__).parent / "api.py").read_text(encoding="utf-8")
+    routes = re.split(r"\n@app\.(?:get|post)\(", source)[1:]
+    offenders = []
+    for chunk in routes:
+        path = chunk.split('"')[1] if '"' in chunk else "?"
+        body = chunk.split("\n@app.")[0]
+        touches_store = "UsageEntryStore" in body or "_cached_route" in body
+        # Either the typed handler, or a generic handler that preserves str(e).
+        reports = "UsageDatabaseSchemaTooNewError" in body or "detail=str(e)" in body
+        if touches_store and not reports:
+            offenders.append(path)
+    assert offenders == [], f"routes that would drop the remediation: {offenders}"

--- a/tests/test_usage_db_schema_too_new.py
+++ b/tests/test_usage_db_schema_too_new.py
@@ -417,16 +417,49 @@ def test_preflight_stays_silent_on_a_corrupt_database() -> None:
 
 
 @pytest.fixture
-def clean_quota_cooldown():
-    """Isolate the module-global quota refresh cooldown between tests."""
+def clean_quota_cooldown(monkeypatch):
+    """Isolate the quota refresh cooldown and make the store read deterministic.
+
+    Two host dependencies have to go, or this only passes on a machine that
+    happens to have quota providers configured:
+
+    * ``collect_enabled_snapshots`` reads the store via ``collect_local_snapshots``,
+      but with no providers it returns [] -- and ``insert_quota_snapshots`` then
+      short-circuits on empty rows *before* opening the database, so nothing ever
+      reaches the schema guard and the route returns 200.
+    * the real collector is called with ``include_network=True``, so the test would
+      do live provider I/O in CI.
+
+    The stub below touches the store exactly as the real collector does, so the
+    error still comes from the real guard in ``_ensure_schema`` rather than a
+    fabricated raise.
+    """
     pytest.importorskip("fastapi")
     import tokdash.api as api
+    from tokdash.sources import quota as quota_module
+
+    def _collect_touching_store(*, include_network=True, store=None, network_sources=None):
+        if store is not None:
+            store._connect()
+        return []
+
+    monkeypatch.setattr(quota_module, "collect_enabled_snapshots", _collect_touching_store)
 
     saved = (api._quota_last_refresh_monotonic, api._quota_prev_refresh_monotonic)
     api._quota_last_refresh_monotonic = 0.0
     api._quota_prev_refresh_monotonic = 0.0
     yield api
     api._quota_last_refresh_monotonic, api._quota_prev_refresh_monotonic = saved
+
+
+def test_quota_refresh_succeeds_on_a_healthy_database(clean_quota_cooldown) -> None:
+    """Guards the fixture: with a readable DB the route must still return 200.
+
+    Without this, a stub that silently stopped touching the store would make the
+    two tests below pass for the wrong reason.
+    """
+    api = clean_quota_cooldown
+    assert api.refresh_quota() == {"snapshots": 0, "inserted": 0}
 
 
 def test_quota_refresh_converts_the_typed_error_to_an_actionable_500(


### PR DESCRIPTION
## Problem

A live server was pinned at 4.2 GB RSS with every page but Overview stuck loading. The dashboard showed `不可用：Local`.

Root cause: `~/.tokdash/usage.sqlite3` had been migrated to schema 9 by a repo checkout, while the installed pipx service only supported schema 7. `_raw_sessions_for_tool` caught the resulting `RuntimeError` with a bare `except Exception`, logged a warning, and fell through to the raw session parsers — reparsing ~6 GB of Codex/Claude JSONL **on every request**. Both compute slots (`TOKDASH_COMPUTE_CONCURRENCY=2`) stayed permanently occupied, so every other cold cache key got an instant `CacheBackpressureError` → 503.

The reparse fallback is the bug. A forward schema mismatch is terminal, not transient: no amount of retrying makes a newer database readable.

## Changes

**Detection** — `UsageDatabaseSchemaTooNewError` carries the path, found and supported schema. Raised before `journal_mode`, DDL or any migration touches the file, with the existing post-DDL check kept for the cross-process race. Re-checked per connect rather than latched, so replacing the database recovers without a restart.

**Fail fast** — the typed error is re-raised ahead of all six generic cache fallbacks (`sessions.py` ×1, `compute.py` ×3, `sources/openclaw.py` ×2). Ordinary SQLite and I/O failures still fall back as before.

**Reporting** — store-backed routes return **500**, not the 503 the dashboard retries three times; `/api/quota/refresh` converts the typed error after releasing its cooldown (a bare `raise` there reached FastAPI as a detail-free 500); `tokdash doctor` reports stored vs supported schema over a read-only URI connection built with `as_uri()`; `/api/version` exposes the supported constant.

**Frontend** — `fetchSelectedServers` and the Quota tab now share one `collectServerResults` settlement policy that preserves the first rejection, so the remediation reaches the status line and the per-server tooltip instead of a generic `loadFailed`. Quota write acknowledgements no longer overwrite an active fetch error. Partial success is unchanged throughout.

**Docs** — both READMEs previously claimed an installed service and a checkout can safely share a database. Corrected: only at equal schema. Repo runs get an isolated data dir.

## Not changed

No upgrade-flow redesign, larger compute concurrency, longer TTL, log archiving, or parser size guard. `tokdash update` already upgrades and restarts correctly, and a schema migration does not invalidate parser caches. A parser size limit would silently skip large logs and produce wrong totals — treating the symptom, not the erroneous fallback.

## Testing

52 new tests across two files. Beyond the direct cases: rejection leaves `sqlite_master` and `journal_mode` untouched; no raw parser is ever reached; the failure is rechecked rather than latched; doctor stays read-only and ignores a disabled DB while flagging an unreadable one; a data dir containing `?#%` resolves correctly; and a whole-surface guard walks every route in `api.py` so no store-backed route can drop the remediation again.

Full suite: 73/73 files pass. `git diff --check` clean.
