### PR TITLE
Release v2.3.0

### DIFF
--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 2.3.0 - 2026-08-26
+
+### Added
+
+- Added Session Explorer support for Antigravity CLI, Cline, Grok Build, Hermes, Kilo Code and omp. Each integration reuses the source parser's token mapping and pricing rules, exposes per-session turns and active time, and has its own dashboard panel and regression suite.
+- Added a Servers tab for comparing configured Tokdash instances, with reachable/stale state, usage shares, leading tools and models, session counts and quota summaries. Session panels can now be collapsed independently.
+- Refresh now reports source-level changes from the incremental usage scan, including added, updated, removed and unchanged rows.
+
+### Changed
+
+- Overview and session-panel runtime KPIs now show agent time consistently. The Servers tab remains available with one configured server so its health and details are still visible.
+- Coding-tool rescans now reuse unchanged source entries and update only changed files while preserving the last complete view when a source read is partial or fails.
+
+### Fixed
+
+- Antigravity conversation titles and projects now refresh when only the summary database WAL changes.
+- Cline now falls back to the session record's working directory when its metadata database has no usable project.
+- Dashboard refresh requests are queued instead of dropped when another update is in flight, and stale overview breakdowns cannot overwrite the currently selected date range.
+
 ## 2.2.0 - 2026-08-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tokdash"
-version = "2.2.0"
+version = "2.3.0"
 description = "Local token & cost dashboard for AI coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tokdash/__init__.py
+++ b/src/tokdash/__init__.py
@@ -1,3 +1,3 @@
 """Tokdash package."""
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"

--- a/src/tokdash/static/release-notes.json
+++ b/src/tokdash/static/release-notes.json
@@ -1,6 +1,32 @@
 {
-  "current": "2.2.0",
+  "current": "2.3.0",
   "releases": [
+    {
+      "version": "2.3.0",
+      "date": "2026-08-26",
+      "sections": [
+        {
+          "type": "added",
+          "items": [
+            "Added Session Explorer support for Antigravity CLI, Cline, Grok Build, Hermes, Kilo Code, and omp, with per-turn usage and active time.",
+            "Added a Servers tab for comparing configured Tokdash instances and collapsible per-tool session panels.",
+            "Refresh now reports source-level additions, updates, removals, and unchanged rows from incremental scans."
+          ]
+        },
+        {
+          "type": "changed",
+          "items": [
+            "Overview and session runtime cards now report agent time consistently, and unchanged source files are reused during rescans."
+          ]
+        },
+        {
+          "type": "fixed",
+          "items": [
+            "Fixed queued dashboard refreshes, stale date-range breakdowns, Antigravity WAL metadata invalidation, and Cline project fallback."
+          ]
+        }
+      ]
+    },
     {
       "version": "2.2.0",
       "date": "2026-08-22",

--- a/tests/test_cline_sessions.py
+++ b/tests/test_cline_sessions.py
@@ -12,7 +12,7 @@ import builtins
 import json
 import os
 import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -426,11 +426,11 @@ def test_parity_with_usage_parser(monkeypatch, tmp_path):
     ]
     for period, date_from, date_to in windows:
         since_ms, until_ms = sessions._window_bounds(period, date_from, date_to)
-        unbounded = period == "all" and date_from is None and date_to is None
-        s_dt = (datetime.fromtimestamp(since_ms / 1000, tz=timezone.utc)
-                if since_ms is not None and not unbounded else None)
-        u_dt = (datetime.fromtimestamp(until_ms / 1000, tz=timezone.utc)
-                if until_ms is not None and not unbounded else None)
+        epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        s_dt = (epoch + timedelta(milliseconds=since_ms)
+                if since_ms is not None else None)
+        u_dt = (epoch + timedelta(milliseconds=until_ms)
+                if until_ms is not None else None)
         entries = parser.collect(s_dt, u_dt)
         p_in = sum(e["input"] + e["cacheWrite"] for e in entries)
         p_cache = sum(e["cacheRead"] for e in entries)


### PR DESCRIPTION
## Summary

- bump package and runtime versions to 2.3.0
- document Session Explorer support for six additional clients
- document Servers, incremental refresh reporting, and refresh correctness changes since v2.2.0

## Validation

- release-safe, version-surface, and package metadata tests: 59 passed
- feature full suite before merge: 1549 passed, 4 skipped
- companion packaging: 3 passed