### PR TITLE
Improve Sessions tab readability

### DIFF
--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -1949,7 +1949,7 @@
         </div>
         <div class="surface p-5">
           <div class="text-xs font-semibold uppercase tracking-wider flex items-center gap-1" style="color: var(--color-label);">
-            <span id="overviewActiveLabel" data-i18n="agentTimeCard">Agent time (est.)</span>
+            <span id="overviewActiveLabel" data-i18n="agentTime">EST. agent time</span>
             <span id="overviewActiveHint" class="cursor-help select-none" style="opacity:0.6;" data-i18n-title="agentTimeOverviewHint" title="Estimated agent working time in the selected range, added up across every session tool: agents running at once each count, idle gaps beyond the cap are excluded.">ⓘ</span>
           </div>
           <div id="overviewActiveTime" class="text-3xl sm:text-4xl font-extrabold mt-2" style="color: var(--color-secondary);">-</div>
@@ -2101,9 +2101,12 @@
 
     <!-- Sessions Tab -->
     <div id="sessions-content" class="tab-content">
-      <div class="flex items-center justify-end gap-2 mb-4">
+      <div id="sessionsPanelToolbar" class="flex items-center justify-end gap-2 mb-4">
         <button id="sessionsExpandAll" class="btn btn-ghost" type="button" data-i18n="sessionsExpandAll">Expand all</button>
         <button id="sessionsCollapseAll" class="btn btn-ghost" type="button" data-i18n="sessionsCollapseAll">Collapse all</button>
+      </div>
+      <div id="sessionsEmptyState" class="surface p-5 mb-6" hidden>
+        <div class="text-sm" style="color: var(--color-muted);" data-i18n="sessionsEmptyRange">No sessions in the selected range.</div>
       </div>
       <section class="surface p-5 mb-6">
         <details class="session-panel" data-panel-details="codex">
@@ -4396,7 +4399,6 @@
         activeTime: 'Estimated active',
         activeTimeColumn: 'Active (est.)',
         agentTime: 'EST. agent time',
-        agentTimeCard: 'Agent time (est.)',
         idleCap: 'Idle cap',
         span: 'Span',
         activeTimeHint: 'Estimate from the gaps between token events: each gap counts up to the idle cap (5 min by default). A short pause reads the same as work, one long operation is truncated at the cap, and a session with a single event measures zero.',
@@ -4408,6 +4410,7 @@
         activeTimeToolsUnavailable: 'No data read for: {tools}',
         combinedSessionsDesc: 'Cross-tool session view grouped by project for the selected range.',
         sessionsRangeDesc: 'Latest session plus sessions for the selected range.',
+        sessionsEmptyRange: 'No sessions in the selected range.',
         panelTokens: 'Tokens',
         panelLast: 'Last',
         sessionsExpandAll: 'Expand all',
@@ -4789,7 +4792,6 @@
         activeTime: '预计活跃时长',
         activeTimeColumn: '活跃时长（估算）',
         agentTime: '智能体时长（估算）',
-        agentTimeCard: '智能体时长（估算）',
         idleCap: '空闲上限',
         span: '跨度',
         activeTimeHint: '基于 token 事件之间间隔的估算：每段间隔最多按空闲上限（默认 5 分钟）计入。短暂停顿与工作无法区分，单次长耗时操作会被截断到上限，只有一个事件的会话则记为 0。',
@@ -4801,6 +4803,7 @@
         activeTimeToolsUnavailable: '未能读取：{tools}',
         combinedSessionsDesc: '按项目汇总所选时间范围内的跨工具会话视图。',
         sessionsRangeDesc: '显示最近一条会话摘要，以及所选时间范围内的会话列表。',
+        sessionsEmptyRange: '所选范围内没有会话。',
         panelTokens: 'Token 数',
         panelLast: '最近',
         sessionsExpandAll: '全部展开',
@@ -6204,16 +6207,7 @@
       return { icon: null, color: '#64748B', fallback: label.charAt(0) || '?' };
     }
 
-    function createToolIdentity(tool, options = {}) {
-      const meta = toolBrandMeta(tool);
-      const identity = document.createElement('span');
-      identity.className = 'tool-identity';
-      identity.dataset.compact = String(Boolean(options.compact));
-      identity.dataset.logoKind = meta.logoKind || 'mark';
-      identity.dataset.darkInvert = String(Boolean(meta.darkInvert));
-      identity.style.setProperty('--tool-brand', meta.color);
-      identity.setAttribute('aria-label', formatToolName(tool));
-
+    function createToolBrandIcon(tool, meta) {
       const icon = document.createElement('span');
       icon.className = 'tool-brand-icon';
       icon.setAttribute('aria-hidden', 'true');
@@ -6235,6 +6229,26 @@
           icon.replaceChildren(image);
         }).catch(() => {});
       }
+      return icon;
+    }
+
+    function createToolIdentity(tool, options = {}) {
+      const meta = toolBrandMeta(tool);
+      const identity = document.createElement('span');
+      identity.className = 'tool-identity';
+      identity.dataset.compact = String(Boolean(options.compact));
+      identity.dataset.logoKind = meta.logoKind || 'mark';
+      identity.dataset.darkInvert = String(Boolean(meta.darkInvert));
+      identity.style.setProperty('--tool-brand', meta.color);
+
+      const icon = createToolBrandIcon(tool, meta);
+      if (options.iconOnly) {
+        // Decorative: the surrounding heading already names the tool.
+        identity.setAttribute('aria-hidden', 'true');
+        identity.append(icon);
+        return identity;
+      }
+      identity.setAttribute('aria-label', formatToolName(tool));
 
       const label = document.createElement('span');
       label.className = 'tool-brand-label';
@@ -7619,6 +7633,14 @@
     function initSessionPanels() {
       document.querySelectorAll("details[data-panel-details]").forEach((details) => {
         const panel = details.dataset.panelDetails;
+        // Brand logo in the header, same identity system as the Overview.
+        // Icon-only: the h2 already names the harness. Combined gets no
+        // identity: the Overview never renders one, and its letter fallback
+        // would collide with Cline's "C" tile.
+        const title = details.querySelector("summary h2");
+        if (title && panel !== "combined" && !details.querySelector("summary .tool-identity")) {
+          title.insertAdjacentElement("beforebegin", createToolIdentity(panel, { iconOnly: true }));
+        }
         details.addEventListener("click", (event) => {
           // Only a plain click on the summary row folds the panel. Interactive
           // controls inside the row (the Codex review toggle) and body clicks do
@@ -7726,8 +7748,14 @@
         const panelLast = document.getElementById(`${prefix}PanelLast`);
         if (panelLast) panelLast.textContent = latest ? formatSessionTime(latest.last_seen_at) : "—";
       }
-      sessionPanelSetOpen(document.querySelector(`details[data-panel-details="${prefix}"]`),
-        sessionPanelShouldOpen(sessionCollapseOverrides[prefix], data));
+      const panelEl = document.querySelector(`details[data-panel-details="${prefix}"]`);
+      // Zero sessions in range: hide the harness section entirely (the wrapper
+      // included, or its empty surface band shows through). Failed fetches stay
+      // visible so their error row is not swallowed.
+      if (panelEl?.parentElement) {
+        panelEl.parentElement.style.display = (!sessions.length && !data?.error) ? "none" : "";
+      }
+      sessionPanelSetOpen(panelEl, sessionPanelShouldOpen(sessionCollapseOverrides[prefix], data));
 
       const tbody = document.getElementById(`${prefix}SessionsTable`);
       if (!tbody) return;
@@ -7896,6 +7924,25 @@
       updateSessionPanel("cline", lastSessionsResponses.cline);
       lastSessionsResponses.combined = buildCombinedSessionsData(lastSessionsResponses);
       updateSessionPanel("combined", lastSessionsResponses.combined, { showTool: true });
+
+      // Tab-level empty state: shown only when no harness has sessions in range
+      // and no fetch failed (error panels keep their error rows visible).
+      const anyPanelSessions = (lastSessionsResponses.combined?.sessions?.length || 0) > 0;
+      // Tool keys only: the response map also carries `combined` (derived, no
+      // errors of its own) and `_errors` (a plain map, not a response).
+      const anyPanelError = SESSION_TOOL_KEYS.some((k) => lastSessionsResponses[k]?.error);
+      const showEmpty = !anyPanelSessions && !anyPanelError;
+      const emptyStateEl = document.getElementById("sessionsEmptyState");
+      if (emptyStateEl) emptyStateEl.hidden = !showEmpty;
+      // The expand/collapse row has nothing to act on over an empty tab.
+      const toolbarEl = document.getElementById("sessionsPanelToolbar");
+      if (toolbarEl) {
+        toolbarEl.hidden = showEmpty;
+        // Tailwind's display utilities override the base [hidden] rule (see
+        // setQuotaSingleServerLayout); the inline display is what actually
+        // hides the flex row.
+        toolbarEl.style.display = showEmpty ? "none" : "";
+      }
 
       // Initialize sortable headers (idempotent — skips if already initialized)
       initSortHeaders("codex", renderSessionsTab);

--- a/tests/test_overview_active_time.py
+++ b/tests/test_overview_active_time.py
@@ -360,7 +360,7 @@ def test_the_card_sits_after_total_messages_in_a_six_column_row():
     assert 'id="overviewActiveDelta"' in kpis
     assert 'id="overviewActiveMeta"' in kpis
     # A one-line label, like every other card in the row.
-    assert 'data-i18n="agentTimeCard"' in kpis
+    assert 'data-i18n="agentTime"' in kpis
     assert 'data-i18n-title="agentTimeOverviewHint"' in kpis
 
 
@@ -480,7 +480,7 @@ def test_the_request_key_identifies_the_servers():
 
 def test_active_time_overview_labels_exist_in_both_languages():
     source = INDEX_HTML.read_text(encoding="utf-8")
-    for key in ("agentTime", "agentTimeCard", "agentTimeOverviewHint", "activeTimeToolsUnavailable", "idleCap"):
+    for key in ("agentTime", "agentTimeOverviewHint", "activeTimeToolsUnavailable", "idleCap"):
         assert len(re.findall(rf"^\s+{key}: ", source, re.MULTILINE)) == 2, key
     # The wording the card no longer uses is gone rather than left to rot.
     assert "activeTimeOverviewMultiServerHint" not in source

--- a/tests/test_session_active_time.py
+++ b/tests/test_session_active_time.py
@@ -353,6 +353,7 @@ def test_active_time_labels_exist_in_both_languages():
         "agentTimePanelHint",
         "activeTimeCombinedHint",
         "activeTimeMultiServerHint",
+        "sessionsEmptyRange",
     ):
         assert len(re.findall(rf"^\s+{key}: ", source, re.MULTILINE)) == 2, key
 

--- a/tests/test_sessions_panel_frontend.py
+++ b/tests/test_sessions_panel_frontend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -91,6 +92,36 @@ def test_every_panel_has_collapsible_markup():
 
 def test_i18n_keys_in_both_languages():
     source = INDEX_HTML.read_text(encoding="utf-8")
-    import re
     for key in ("panelTokens", "panelLast", "sessionsExpandAll", "sessionsCollapseAll"):
         assert len(re.findall(rf"^\s+{key}: ", source, re.MULTILINE)) == 2, key
+
+
+def test_sessions_panels_have_logos_and_hide_when_empty():
+    """Panel headers reuse the Overview brand identity (icon-only; combined
+    gets none) and zero-session harnesses are hidden, with a tab-level empty
+    state as the fallback."""
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    panels = set(re.findall(r'data-panel-details="(\w+)"', source))
+    assert len(panels) >= 15, panels
+    # Icon-only identity injected once per panel header, combined excluded.
+    assert 'createToolIdentity(panel, { iconOnly: true })' in source
+    assert 'function createToolBrandIcon(tool, meta)' in source
+    assert '!details.querySelector("summary .tool-identity")' in source
+    assert 'panel !== "combined"' in source
+    # Empty-range panels are hidden only when the range has no sessions and
+    # the fetch did not fail. Assert on the guard pieces, not the formatting.
+    hide_line = next(l for l in source.splitlines() if "panelEl.parentElement.style.display" in l)
+    assert "!sessions.length" in hide_line, hide_line
+    assert "!data?.error" in hide_line, hide_line
+    assert '"none"' in hide_line, hide_line
+    # Tab-level empty state and the expand/collapse row share the same gate.
+    assert 'id="sessionsEmptyState"' in source
+    assert 'data-i18n="sessionsEmptyRange"' in source
+    assert 'id="sessionsPanelToolbar"' in source
+    # `hidden` alone is beaten by Tailwind's display utilities on the flex row;
+    # the inline display is what actually hides it, and both must gate on
+    # showEmpty.
+    toolbar_line = next(l for l in source.splitlines() if "toolbarEl.hidden" in l)
+    assert "showEmpty" in toolbar_line, toolbar_line
+    display_line = next(l for l in source.splitlines() if "toolbarEl.style.display" in l)
+    assert "showEmpty" in display_line, display_line


### PR DESCRIPTION
## Summary

Three changes to make the Sessions tab scannable when only a few harnesses are actually in use.

- **Brand logos in panel headers.** Each harness panel header now carries its brand icon, reusing the Overview's identity system via a new `createToolBrandIcon` split out of `createToolIdentity`. Icon-only and `aria-hidden`, since the `h2` beside it already names the tool. Combined is excluded — the Overview never renders an identity for it, and its letter fallback would collide with Cline's `C` tile.
- **Hide empty harness sections.** A panel whose section has no sessions in the selected range is hidden entirely (the wrapping `section`, not just the `details`, or its empty surface band shows through). A panel whose fetch *failed* stays visible so its error row is not swallowed.
- **Tab-level empty state.** When no harness has sessions in range and nothing errored, a single "No sessions in the selected range." band replaces the 16 hidden panels. The expand/collapse toolbar hides with it — it has nothing to act on.

Also collapses the duplicate `agentTimeCard` i18n key into `agentTime`; the two carried identical Chinese text and near-identical English.

## Notes

Each `details[data-panel-details]` has its own dedicated `<section>` parent, so hiding `parentElement` hides exactly one panel — verified across all 16.

`renderSessionsTab` already returns early until at least one tool response has landed, so the empty state cannot paint before the first fetch resolves.

`toolbarEl.hidden` alone is not enough — Tailwind's display utilities on the flex row beat the base `[hidden]` rule — so the inline `display` is set alongside it, the same pattern as `setQuotaSingleServerLayout`.

## Validation

- Full suite: 1553 passed, 4 skipped
- New `test_sessions_panels_have_logos_and_hide_when_empty` covers the identity injection, the hide guard, and both halves of the toolbar gate
- i18n key-parity tests updated for the `agentTimeCard` removal and the new `sessionsEmptyRange`