### PR TITLE
Release v2.3.1

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -420,6 +420,7 @@ Tokdash 默认**只监听 localhost**。
 - `TOKDASH_CACHE_TTL`（默认：`600` 秒）
 - `TOKDASH_CACHE_MAX_ENTRIES`（默认：`256`）——限制 API 响应缓存及其空闲键锁的数量
 - `TOKDASH_COMPUTE_CONCURRENCY`（默认：`2`）——同时进行的重型历史重解析数量上限；超出的冷请求会立即返回 `503`，而不是在高负载下耗尽服务线程
+- `TOKDASH_STARTUP_WARM_JOIN_SECONDS`（默认：`30` 秒）——启动预热某个键期间，第一个请求该键的请求最多等待该次预热多久，而不是直接返回 `503`；每个键最多只有一个请求等待
 - `TOKDASH_LIMIT_CONCURRENCY`（默认：`64`）——uvicorn 接受的最大并发连接数（背压）
 - `TOKDASH_KEEPALIVE`（默认：`5` 秒）——uvicorn keep-alive 超时
 - `TOKDASH_ALLOW_ORIGINS`（逗号分隔，默认：空）

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 2.3.1 - 2026-08-27
+
+### Changed
+
+- Sessions panels now carry each harness's brand logo in the panel header, reusing the Overview's identity system. A harness with no sessions in the selected range is hidden instead of rendering an empty panel, and when no harness has sessions in range a single empty-state band replaces them all. A panel whose fetch failed stays visible so its error row is not swallowed.
+
+### Fixed
+
+- The first dashboard load no longer races the startup cache warmer into a transient `503`. One foreground request per key may join the warm fill already running on its behalf, bounded by `TOKDASH_STARTUP_WARM_JOIN_SECONDS` (default `30` seconds); every other same-key cold miss keeps the existing fail-fast backpressure, and the warmer's own backpressure no longer logs as a warning. The unused period-only Today usage key is no longer warmed, dropping a duplicate of the largest startup aggregation. Direct callers of `/api/usage?period=today` still compute the same data but no longer find it pre-cached.
+
 ## 2.3.0 - 2026-08-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tokdash"
-version = "2.3.0"
+version = "2.3.1"
 description = "Local token & cost dashboard for AI coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tokdash/__init__.py
+++ b/src/tokdash/__init__.py
@@ -1,3 +1,3 @@
 """Tokdash package."""
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"

--- a/src/tokdash/static/release-notes.json
+++ b/src/tokdash/static/release-notes.json
@@ -1,6 +1,24 @@
 {
-  "current": "2.3.0",
+  "current": "2.3.1",
   "releases": [
+    {
+      "version": "2.3.1",
+      "date": "2026-08-27",
+      "sections": [
+        {
+          "type": "changed",
+          "items": [
+            "Session panels now show each harness's brand logo, and harnesses with no sessions in the selected range are hidden instead of rendering empty panels."
+          ]
+        },
+        {
+          "type": "fixed",
+          "items": [
+            "The first dashboard load after startup no longer returns a transient 503 while the cache warms."
+          ]
+        }
+      ]
+    },
     {
       "version": "2.3.0",
       "date": "2026-08-26",


### PR DESCRIPTION
Patch release. Version bumped 2.3.0 → 2.3.1 in `pyproject.toml` and `src/tokdash/__init__.py`.

## Contents

- #42 — startup cache warm coalescing (no more transient `503` on the first dashboard load)
- #45 — Sessions tab readability: brand logos in panel headers, empty harnesses hidden, tab-level empty state

## Release chores

- `docs/development/CHANGELOG.md` — 2.3.1 entry under Changed / Fixed
- `src/tokdash/static/release-notes.json` — 2.3.1 entry and `current` bump, so the in-dashboard What's New drawer matches the package version (`test_release_notes_ship_with_the_current_package_version`)
- `README_CN.md` — adds `TOKDASH_STARTUP_WARM_JOIN_SECONDS` to the Configuration list, keeping it in sync with the English README after #44. Both files now list 19 env vars.

## Validation

Full suite: 1553 passed, 4 skipped.