### PR TITLE
Show refresh reports for every usage refresh

### DIFF
--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -4092,6 +4092,7 @@
     let refreshCooldownRemaining = 0;
     let lastUsageResponse = null;
     let lastRefreshReport = null;
+    let refreshReportDismissedWindowKey = null;
     const SESSION_TOOL_KEYS = ['codex', 'claude', 'opencode', 'pi_agent', 'mimo', 'kimi', 'dsh', 'reasonix', 'zcode', 'kilocode', 'omp', 'grok', 'hermes', 'antigravity_cli', 'cline'];
     let lastSessionsResponses = { codex: null, claude: null, opencode: null, pi_agent: null, mimo: null, kimi: null, dsh: null, reasonix: null, zcode: null, kilocode: null, omp: null, grok: null, hermes: null, antigravity_cli: null, cline: null, combined: null };
     let lastCombinedModels = [];
@@ -5692,9 +5693,12 @@
       document.getElementById('refreshBtn')?.setAttribute('aria-expanded', 'true');
     }
 
-    function hideUsageRefreshReport({ focusButton = false } = {}) {
+    function hideUsageRefreshReport({ focusButton = false, dismissed = false } = {}) {
       const panel = document.getElementById('refreshReport');
       if (panel) panel.hidden = true;
+      // An explicit dismissal remains in effect for this range, so a background
+      // refresh cannot reopen and re-announce the report every five minutes.
+      if (dismissed) refreshReportDismissedWindowKey = lastRefreshReport?.windowKey || null;
       const button = document.getElementById('refreshBtn');
       button?.setAttribute('aria-expanded', 'false');
       if (focusButton) button?.focus();
@@ -6959,6 +6963,9 @@
       if (forceRefresh || (lastRefreshReport?.windowKey && lastRefreshReport.windowKey !== windowKey)) {
         hideUsageRefreshReport();
       }
+      // The refresh button is an explicit request for new feedback, so it restores
+      // the report even when the user previously dismissed it for this range.
+      if (forceRefresh) refreshReportDismissedWindowKey = null;
 
       // The date picker moved its label before this ran, so whatever is on screen now
       // sits under a heading that does not name it. Drop the deferred breakdowns and
@@ -7024,7 +7031,8 @@
       // on screen. This includes the five-minute timer and other programmatic
       // reloads, while the first load and a genuine range change remain ordinary
       // loads and do not present unrelated values as a before/after comparison.
-      const shouldReportRefresh = forceRefresh || previousUsageForReport !== null;
+      const shouldReportRefresh = (forceRefresh || previousUsageForReport !== null)
+        && refreshReportDismissedWindowKey !== windowKey;
       const reportRangeLabel = refreshReportRangeLabel();
       if (forceRefresh) {
         setRefreshUiState('refreshing');
@@ -13027,7 +13035,7 @@
       }
     });
     document.getElementById('refreshReportClose')?.addEventListener('click', () => {
-      hideUsageRefreshReport({ focusButton: true });
+      hideUsageRefreshReport({ focusButton: true, dismissed: true });
     });
 
     document.getElementById('readableTokensToggle')?.addEventListener('click', () => {
@@ -13050,7 +13058,7 @@
         setSettingsPanelOpen(false, true);
       }
       if (event.key === 'Escape' && !document.getElementById('refreshReport')?.hidden) {
-        hideUsageRefreshReport({ focusButton: true });
+        hideUsageRefreshReport({ focusButton: true, dismissed: true });
       }
     });
 

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -1807,14 +1807,14 @@
                     </svg>
                   </span>
                   <div>
-                    <h2 id="refreshReportTitle" class="refresh-report-title">Scan complete</h2>
+                    <h2 id="refreshReportTitle" class="refresh-report-title">Refresh complete</h2>
                     <p id="refreshReportMeta" class="refresh-report-meta"></p>
                   </div>
                   <button id="refreshReportClose" class="refresh-report-close" type="button" aria-label="Close">
                     <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="m7 7 10 10M17 7 7 17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
                   </button>
                 </div>
-                <div class="refresh-report-deltas" aria-label="Changes after scan">
+                <div class="refresh-report-deltas" aria-label="Changes after refresh">
                   <div class="refresh-report-delta"><strong id="refreshReportTokens" class="mono">—</strong><span data-i18n="refreshReportTokens">Tokens</span></div>
                   <div class="refresh-report-delta"><strong id="refreshReportCost" class="mono">—</strong><span data-i18n="refreshReportCost">Cost</span></div>
                   <div class="refresh-report-delta"><strong id="refreshReportMessages" class="mono">—</strong><span data-i18n="refreshReportMessages">Messages</span></div>
@@ -4187,21 +4187,21 @@
         refreshBusy: 'Busy',
         refreshFailed: 'Failed — retry',
         refreshCooldown: 'Wait {n}s',
-        refreshReportComplete: 'Scan complete',
-        refreshReportPreserved: 'Scan complete · previous data kept',
-        refreshReportPartial: 'Scan incomplete',
-        refreshReportFailed: 'Scan failed · previous data kept',
+        refreshReportComplete: 'Refresh complete',
+        refreshReportPreserved: 'Refresh complete · previous data kept',
+        refreshReportPartial: 'Refresh incomplete',
+        refreshReportFailed: 'Refresh failed · previous data kept',
         refreshReportTokens: 'Tokens',
         refreshReportCost: 'Cost',
         refreshReportMessages: 'Messages',
         refreshReportNoBaseline: 'Baseline saved · {n} tools found',
         refreshReportToolsChanged: '{n} tools changed',
         refreshReportNoChanges: 'No usage changes found',
-        refreshReportRetained: 'Kept the previous result for {names}; this scan could not read complete data.',
+        refreshReportRetained: 'Kept the previous result for {names}; this refresh could not read complete data.',
         refreshReportUnavailable: 'No earlier result was available for {names}; displayed totals may be incomplete.',
         refreshReportRange: '{range} · {time}',
-        refreshReportDiffLabel: 'Changes after scan',
-        refreshReportClose: 'Close scan report',
+        refreshReportDiffLabel: 'Changes after refresh',
+        refreshReportClose: 'Close refresh report',
         settings: 'Settings',
         servers: 'Servers',
         allServers: 'Use all',
@@ -4580,10 +4580,10 @@
         refreshBusy: '繁忙',
         refreshFailed: '失败，请重试',
         refreshCooldown: '{n} 秒后重试',
-        refreshReportComplete: '扫描完成',
-        refreshReportPreserved: '扫描完成 · 已保留旧数据',
-        refreshReportPartial: '扫描不完整',
-        refreshReportFailed: '扫描失败 · 已保留旧数据',
+        refreshReportComplete: '刷新完成',
+        refreshReportPreserved: '刷新完成 · 已保留旧数据',
+        refreshReportPartial: '刷新不完整',
+        refreshReportFailed: '刷新失败 · 已保留旧数据',
         refreshReportTokens: 'Tokens',
         refreshReportCost: '费用',
         refreshReportMessages: '消息数',
@@ -4593,8 +4593,8 @@
         refreshReportRetained: '{names} 本次未能完整读取，已保留该范围的上一次结果。',
         refreshReportUnavailable: '{names} 没有可用的旧结果，当前合计可能不完整。',
         refreshReportRange: '{range} · {time}',
-        refreshReportDiffLabel: '扫描后的变化',
-        refreshReportClose: '关闭扫描报告',
+        refreshReportDiffLabel: '刷新后的变化',
+        refreshReportClose: '关闭刷新报告',
         settings: '设置',
         servers: '服务器',
         allServers: '全部启用',
@@ -7020,6 +7020,11 @@
       const previousUsageForReport = lastWindowKey === windowKey && lastUsageServerKey === usageServerKey
         ? lastUsageResponse
         : null;
+      // A refresh is any re-fetch of the exact range and server selection already
+      // on screen. This includes the five-minute timer and other programmatic
+      // reloads, while the first load and a genuine range change remain ordinary
+      // loads and do not present unrelated values as a before/after comparison.
+      const shouldReportRefresh = forceRefresh || previousUsageForReport !== null;
       const reportRangeLabel = refreshReportRangeLabel();
       if (forceRefresh) {
         setRefreshUiState('refreshing');
@@ -7089,6 +7094,10 @@
             const cacheMeta = lastUsageResponse?.response_cache || null;
             setRefreshUiState(cacheMeta?.served_from_cache ? 'cached' : 'updated', { resetAfterMs: 1800 });
           }
+        } else if (refreshUiState !== 'idle') {
+          setRefreshUiState('idle');
+        }
+        if (shouldReportRefresh) {
           const scan = lastUsageResponse?._scan_reconciliation || {};
           showUsageRefreshReport(buildUsageRefreshReport(previousUsageForReport, lastUsageResponse, {
             failed: !!usageFetchError,
@@ -7098,8 +7107,6 @@
             unavailable: scan.unavailable,
             error: usageFetchError?.message || '',
           }));
-        } else if (refreshUiState !== 'idle') {
-          setRefreshUiState('idle');
         }
 
         if (isOverviewActive()) renderOverviewTab(lastUsageResponse);
@@ -7119,6 +7126,8 @@
         setDashboardFetchStatus(error);
         if (forceRefresh) {
           setRefreshUiState(error?.status === 503 ? 'busy' : 'failed', { resetAfterMs: 2600 });
+        }
+        if (shouldReportRefresh) {
           const scan = usageReconciliation || reconcileUsageRows([], windowKey, usageServers);
           showUsageRefreshReport(buildUsageRefreshReport(previousUsageForReport, previousUsageForReport, {
             failed: true,

--- a/tests/test_dashboard_queue_frontend.py
+++ b/tests/test_dashboard_queue_frontend.py
@@ -47,6 +47,7 @@ let updateIsManualRefresh = false;
 let refreshUiState = 'idle';
 let lastUsageResponse = null;
 let lastRefreshReport = null;
+let refreshReportDismissedWindowKey = null;
 let lastSessionsResponses = null;
 let sessionsLoadedKey = null;
 let lastWindowKey = null;
@@ -83,7 +84,9 @@ function isOverviewActive() { return true; }
 function renderOverviewTab(data) { log.rendered.push(data && data.range); }
 function renderSessionsTab() {}
 function renderRefreshButton() {}
-function hideUsageRefreshReport() {}
+function hideUsageRefreshReport({ dismissed = false } = {}) {
+  if (dismissed) refreshReportDismissedWindowKey = lastRefreshReport?.windowKey || null;
+}
 function showUsageRefreshReport(report) { lastRefreshReport = report; log.refreshReports.push(report); }
 function refreshReportRangeLabel() { return 'test range'; }
 function clearOverviewBreakdowns() { overviewBreakdownWindowKey = null; }
@@ -269,11 +272,32 @@ async function main() {
     out.afterAutomaticRefresh = log.refreshReports.length;
     out.automaticDelta = lastRefreshReport && lastRefreshReport.tokens;
 
+    hideUsageRefreshReport({ dismissed: true });
+    pick('X');
+    await settle();
+    resolveRange('X', { total_tokens: 150, total_cost: 1.5, total_messages: 4 });
+    await settle(); await settle();
+    out.afterDismissedAutomaticRefresh = log.refreshReports.length;
+
+    pick('X', { forceRefresh: true });
+    await settle();
+    resolveRange('X', { total_tokens: 175, total_cost: 1.75, total_messages: 5 });
+    await settle(); await settle();
+    out.afterForcedRefresh = log.refreshReports.length;
+    out.forcedDelta = lastRefreshReport && lastRefreshReport.tokens;
+
+    hideUsageRefreshReport({ dismissed: true });
     pick('Y');
     await settle();
     resolveRange('Y', { total_tokens: 5, total_cost: 0.05, total_messages: 1 });
     await settle(); await settle();
     out.afterRangeChange = log.refreshReports.length;
+
+    pick('Y');
+    await settle();
+    resolveRange('Y', { total_tokens: 10, total_cost: 0.1, total_messages: 2 });
+    await settle(); await settle();
+    out.afterOtherRangeRefresh = log.refreshReports.length;
   }
 
   process.stdout.write(JSON.stringify(out));
@@ -400,4 +424,8 @@ def test_every_same_range_refresh_reports_but_initial_and_range_loads_do_not(tmp
     assert out["afterInitialLoad"] == 0
     assert out["afterAutomaticRefresh"] == 1
     assert out["automaticDelta"] == 25
-    assert out["afterRangeChange"] == 1
+    assert out["afterDismissedAutomaticRefresh"] == 1
+    assert out["afterForcedRefresh"] == 2
+    assert out["forcedDelta"] == 25
+    assert out["afterRangeChange"] == 2
+    assert out["afterOtherRangeRefresh"] == 3

--- a/tests/test_dashboard_queue_frontend.py
+++ b/tests/test_dashboard_queue_frontend.py
@@ -60,7 +60,7 @@ function isServersActive() { return false; }
 function renderServersTab() {}
 
 
-const log = { rendered: [], errors: [], alerts: [], refreshStates: [], activeCards: [], activeLoads: [], stale: [] };
+const log = { rendered: [], errors: [], alerts: [], refreshStates: [], refreshReports: [], activeCards: [], activeLoads: [], stale: [] };
 const fetches = [];
 
 function deferred() {
@@ -84,7 +84,7 @@ function renderOverviewTab(data) { log.rendered.push(data && data.range); }
 function renderSessionsTab() {}
 function renderRefreshButton() {}
 function hideUsageRefreshReport() {}
-function showUsageRefreshReport(report) { lastRefreshReport = report; }
+function showUsageRefreshReport(report) { lastRefreshReport = report; log.refreshReports.push(report); }
 function refreshReportRangeLabel() { return 'test range'; }
 function clearOverviewBreakdowns() { overviewBreakdownWindowKey = null; }
 function setOverviewState(state) { log.stale.push(!!(state && (state.pending || state.stale))); }
@@ -255,6 +255,27 @@ async function main() {
     out.totalTokens = lastUsageResponse && lastUsageResponse.total_tokens;
   }
 
+  if (scenario === 'every-same-range-refresh-reports') {
+    pick('X');
+    await settle();
+    resolveRange('X', { total_tokens: 100, total_cost: 1, total_messages: 2 });
+    await settle(); await settle();
+    out.afterInitialLoad = log.refreshReports.length;
+
+    pick('X');
+    await settle();
+    resolveRange('X', { total_tokens: 125, total_cost: 1.25, total_messages: 3 });
+    await settle(); await settle();
+    out.afterAutomaticRefresh = log.refreshReports.length;
+    out.automaticDelta = lastRefreshReport && lastRefreshReport.tokens;
+
+    pick('Y');
+    await settle();
+    resolveRange('Y', { total_tokens: 5, total_cost: 0.05, total_messages: 1 });
+    await settle(); await settle();
+    out.afterRangeChange = log.refreshReports.length;
+  }
+
   process.stdout.write(JSON.stringify(out));
 }
 
@@ -371,3 +392,12 @@ def test_total_outage_never_relabels_another_server_selections_aggregate(tmp_pat
     assert out["lastStale"] is True, "the local-only total is not Studio's total"
     assert out["lastUsageServerKey"] == "local"
     assert out["totalTokens"] == 100
+
+
+def test_every_same_range_refresh_reports_but_initial_and_range_loads_do_not(tmp_path):
+    out = _run(tmp_path, "every-same-range-refresh-reports")
+
+    assert out["afterInitialLoad"] == 0
+    assert out["afterAutomaticRefresh"] == 1
+    assert out["automaticDelta"] == 25
+    assert out["afterRangeChange"] == 1

--- a/tests/test_usage_refresh_frontend.py
+++ b/tests/test_usage_refresh_frontend.py
@@ -166,9 +166,11 @@ def test_refresh_report_is_accessible_and_the_scan_stays_incremental() -> None:
     assert 'role="status"' in html
     assert 'aria-live="polite"' in html
     assert 'id="refreshReportClose"' in html
-    assert "refreshReportComplete: 'Scan complete'" in html
-    assert "refreshReportComplete: '扫描完成'" in html
+    assert "refreshReportComplete: 'Refresh complete'" in html
+    assert "refreshReportComplete: '刷新完成'" in html
     assert "usageApiUrl += '&refresh=1';" in updater
     assert updater.count("fetchSelectedServers(usageApiUrl)") == 1
     assert "reconcileUsageRows(rows, windowKey, usageServers)" in updater
+    assert "const shouldReportRefresh = forceRefresh || previousUsageForReport !== null;" in updater
+    assert updater.count("if (shouldReportRefresh) {") == 2
     assert "localStorage" not in reconcile

--- a/tests/test_usage_refresh_frontend.py
+++ b/tests/test_usage_refresh_frontend.py
@@ -171,6 +171,8 @@ def test_refresh_report_is_accessible_and_the_scan_stays_incremental() -> None:
     assert "usageApiUrl += '&refresh=1';" in updater
     assert updater.count("fetchSelectedServers(usageApiUrl)") == 1
     assert "reconcileUsageRows(rows, windowKey, usageServers)" in updater
-    assert "const shouldReportRefresh = forceRefresh || previousUsageForReport !== null;" in updater
+    assert "const shouldReportRefresh = (forceRefresh || previousUsageForReport !== null)" in updater
+    assert "&& refreshReportDismissedWindowKey !== windowKey;" in updater
     assert updater.count("if (shouldReportRefresh) {") == 2
+    assert html.count("hideUsageRefreshReport({ focusButton: true, dismissed: true });") == 2
     assert "localStorage" not in reconcile


### PR DESCRIPTION
## Summary

- show the existing refresh report after automatic and other same-range usage refreshes, not only manual scans
- keep initial loads and genuine range changes out of before/after reporting
- use refresh-neutral English and Chinese copy because cached automatic updates are not scans

## Performance

This adds no request, timer, dependency, or persisted state. It reuses the response and same-range baseline already held in memory; the existing report calculation remains a small pass over the tool summary after the request completes.

## Verification

- 53 focused frontend tests passed
- 1,554 full-suite tests passed; one unrelated pre-existing calendar-month timezone assertion failed under Asia/Hong_Kong
- Python compile check passed
- targeted Ruff checks passed
- manually verified the accessible inline report in the running dashboard

This follows the refresh-report behavior introduced before v2.3.1 and broadens only when that existing UI is surfaced.