### PR TITLE
Release v2.4.0

### DIFF
--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -6,9 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+## 2.4.0 - 2026-08-28
+
 ### Added
 
+- Added Japanese, Korean, Spanish, and Portuguese dashboard languages alongside English and Simplified Chinese. The System option follows the browser language, dates and numbers use the selected locale, and each language has a linked README.
 - Added opt-in Z.ai Coding Plan quota tracking. Tokdash discovers Coding Plan keys from ZCode, supported OpenCode/Claude-compatible provider configs, or `ZAI_API_KEY` / `Z_AI_API_KEY`, then reads the provider's 5-hour and weekly credit windows plus legacy MCP limits from Z.ai's quota endpoint without refreshing or writing credentials.
+- Updated the bundled pricing database to 2.0.20, adding 14 model entries across Z.ai, DeepSeek, Qwen, ByteDance, Tencent, Mistral, Meta, and NVIDIA.
+
+### Changed
+
+- Usage refresh reports now appear for every repeat refresh of the displayed range, including timer-driven refreshes, while an explicit dismissal remains in effect until the range changes or the user requests another refresh.
 
 ## 2.3.1 - 2026-08-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tokdash"
-version = "2.3.1"
+version = "2.4.0"
 description = "Local token & cost dashboard for AI coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tokdash/__init__.py
+++ b/src/tokdash/__init__.py
@@ -1,3 +1,3 @@
 """Tokdash package."""
 
-__version__ = "2.3.1"
+__version__ = "2.4.0"

--- a/src/tokdash/static/release-notes.json
+++ b/src/tokdash/static/release-notes.json
@@ -1,6 +1,26 @@
 {
-  "current": "2.3.1",
+  "current": "2.4.0",
   "releases": [
+    {
+      "version": "2.4.0",
+      "date": "2026-08-28",
+      "sections": [
+        {
+          "type": "added",
+          "items": [
+            "Added Japanese, Korean, Spanish, and Portuguese dashboard languages, with automatic browser-language detection and locale-aware dates and numbers.",
+            "Added opt-in Z.ai Coding Plan quota tracking for 5-hour, weekly credit, and legacy MCP windows.",
+            "Updated pricing data to 2.0.20 with 14 newly listed models."
+          ]
+        },
+        {
+          "type": "changed",
+          "items": [
+            "Refresh reports now appear for every repeat refresh of the displayed range while respecting an explicit dismissal."
+          ]
+        }
+      ]
+    },
     {
       "version": "2.3.1",
       "date": "2026-08-27",


### PR DESCRIPTION
## Summary

- bump package and runtime versions to 2.4.0
- publish the 2.4.0 changelog entry for six-language UI support, Z.ai quota tracking, refresh reports, and pricing DB 2.0.20
- add the matching in-dashboard release notes

## Verification

- release metadata, dashboard release notes, version surfaces, and release-safe pricing tests: 64 passed
- feature PR #49 passed all Ubuntu, Windows, macOS, and security checks