### PR TITLE
Release v2.4.1

### DIFF
--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+## 2.4.1 - 2026-08-28
+
+### Fixed
+
+- Quota provider visibility controls are now scoped to each server's reported harnesses in multi-server mode. The shared show/hide preference updates every rendered server block, including partial loads where only one of several selected servers responds.
+
 ## 2.4.0 - 2026-08-28
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tokdash"
-version = "2.4.0"
+version = "2.4.1"
 description = "Local token & cost dashboard for AI coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tokdash/__init__.py
+++ b/src/tokdash/__init__.py
@@ -1,3 +1,3 @@
 """Tokdash package."""
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -3555,20 +3555,6 @@
           <option value="30d" data-i18n="quotaRange30d">Last 30 Days</option>
           <option value="all" data-i18n="quotaRangeAll">All Time</option>
         </select>
-        <div id="quotaVisibilityWrap" class="quota-visibility-wrap">
-          <button type="button" id="quotaVisibilityBtn" class="ui-input compact-control quota-visibility-btn" aria-haspopup="true" aria-expanded="false">
-            <span id="quotaVisibilityLabel" data-i18n="quotaVisibilityAll">Show: All</span><span aria-hidden="true" class="quota-visibility-caret">▾</span>
-          </button>
-          <div id="quotaVisibilityPanel" class="quota-visibility-panel hidden" role="menu" aria-label="Show providers">
-            <label class="quota-visibility-item"><input type="checkbox" data-quota-provider="codex" checked><span>Codex</span></label>
-            <label class="quota-visibility-item"><input type="checkbox" data-quota-provider="claude" checked><span>Claude Code</span></label>
-            <label class="quota-visibility-item"><input type="checkbox" data-quota-provider="antigravity" checked><span>Antigravity</span></label>
-            <label class="quota-visibility-item"><input type="checkbox" data-quota-provider="minimax" checked><span>MiniMax</span></label>
-            <label class="quota-visibility-item"><input type="checkbox" data-quota-provider="kimi" checked><span>Kimi Code</span></label>
-            <label class="quota-visibility-item"><input type="checkbox" data-quota-provider="grok" checked><span>Grok Build</span></label>
-            <label class="quota-visibility-item"><input type="checkbox" data-quota-provider="zai" checked><span>Z.ai</span></label>
-          </div>
-        </div>
         <span id="quotaGlobalStatusLine" class="text-xs" style="color:var(--color-muted)"></span>
       </div>
       <section id="quotaSingleServerPanel" class="surface p-5 mb-6">
@@ -3596,6 +3582,7 @@
             </label>
             <span id="quotaIntervalSource" class="text-xs" style="color: var(--color-muted);"></span>
             <span id="quotaGlobalControlsSingleSlot" style="display:contents"></span>
+            <span id="quotaVisibilityHost" style="display:contents"></span>
             <!-- TASK 2: no dedicated quota refresh button anymore — the global #refreshBtn
                  refreshes quota when this tab is active. This line keeps the poll.last_run
                  freshness readout visible, and doubles as the transient status surface for
@@ -7654,15 +7641,15 @@
         lastQuotaServerRows.forEach((row) => renderQuotaServerBlock(row.server, row.payload, row.history));
       } else {
         if (lastQuotaPayload) renderQuotaProviderCards(lastQuotaPayload);
-        if (lastQuotaHistory) renderQuotaCharts(lastQuotaHistory);
+        if (lastQuotaHistory) renderQuotaCharts(lastQuotaHistory, { present: quotaPresentProviders(lastQuotaPayload) });
         if (lastQuotaPayload) renderQuotaSettings(lastQuotaPayload);
+        if (lastQuotaPayload) syncQuotaSingleVisibility(lastQuotaPayload);
       }
       renderServerSettings();
       renderServerFormStatus();
       if (lastRefreshReport && !document.getElementById('refreshReport')?.hidden) {
         showUsageRefreshReport(lastRefreshReport);
       }
-      updateQuotaVisibilityLabel();  // imperative label (data-i18n removed), re-derive on switch
       const quotaUnitEl = document.getElementById('quotaConsumptionUnit');
       if (quotaUnitEl && !quotaUnitEl.hasAttribute('data-i18n')) {
         const granularity = currentQuotaRange() === '24h' ? 'hour' : 'day';
@@ -10771,7 +10758,8 @@
     function renderQuotaProviderCards(payload, containerOverride = null, ownerServer = LOCAL_SERVER) {
       const container = containerOverride || document.getElementById('quotaProviderCards');
       if (!container) return;
-      updateQuotaProviderPresence(payload);
+      // Visibility is scoped to this payload's provider set, not a global union.
+      const present = quotaPresentProviders(payload);
       if (payload?.enabled === false) {
         renderQuotaDisabledCard(container, ownerServer);
         return;
@@ -10782,8 +10770,9 @@
       let renderedCards = 0;
 
       order.forEach((providerKey) => {
-        // Provider-visibility dropdown: skip providers the user has hidden.
-        if (!quotaProviderVisible(providerKey)) return;
+        // Provider-visibility dropdown: skip providers the user has hidden or that
+        // this server's payload does not report.
+        if (!quotaProviderVisible(providerKey, present)) return;
         renderedCards += 1;
         const provider = providers[providerKey] || {};
         const buckets = Array.isArray(provider.buckets) ? provider.buckets.filter(isQuotaUsageBucket) : [];
@@ -10964,31 +10953,25 @@
       return [...passthrough, ...pooled];
     }
 
-    // Provider-visibility dropdown state. The user can hide whole providers from both
-    // the cards and the charts; the choice is persisted
-    // in localStorage and defaults to all-visible. Unknown providers default to visible.
+    // Provider-visibility dropdown ("Show: All / Codex / …"). The show/hide choice is one
+    // persisted display preference (provider -> bool), but the control is scoped per server:
+    // in multi-server mode every server block carries its own dropdown, and each dropdown
+    // only offers the providers present in THAT server's /api/quota payload — never the
+    // union of harnesses across servers. Single-server mode uses the same control, placed
+    // in the settings row via #quotaVisibilityHost.
     const QUOTA_PROVIDERS = ['codex', 'claude', 'antigravity', 'minimax', 'kimi', 'grok', 'zai'];
     const QUOTA_VISIBILITY_KEY = 'tokdash-quota-visible';
     let quotaVisibilityState = null;
-    let quotaPresentProviders = null;
 
-    function updateQuotaProviderPresence(payload) {
-      const providers = payload?.providers || {};
-      quotaPresentProviders = new Set(QUOTA_PROVIDERS.filter((provider) => {
+    // Providers actually present in one server's quota payload: detected locally,
+    // network-enabled, or carrying bucket data.
+    function quotaPresentProviders(payload) {
+      const providers = (payload && payload.providers) || {};
+      return new Set(QUOTA_PROVIDERS.filter((provider) => {
         const item = providers[provider] || {};
         const buckets = Array.isArray(item.buckets) ? item.buckets : [];
         return item.detected === true || item.network_enabled === true || buckets.length > 0;
       }));
-      document.querySelectorAll('#quotaVisibilityPanel input[data-quota-provider]').forEach((input) => {
-        const provider = input.getAttribute('data-quota-provider');
-        const row = input.closest('.quota-visibility-item');
-        if (row) row.classList.toggle('hidden', !quotaPresentProviders.has(provider));
-      });
-      updateQuotaVisibilityLabel();
-    }
-
-    function quotaProviderPresent(provider) {
-      return quotaPresentProviders === null || quotaPresentProviders.has(provider);
     }
 
     function loadQuotaVisibility() {
@@ -11005,73 +10988,204 @@
       return state;
     }
 
-    function quotaProviderVisible(provider) {
-      return quotaProviderPresent(provider) && loadQuotaVisibility()[provider] !== false;
+    // `present` is the scope's provider set (that server's payload); omitting it keeps the
+    // legacy all-present behavior for any caller without a scope.
+    function quotaProviderVisible(provider, present) {
+      return (present === null || present === undefined || present.has(provider)) && loadQuotaVisibility()[provider] !== false;
     }
 
     function persistQuotaVisibility() {
       try { localStorage.setItem(QUOTA_VISIBILITY_KEY, JSON.stringify(loadQuotaVisibility())); } catch (e) { /* ignore */ }
     }
 
-    function updateQuotaVisibilityLabel() {
-      const label = document.getElementById('quotaVisibilityLabel');
-      if (!label) return;
+    function quotaVisibilityLabelText(present) {
       const state = loadQuotaVisibility();
-      const available = QUOTA_PROVIDERS.filter(quotaProviderPresent);
-      const shown = available.filter((p) => state[p] !== false);
-      label.removeAttribute('data-i18n');
-      if (available.length === 0 || shown.length === 0) label.textContent = t('quotaVisibilityNone');
-      else if (shown.length === available.length) label.textContent = t('quotaVisibilityAll');
-      else label.textContent = `${t('quotaVisibilityPrefix')} ${shown.map(quotaProviderLabel).join(', ')}`;
+      const available = QUOTA_PROVIDERS.filter((provider) => present.has(provider));
+      const shown = available.filter((provider) => state[provider] !== false);
+      if (available.length === 0 || shown.length === 0) return t('quotaVisibilityNone');
+      if (shown.length === available.length) return t('quotaVisibilityAll');
+      return `${t('quotaVisibilityPrefix')} ${shown.map(quotaProviderLabel).join(', ')}`;
     }
 
-    function closeQuotaVisibilityPanel() {
-      const panel = document.getElementById('quotaVisibilityPanel');
-      const btn = document.getElementById('quotaVisibilityBtn');
-      if (panel) panel.classList.add('hidden');
-      if (btn) btn.setAttribute('aria-expanded', 'false');
+    function buildQuotaVisibilityRow(provider) {
+      const item = document.createElement('label');
+      item.className = 'quota-visibility-item';
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.dataset.provider = provider;
+      input.checked = loadQuotaVisibility()[provider] !== false;
+      input.addEventListener('change', () => {
+        loadQuotaVisibility()[provider] = input.checked;
+        persistQuotaVisibility();
+        // One shared preference: propagate the change to every rendered scope.
+        applyQuotaVisibilityChange();
+      });
+      const span = document.createElement('span');
+      span.textContent = quotaProviderLabel(provider);
+      item.appendChild(input);
+      item.appendChild(span);
+      return item;
     }
 
-    function initQuotaVisibilityControls() {
-      const state = loadQuotaVisibility();
-      const panel = document.getElementById('quotaVisibilityPanel');
-      const btn = document.getElementById('quotaVisibilityBtn');
-      if (!panel || !btn) return;
-      panel.querySelectorAll('input[data-quota-provider]').forEach((input) => {
-        const provider = input.getAttribute('data-quota-provider');
-        input.checked = state[provider] !== false;
-        input.addEventListener('change', () => {
-          state[provider] = input.checked;
-          persistQuotaVisibility();
-          updateQuotaVisibilityLabel();
-          // Re-render from the cached payloads — a visibility change never needs a refetch.
-          if (lastQuotaServerRows.length > 1) lastQuotaServerRows.forEach((row) => renderQuotaServerBlock(row.server, row.payload, row.history));
-          else {
-            if (lastQuotaPayload) renderQuotaProviderCards(lastQuotaPayload);
-            if (lastQuotaHistory) renderQuotaCharts(lastQuotaHistory);
-          }
-        });
+    function createQuotaVisibilityControl(present) {
+      const wrap = document.createElement('div');
+      wrap.className = 'quota-visibility-wrap';
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'ui-input compact-control quota-visibility-btn';
+      btn.setAttribute('aria-haspopup', 'true');
+      btn.setAttribute('aria-expanded', 'false');
+      const label = document.createElement('span');
+      label.className = 'quota-visibility-label';
+      label.textContent = quotaVisibilityLabelText(present);
+      const caret = document.createElement('span');
+      caret.className = 'quota-visibility-caret';
+      caret.setAttribute('aria-hidden', 'true');
+      caret.textContent = '▾';
+      btn.appendChild(label);
+      btn.appendChild(caret);
+      const panel = document.createElement('div');
+      panel.className = 'quota-visibility-panel hidden';
+      panel.setAttribute('role', 'menu');
+      panel.setAttribute('aria-label', 'Show providers');
+      QUOTA_PROVIDERS.forEach((provider) => {
+        if (!present.has(provider)) return;
+        panel.appendChild(buildQuotaVisibilityRow(provider));
       });
       btn.addEventListener('click', (event) => {
         event.stopPropagation();
         const hidden = panel.classList.toggle('hidden');
         btn.setAttribute('aria-expanded', String(!hidden));
       });
+      wrap.appendChild(btn);
+      wrap.appendChild(panel);
+      return wrap;
+    }
+
+    // Rebuild a scope's dropdown when its provider set changes (refresh / i18n / consent
+    // write): options and label follow the new set. Toggles use
+    // syncQuotaVisibilityControlInPlace instead, so the open panel is never rebuilt.
+    function syncQuotaVisibilityControl(control, present) {
+      const panel = control.querySelector('.quota-visibility-panel');
+      if (!panel) return;
+      panel.replaceChildren();
+      QUOTA_PROVIDERS.forEach((provider) => {
+        if (!present.has(provider)) return;
+        panel.appendChild(buildQuotaVisibilityRow(provider));
+      });
+      const label = control.querySelector('.quota-visibility-label');
+      if (label) label.textContent = quotaVisibilityLabelText(present);
+    }
+
+    // Toggle path: update one scope's dropdown in place. Label text and checkbox states
+    // follow the shared preference; rows are not rebuilt, so the open panel keeps its
+    // identity and focus while the user works through the menu.
+    function syncQuotaVisibilityControlInPlace(control, present) {
+      if (!control || !present) return;
+      const label = control.querySelector('.quota-visibility-label');
+      if (label) label.textContent = quotaVisibilityLabelText(present);
+      const state = loadQuotaVisibility();
+      control.querySelectorAll('.quota-visibility-item input').forEach((input) => {
+        if (input.dataset.provider) input.checked = state[input.dataset.provider] !== false;
+      });
+    }
+
+    function closeQuotaVisibilityPanels() {
+      document.querySelectorAll('.quota-visibility-panel:not(.hidden)').forEach((panel) => {
+        panel.classList.add('hidden');
+        const btn = panel.closest('.quota-visibility-wrap')?.querySelector('.quota-visibility-btn');
+        if (btn) btn.setAttribute('aria-expanded', 'false');
+      });
+    }
+
+    function initQuotaVisibilityControls() {
+      // Controls are built dynamically per scope (server block / single-server row), so
+      // document-level listeners close whichever panel(s) are open. A click inside a
+      // wrap keeps that wrap's panel open.
       document.addEventListener('click', (event) => {
-        if (panel.classList.contains('hidden')) return;
-        if (!panel.contains(event.target) && !btn.contains(event.target)) closeQuotaVisibilityPanel();
+        const open = document.querySelectorAll('.quota-visibility-panel:not(.hidden)');
+        if (!open.length) return;
+        const wrap = event.target.closest ? event.target.closest('.quota-visibility-wrap') : null;
+        open.forEach((panel) => {
+          if (panel.closest('.quota-visibility-wrap') === wrap) return;
+          panel.classList.add('hidden');
+          const btn = panel.closest('.quota-visibility-wrap')?.querySelector('.quota-visibility-btn');
+          if (btn) btn.setAttribute('aria-expanded', 'false');
+        });
       });
       document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') closeQuotaVisibilityPanel();
+        if (event.key === 'Escape') closeQuotaVisibilityPanels();
       });
-      updateQuotaVisibilityLabel();
+    }
+
+    // Toggle path: re-render one scope's cards and charts, and sync that scope's
+    // dropdown in place (label + checkbox states; the open panel is never rebuilt).
+    function refreshQuotaServerScope(server) {
+      const row = (lastQuotaServerRows || []).find((r) => r.server && r.server.id === server.id);
+      const block = document.querySelector(`#quotaServerBlocks [data-server-id="${CSS.escape(server.id)}"]`);
+      if (!row || !block) return;
+      const present = quotaPresentProviders(row.payload);
+      renderQuotaProviderCards(row.payload, block.querySelector('[data-role="cards"]'), server);
+      renderQuotaCharts(row.history, {
+        serverId: server.id,
+        utilizationCanvas: block.querySelector('[data-role="utilization"]'),
+        consumptionCanvas: block.querySelector('[data-role="consumption"]'),
+        estimatedBanner: block.querySelector('[data-role="estimated"]'),
+        present,
+      });
+      syncQuotaVisibilityControlInPlace(block.querySelector('[data-role="visibility"] .quota-visibility-wrap'), present);
+    }
+
+    function refreshQuotaSingleScope() {
+      if (!lastQuotaPayload) return;
+      const present = quotaPresentProviders(lastQuotaPayload);
+      renderQuotaProviderCards(lastQuotaPayload);
+      if (lastQuotaHistory) renderQuotaCharts(lastQuotaHistory, { present });
+      syncQuotaVisibilityControlInPlace(document.getElementById('quotaVisibilityHost')?.querySelector('.quota-visibility-wrap'), present);
+    }
+
+    // The show/hide preference is shared across scopes, so a toggle in one dropdown
+    // re-renders every rendered scope — the one under the cursor and all the others —
+    // so no block keeps stale cards, charts, labels, or checkbox state. Branch on the
+    // layout (selected server count), not the successful-row count: a partial multi
+    // load (one of two servers answering) still renders server blocks and must update
+    // them, not the hidden single-server UI.
+    function applyQuotaVisibilityChange() {
+      if (selectedServers().length > 1) {
+        lastQuotaServerRows.forEach((row) => refreshQuotaServerScope(row.server));
+      } else {
+        refreshQuotaSingleScope();
+      }
+    }
+
+    // Per-server dropdown slot in the block header; hidden entirely when the server
+    // reports no providers.
+    function syncQuotaServerVisibilityControl(block, payload) {
+      const host = block.querySelector('[data-role="visibility"]');
+      if (!host) return;
+      const present = quotaPresentProviders(payload);
+      if (!present.size) { host.replaceChildren(); return; }
+      const control = host.querySelector('.quota-visibility-wrap');
+      if (control) syncQuotaVisibilityControl(control, present);
+      else host.appendChild(createQuotaVisibilityControl(present));
+    }
+
+    // Single-server dropdown slot in the settings row.
+    function syncQuotaSingleVisibility(payload) {
+      const host = document.getElementById('quotaVisibilityHost');
+      if (!host) return;
+      const present = quotaPresentProviders(payload);
+      if (!present.size) { host.replaceChildren(); return; }
+      const control = host.querySelector('.quota-visibility-wrap');
+      if (control) syncQuotaVisibilityControl(control, present);
+      else host.appendChild(createQuotaVisibilityControl(present));
     }
 
     function renderQuotaCharts(history, targets = {}) {
-      // Provider-visibility filter (dropdown next to the interval selector): drop whole
-      // provider series the user has hidden before any dataset is built.
+      // Provider-visibility filter (per-server "Show: …" dropdown): drop whole provider
+      // series the user has hidden, or that this server does not report.
       const series = collapseAntigravitySeriesForCharts(history?.series || [])
-        .filter((item) => quotaProviderVisible(item.provider));
+        .filter((item) => quotaProviderVisible(item.provider, targets.present));
       const granularity = history?.granularity || 'hour';
       const palette = getChartPalette();
       const utilizationCanvas = targets.utilizationCanvas || document.getElementById('quotaUtilizationChart');
@@ -11245,7 +11359,7 @@
       block.className = 'surface p-5';
       block.dataset.serverId = server.id;
       const minute = t('minuteShort');
-      block.innerHTML = `<div class="flex flex-wrap items-center justify-between gap-3 mb-4"><h2 class="text-base font-extrabold mono"></h2><div class="flex flex-wrap items-center gap-2"><label class="text-sm"><input data-control="enabled" type="checkbox"> <span data-i18n="quotaTracking">${t('quotaTracking')}</span></label><label class="text-sm"><input data-control="credentials" type="checkbox"> <span data-i18n="quotaCredentialScan">${t('quotaCredentialScan')}</span></label><select data-control="interval" class="ui-input compact-control"><option value="15">15 ${minute}</option><option value="30">30 ${minute}</option><option value="60">60 ${minute}</option><option value="120">120 ${minute}</option></select><span data-role="status" class="text-xs" style="color:var(--color-muted)"></span></div></div><div data-role="cards" class="grid grid-cols-1 lg:grid-cols-3 gap-4"></div><div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4"><div class="surface p-5"><h3 class="text-base font-extrabold mono mb-3" data-i18n="utilizationHistory">${t('utilizationHistory')}</h3><div class="h-[280px]"><canvas data-role="utilization"></canvas></div></div><div class="surface p-5"><h3 class="text-base font-extrabold mono mb-3" data-i18n="consumptionHistory">${t('consumptionHistory')}</h3><div data-role="estimated" class="text-xs mb-2 hidden" style="color:var(--color-muted)" data-i18n="quotaConsumptionEstimated">${t('quotaConsumptionEstimated')}</div><div class="h-[280px]"><canvas data-role="consumption"></canvas></div></div></div>`;
+      block.innerHTML = `<div class="flex flex-wrap items-center justify-between gap-3 mb-4"><h2 class="text-base font-extrabold mono"></h2><div class="flex flex-wrap items-center gap-2"><label class="text-sm"><input data-control="enabled" type="checkbox"> <span data-i18n="quotaTracking">${t('quotaTracking')}</span></label><label class="text-sm"><input data-control="credentials" type="checkbox"> <span data-i18n="quotaCredentialScan">${t('quotaCredentialScan')}</span></label><select data-control="interval" class="ui-input compact-control"><option value="15">15 ${minute}</option><option value="30">30 ${minute}</option><option value="60">60 ${minute}</option><option value="120">120 ${minute}</option></select><span data-role="visibility" class="flex items-center gap-2"></span><span data-role="status" class="text-xs" style="color:var(--color-muted)"></span></div></div><div data-role="cards" class="grid grid-cols-1 lg:grid-cols-3 gap-4"></div><div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4"><div class="surface p-5"><h3 class="text-base font-extrabold mono mb-3" data-i18n="utilizationHistory">${t('utilizationHistory')}</h3><div class="h-[280px]"><canvas data-role="utilization"></canvas></div></div><div class="surface p-5"><h3 class="text-base font-extrabold mono mb-3" data-i18n="consumptionHistory">${t('consumptionHistory')}</h3><div data-role="estimated" class="text-xs mb-2 hidden" style="color:var(--color-muted)" data-i18n="quotaConsumptionEstimated">${t('quotaConsumptionEstimated')}</div><div class="h-[280px]"><canvas data-role="consumption"></canvas></div></div></div>`;
       block.querySelector('h2').textContent = server.label;
       return block;
     }
@@ -11263,8 +11377,9 @@
       enabled.onchange = () => setQuotaEnabled(enabled.checked, server).catch(() => { enabled.checked = !enabled.checked; });
       credentials.onchange = () => setQuotaCredentialScan(credentials.checked, server).catch(() => { credentials.checked = !credentials.checked; });
       interval.onchange = () => setQuotaInterval(interval.value, server);
+      syncQuotaServerVisibilityControl(block, payload);
       renderQuotaProviderCards(payload, block.querySelector('[data-role="cards"]'), server);
-      renderQuotaCharts(history, { serverId: server.id, utilizationCanvas: block.querySelector('[data-role="utilization"]'), consumptionCanvas: block.querySelector('[data-role="consumption"]'), estimatedBanner: block.querySelector('[data-role="estimated"]') });
+      renderQuotaCharts(history, { serverId: server.id, utilizationCanvas: block.querySelector('[data-role="utilization"]'), consumptionCanvas: block.querySelector('[data-role="consumption"]'), estimatedBanner: block.querySelector('[data-role="estimated"]'), present: quotaPresentProviders(payload) });
     }
 
     // ---- Servers tab (per-server stats) ----------------------------------------
@@ -11842,8 +11957,9 @@
         quotaLoaded = true;
         if (!multi) {
           renderQuotaSettings(payload);
+          syncQuotaSingleVisibility(payload);
           renderQuotaProviderCards(payload);
-          renderQuotaCharts(history);
+          renderQuotaCharts(history, { present: quotaPresentProviders(payload) });
         }
         return true;
       } catch (error) {
@@ -11851,8 +11967,9 @@
         setQuotaFetchStatus(error);
         if (lastQuotaServerRows.length <= 1) {
           if (lastQuotaPayload) renderQuotaSettings(lastQuotaPayload);
+          if (lastQuotaPayload) syncQuotaSingleVisibility(lastQuotaPayload);
           if (lastQuotaPayload) renderQuotaProviderCards(lastQuotaPayload);
-          if (lastQuotaHistory) renderQuotaCharts(lastQuotaHistory);
+          if (lastQuotaHistory) renderQuotaCharts(lastQuotaHistory, { present: quotaPresentProviders(lastQuotaPayload) });
         }
         // Reported rather than rethrown: callers that follow a write with a reload
         // must not acknowledge "saved" over an active fetch error (which would also

--- a/src/tokdash/static/release-notes.json
+++ b/src/tokdash/static/release-notes.json
@@ -1,6 +1,18 @@
 {
-  "current": "2.4.0",
+  "current": "2.4.1",
   "releases": [
+    {
+      "version": "2.4.1",
+      "date": "2026-08-28",
+      "sections": [
+        {
+          "type": "fixed",
+          "items": [
+            "Quota provider visibility menus now list the harnesses reported by their own server and keep every server block synchronized when the shared preference changes."
+          ]
+        }
+      ]
+    },
     {
       "version": "2.4.0",
       "date": "2026-08-28",

--- a/tests/test_multi_server_frontend.py
+++ b/tests/test_multi_server_frontend.py
@@ -283,3 +283,364 @@ def test_companion_v2_schema_and_loose_test_rule_are_present():
     fixture_name = 'ContractFile("expected", "multi-server.json")'
     assert fixture_name in (root / "companion/windows/TokdashCompanion.Tests/MultiServerContractTests.cs").read_text(encoding="utf-8")
     assert 'contractURL("expected/multi-server.json")' in (root / "companion/macos/TokdashCompanionTests/SnapshotTests.swift").read_text(encoding="utf-8")
+
+
+def test_quota_visibility_dropdown_is_scoped_per_server():
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    # The old global dropdown (its option list was driven by the last-rendered
+    # server's payload, i.e. not the per-server harness set) is gone.
+    for gone in ('id="quotaVisibilityWrap"', 'id="quotaVisibilityBtn"', 'id="quotaVisibilityPanel"', 'id="quotaVisibilityLabel"'):
+        assert gone not in source
+    # One dropdown slot per server block, plus the single-server slot in the settings row.
+    assert 'data-role="visibility"' in source
+    assert 'id="quotaVisibilityHost"' in source
+    # Presence is computed per payload and threaded into cards and charts.
+    assert "const present = quotaPresentProviders(payload);" in source
+    assert "const present = quotaPresentProviders(row.payload);" in source
+    assert "present: quotaPresentProviders(payload)" in source
+    assert "syncQuotaServerVisibilityControl(block, payload);" in source
+    assert "syncQuotaSingleVisibility(payload);" in source
+    # A toggle propagates to every rendered scope and syncs each dropdown in place.
+    assert "syncQuotaVisibilityControlInPlace(block.querySelector" in source
+    # The toggle branches on the layout (selected servers), not the successful-row
+    # count, so a partial multi load (one of two answering) still updates blocks.
+    assert "function applyQuotaVisibilityChange() {\n      if (selectedServers().length > 1) {" in source
+    # The static HTML checkboxes are gone; rows are built per scope.
+    assert "data-quota-provider=" not in source
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_quota_presence_and_label_are_per_payload(tmp_path):
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    functions = [
+        "const QUOTA_PROVIDERS = ['codex', 'claude', 'antigravity', 'minimax', 'kimi', 'grok', 'zai'];",
+        "const QUOTA_VISIBILITY_KEY = 'tokdash-quota-visible';",
+        "let quotaVisibilityState = null;",
+        _extract_js_function(source, "function quotaPresentProviders(payload) {"),
+        _extract_js_function(source, "function loadQuotaVisibility() {"),
+        _extract_js_function(source, "function quotaProviderLabel(provider) {"),
+        _extract_js_function(source, "function quotaVisibilityLabelText(present) {"),
+    ]
+    expression = """(() => {
+      global.localStorage = { getItem: () => null, setItem: () => {} };
+      global.t = (key) => key;
+      const serverA = { providers: { codex: { detected: true }, claude: { detected: true } } };
+      const serverB = { providers: { codex: { detected: true }, kimi: { network_enabled: true } } };
+      const pa = quotaPresentProviders(serverA);
+      const pb = quotaPresentProviders(serverB);
+      return {
+        a: Array.from(pa).sort(),
+        b: Array.from(pb).sort(),
+        labelA: quotaVisibilityLabelText(pa),
+        labelB: quotaVisibilityLabelText(pb),
+        hiddenClaude: (() => { loadQuotaVisibility().claude = false; return quotaVisibilityLabelText(pa); })(),
+      };
+    })()"""
+    out = _run(tmp_path, "quota-visibility-scopes", functions, expression, {})
+    # Each scope sees only its own server's harnesses — never the other's.
+    assert out["a"] == ["claude", "codex"]
+    assert out["b"] == ["codex", "kimi"]
+    assert out["labelA"] == "quotaVisibilityAll"
+    assert out["labelB"] == "quotaVisibilityAll"
+    # Hiding a provider only changes the label over the providers present in the scope.
+    assert out["hiddenClaude"] == "quotaVisibilityPrefix Codex"
+
+
+# --- Quota visibility: checkbox event path (DOM-level) -------------------------
+# The show/hide preference is shared, so a toggle in one scope must re-render every
+# rendered scope (cards, charts) and sync every dropdown (label + checkbox states)
+# in place, without rebuilding the open panel.
+
+QUOTA_VISIBILITY_DOM_STUBS = r"""
+// --- minimal DOM stub: just enough for the quota visibility controls ---------
+class El {
+  constructor(tag) {
+    this.tag = tag;
+    this.children = [];
+    this.parent = null;
+    this.className = '';
+    this.attrs = {};
+    this.dataset = {};
+    this.textContent = '';
+    this.checked = false;
+    this.style = {};
+    this.listeners = {};
+  }
+  get classes() { return new Set(this.className.split(/\s+/).filter(Boolean)); }
+  get classList() {
+    const el = this;
+    return {
+      contains: (c) => el.classes.has(c),
+      add: (c) => { const s = new Set(el.classes); s.add(c); el.className = [...s].join(' '); },
+      remove: (c) => { el.className = [...el.classes].filter((x) => x !== c).join(' '); },
+      toggle: (c) => {
+        const s = new Set(el.classes);
+        if (s.has(c)) { s.delete(c); el.className = [...s].join(' '); return false; }
+        s.add(c); el.className = [...s].join(' '); return true;
+      },
+    };
+  }
+  appendChild(child) { child.parent = this; this.children.push(child); return child; }
+  replaceChildren() { this.children.length = 0; }
+  setAttribute(name, value) { this.attrs[name] = String(value); }
+  getAttribute(name) { return name in this.attrs ? this.attrs[name] : null; }
+  addEventListener(type, fn) { (this.listeners[type] = this.listeners[type] || []).push(fn); }
+  dispatch(type) { (this.listeners[type] || []).forEach((fn) => fn({ target: this, stopPropagation() {} })); }
+  matches(part) {
+    const tag = part.match(/^[a-zA-Z][\w-]*/);
+    if (tag && this.tag !== tag[0]) return false;
+    for (const cls of part.match(/\.[\w-]+/g) || []) if (!this.classes.has(cls.slice(1))) return false;
+    const id = part.match(/#[\w-]+/);
+    if (id && this.attrs.id !== id[0].slice(1)) return false;
+    for (const a of part.match(/\[[\w-]+(?:="[^"]*")?\]/g) || []) {
+      const m = a.match(/\[([\w-]+)(?:="([^"]*)")?\]/);
+      if (this.attrs[m[1]] === undefined || (m[2] !== undefined && this.attrs[m[1]] !== m[2])) return false;
+    }
+    return true;
+  }
+  find(sel) {
+    let current = [this];
+    for (const part of sel.trim().split(/\s+/)) {
+      const next = [];
+      const walk = (node) => node.children.forEach((child) => { if (child.matches(part)) next.push(child); walk(child); });
+      current.forEach(walk);
+      current = next;
+    }
+    return current;
+  }
+  querySelectorAll(sel) { return this.find(sel); }
+  querySelector(sel) { return this.find(sel)[0] || null; }
+}
+const document = {
+  createElement: (tag) => new El(tag),
+  getElementById: () => null,
+  querySelector: () => null,
+};
+function t(key) { return key; }
+global.CSS = { escape: (s) => String(s) };
+global.localStorage = { getItem: () => null, setItem: () => {} };
+const renderLog = [];
+function renderQuotaProviderCards(payload, container, ownerServer) {
+  renderLog.push({ kind: 'cards', server: ownerServer ? ownerServer.id : 'local', present: [...quotaPresentProviders(payload)].sort() });
+}
+function renderQuotaCharts(history, targets) {
+  renderLog.push({ kind: 'charts', server: targets.serverId || 'local', present: [...(targets.present || [])].sort() });
+}
+function inputFor(control, provider) {
+  return control.querySelectorAll('.quota-visibility-item input').find((i) => i.dataset.provider === provider);
+}
+"""
+
+QUOTA_VISIBILITY_MULTI_SCENARIO = r"""
+function selectedServers() { return [{ id: 'A' }, { id: 'B' }]; }
+
+const root = new El('body');
+const blocks = new El('div');
+blocks.setAttribute('id', 'quotaServerBlocks');
+root.appendChild(blocks);
+const singleHost = new El('span');
+singleHost.setAttribute('id', 'quotaVisibilityHost');
+root.appendChild(singleHost);
+document.getElementById = (id) => (id === 'quotaVisibilityHost' ? singleHost : null);
+document.querySelector = (sel) => root.find(sel)[0] || null;
+
+const serverA = { id: 'A', label: 'A', payload: { providers: { codex: { detected: true }, claude: { detected: true } } }, history: {} };
+const serverB = { id: 'B', label: 'B', payload: { providers: { codex: { detected: true }, kimi: { detected: true } } }, history: {} };
+lastQuotaServerRows = [
+  { server: serverA, payload: serverA.payload, history: serverA.history },
+  { server: serverB, payload: serverB.payload, history: serverB.history },
+];
+
+function makeBlock(id) {
+  const block = new El('section');
+  block.setAttribute('data-server-id', id);
+  ['cards', 'visibility', 'utilization', 'consumption', 'estimated'].forEach((role) => {
+    const el = new El('div');
+    el.setAttribute('data-role', role);
+    block.appendChild(el);
+  });
+  blocks.appendChild(block);
+  return block;
+}
+const blockA = makeBlock('A');
+const blockB = makeBlock('B');
+const controlA = createQuotaVisibilityControl(quotaPresentProviders(serverA.payload));
+blockA.querySelector('[data-role="visibility"]').appendChild(controlA);
+const controlB = createQuotaVisibilityControl(quotaPresentProviders(serverB.payload));
+blockB.querySelector('[data-role="visibility"]').appendChild(controlB);
+
+// Open A's dropdown and hide Codex there.
+const panelA = controlA.querySelector('.quota-visibility-panel');
+controlA.querySelector('.quota-visibility-btn').dispatch('click');
+const codexA = inputFor(controlA, 'codex');
+codexA.checked = false;
+codexA.dispatch('change');
+
+process.stdout.write(JSON.stringify({
+  labelA: controlA.querySelector('.quota-visibility-label').textContent,
+  labelB: controlB.querySelector('.quota-visibility-label').textContent,
+  codexBChecked: inputFor(controlB, 'codex').checked,
+  kimiBChecked: inputFor(controlB, 'kimi').checked,
+  panelAOpen: !panelA.classList.contains('hidden'),
+  rowKept: inputFor(controlA, 'codex') === codexA,
+  renders: renderLog,
+}));
+"""
+
+QUOTA_VISIBILITY_SINGLE_SCENARIO = r"""
+function selectedServers() { return [{ id: 'local' }]; }
+
+const root = new El('body');
+const singleHost = new El('span');
+singleHost.setAttribute('id', 'quotaVisibilityHost');
+root.appendChild(singleHost);
+document.getElementById = (id) => (id === 'quotaVisibilityHost' ? singleHost : null);
+document.querySelector = (sel) => root.find(sel)[0] || null;
+
+lastQuotaServerRows = [];
+lastQuotaPayload = { providers: { codex: { detected: true }, claude: { detected: true } } };
+lastQuotaHistory = {};
+
+const control = createQuotaVisibilityControl(quotaPresentProviders(lastQuotaPayload));
+singleHost.appendChild(control);
+
+const claude = inputFor(control, 'claude');
+claude.checked = false;
+claude.dispatch('change');
+
+process.stdout.write(JSON.stringify({
+  label: control.querySelector('.quota-visibility-label').textContent,
+  codexChecked: inputFor(control, 'codex').checked,
+  renders: renderLog,
+}));
+"""
+
+
+QUOTA_VISIBILITY_PARTIAL_SCENARIO = r"""
+// Two servers selected, only A responded: multi layout with a single block.
+function selectedServers() { return [{ id: 'A' }, { id: 'B' }]; }
+
+const root = new El('body');
+const blocks = new El('div');
+blocks.setAttribute('id', 'quotaServerBlocks');
+root.appendChild(blocks);
+const singleHost = new El('span');
+singleHost.setAttribute('id', 'quotaVisibilityHost');
+root.appendChild(singleHost);
+document.getElementById = (id) => (id === 'quotaVisibilityHost' ? singleHost : null);
+document.querySelector = (sel) => root.find(sel)[0] || null;
+
+const serverA = { id: 'A', label: 'A', payload: { providers: { codex: { detected: true }, claude: { detected: true } } }, history: {} };
+lastQuotaServerRows = [ { server: serverA, payload: serverA.payload, history: serverA.history } ];
+// Stale single-server cache: if the single path were taken, these would be rendered.
+lastQuotaPayload = { providers: { grok: { detected: true } } };
+lastQuotaHistory = {};
+
+function makeBlock(id) {
+  const block = new El('section');
+  block.setAttribute('data-server-id', id);
+  ['cards', 'visibility', 'utilization', 'consumption', 'estimated'].forEach((role) => {
+    const el = new El('div');
+    el.setAttribute('data-role', role);
+    block.appendChild(el);
+  });
+  blocks.appendChild(block);
+  return block;
+}
+const blockA = makeBlock('A');
+const controlA = createQuotaVisibilityControl(quotaPresentProviders(serverA.payload));
+blockA.querySelector('[data-role="visibility"]').appendChild(controlA);
+
+const panelA = controlA.querySelector('.quota-visibility-panel');
+controlA.querySelector('.quota-visibility-btn').dispatch('click');
+const codexA = inputFor(controlA, 'codex');
+codexA.checked = false;
+codexA.dispatch('change');
+
+process.stdout.write(JSON.stringify({
+  labelA: controlA.querySelector('.quota-visibility-label').textContent,
+  singleHostChildren: singleHost.children.length,
+  renders: renderLog,
+}));
+"""
+
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_quota_visibility_toggle_on_partial_multi_load_updates_the_block(tmp_path):
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    body = QUOTA_VISIBILITY_DOM_STUBS + "\n" + _quota_visibility_dom_functions(source) + "\n" + QUOTA_VISIBILITY_PARTIAL_SCENARIO
+    out = _run_quota_dom(tmp_path, "quota-visibility-partial", body)
+    # One of two selected servers responded: the toggle must update the rendered
+    # server block (multi layout), not the hidden single-server UI.
+    assert out["labelA"] == "quotaVisibilityPrefix Claude Code"
+    assert out["singleHostChildren"] == 0
+    assert out["renders"] == [
+        {"kind": "cards", "server": "A", "present": ["claude", "codex"]},
+        {"kind": "charts", "server": "A", "present": ["claude", "codex"]},
+    ]
+
+
+def _quota_visibility_dom_functions(source: str) -> str:
+    return "\n".join(
+        [
+            "const QUOTA_PROVIDERS = ['codex', 'claude', 'antigravity', 'minimax', 'kimi', 'grok', 'zai'];",
+            "const QUOTA_VISIBILITY_KEY = 'tokdash-quota-visible';",
+            "let quotaVisibilityState = null;",
+            "let lastQuotaServerRows = [];",
+            "let lastQuotaPayload = null;",
+            "let lastQuotaHistory = null;",
+            _extract_js_function(source, "function quotaPresentProviders(payload) {"),
+            _extract_js_function(source, "function loadQuotaVisibility() {"),
+            _extract_js_function(source, "function persistQuotaVisibility() {"),
+            _extract_js_function(source, "function quotaProviderLabel(provider) {"),
+            _extract_js_function(source, "function quotaVisibilityLabelText(present) {"),
+            _extract_js_function(source, "function buildQuotaVisibilityRow(provider) {"),
+            _extract_js_function(source, "function createQuotaVisibilityControl(present) {"),
+            _extract_js_function(source, "function syncQuotaVisibilityControlInPlace(control, present) {"),
+            _extract_js_function(source, "function refreshQuotaServerScope(server) {"),
+            _extract_js_function(source, "function refreshQuotaSingleScope() {"),
+            _extract_js_function(source, "function applyQuotaVisibilityChange() {"),
+        ]
+    )
+
+
+def _run_quota_dom(tmp_path: Path, name: str, body: str) -> dict:
+    harness = tmp_path / f"{name}.js"
+    harness.write_text(body, encoding="utf-8")
+    result = subprocess.run(["node", str(harness)], check=True, capture_output=True, encoding="utf-8")
+    return json.loads(result.stdout)
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_quota_visibility_toggle_propagates_to_all_server_blocks(tmp_path):
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    body = QUOTA_VISIBILITY_DOM_STUBS + "\n" + _quota_visibility_dom_functions(source) + "\n" + QUOTA_VISIBILITY_MULTI_SCENARIO
+    out = _run_quota_dom(tmp_path, "quota-visibility-multi", body)
+    # Hiding Codex in A's dropdown re-renders BOTH blocks and updates BOTH dropdowns.
+    assert out["labelA"] == "quotaVisibilityPrefix Claude Code"
+    assert out["labelB"] == "quotaVisibilityPrefix Kimi Code"
+    assert out["codexBChecked"] is False
+    assert out["kimiBChecked"] is True
+    # The label follows the toggle in place and the open panel is not rebuilt.
+    assert out["panelAOpen"] is True
+    assert out["rowKept"] is True
+    assert out["renders"] == [
+        {"kind": "cards", "server": "A", "present": ["claude", "codex"]},
+        {"kind": "charts", "server": "A", "present": ["claude", "codex"]},
+        {"kind": "cards", "server": "B", "present": ["codex", "kimi"]},
+        {"kind": "charts", "server": "B", "present": ["codex", "kimi"]},
+    ]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_quota_visibility_toggle_updates_single_server_scope(tmp_path):
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    body = QUOTA_VISIBILITY_DOM_STUBS + "\n" + _quota_visibility_dom_functions(source) + "\n" + QUOTA_VISIBILITY_SINGLE_SCENARIO
+    out = _run_quota_dom(tmp_path, "quota-visibility-single", body)
+    assert out["label"] == "quotaVisibilityPrefix Codex"
+    assert out["codexChecked"] is True
+    assert out["renders"] == [
+        {"kind": "cards", "server": "local", "present": ["claude", "codex"]},
+        {"kind": "charts", "server": "local", "present": ["claude", "codex"]},
+    ]

--- a/tests/test_usage_db_schema_frontend.py
+++ b/tests/test_usage_db_schema_frontend.py
@@ -275,6 +275,8 @@ function renderQuotaServerBlock(server) { rendered.push(server.id); }
 function renderQuotaSettings() {}
 function renderQuotaProviderCards() {}
 function renderQuotaCharts() {}
+function syncQuotaSingleVisibility() {}
+function quotaPresentProviders() { return new Set(); }
 function makeError(spec) {
   const error = new Error(spec.message);
   if (spec.status !== undefined && spec.status !== null) error.status = spec.status;
@@ -523,6 +525,8 @@ function renderQuotaServerBlock() {}
 function renderQuotaSettings() {}
 function renderQuotaProviderCards() {}
 function renderQuotaCharts() {}
+function syncQuotaSingleVisibility() {}
+function quotaPresentProviders() { return new Set(); }
 async function postJsonWithCsrf() { postCalls += 1; return { ok: true }; }
 async function fetchJsonWithRetry() {
   if (scenario.reloadFails) {


### PR DESCRIPTION
## Summary
- scope the quota provider visibility menu to each server's reported harnesses
- keep the shared visibility preference synchronized across all rendered server blocks
- handle partial multi-server loads and preserve open-menu state while toggling
- bump the package and dashboard release metadata to v2.4.1

## Verification
- 76 targeted frontend, pricing-contract, normalization, and release-notes tests passed
- 1579 passed, 4 skipped in the broader suite with the two known offline distribution-build tests excluded
- git diff --check