### PR TITLE
Release v2.4.2

### DIFF
--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+## 2.4.2 - 2026-08-30
+
+### Fixed
+
+- A past date range is no longer answered from a snapshot taken while that range was still running. The dashboard sends every quick range as an explicit `date_from`/`date_to` pair, so viewing Today on one day and clicking Yesterday on the next built the same response-cache key, and the cache serves a stale entry with no upper bound on its age: the partial mid-day figures came back until the Refresh button forced a recompute. Response-cache keys for a window that can still gain usage now carry the local day they were computed on, so a key without that stamp can only have been filled after its window closed. Yesterday, Last week, Last month, Last year and any custom picker range that repeats an earlier open pair are recomputed once and then cached for good, and the same rule covers `/api/sessions`, `/api/active-time`, `/api/openclaw`, `/api/tools`, `/api/stats` (a past year now caches indefinitely) and `/api/activity-insights`. Today and other ranges that include the current day keep the existing TTL, background revalidation and Refresh behaviour.
+
 ## 2.4.1 - 2026-08-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tokdash"
-version = "2.4.1"
+version = "2.4.2"
 description = "Local token & cost dashboard for AI coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tokdash/__init__.py
+++ b/src/tokdash/__init__.py
@@ -1,3 +1,3 @@
 """Tokdash package."""
 
-__version__ = "2.4.1"
+__version__ = "2.4.2"

--- a/src/tokdash/api.py
+++ b/src/tokdash/api.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -218,6 +218,60 @@ class TailnetCORSMiddleware(CORSMiddleware):
         )
 
 
+def _local_today() -> date:
+    """Today in the machine's local timezone, matching the dashboard's date picker.
+
+    The single clock for both halves of the window rule, so the stamp a key carries and
+    the open/closed test that decides whether to stamp it can never disagree.
+    """
+    return datetime.now().astimezone().date()
+
+
+def _usage_window_is_open(date_from: Optional[str], date_to: Optional[str]) -> bool:
+    """True while the requested window can still gain usage.
+
+    A period-only query ("today", "7", ...) is resolved against the clock on every
+    compute, so it is always open. An explicit range stays open until its last day has
+    passed. An unparseable date counts as open, so a bad value can only cost a
+    recompute and never serves incomplete data.
+
+    The comparison is on parsed dates, not on the strings: ``strptime`` accepts an
+    unpadded ``2026-9-1``, which sorts after ``2026-10-01`` lexically and would keep a
+    long-closed window recomputing every day.
+    """
+    if not date_to:
+        return True
+    try:
+        end = datetime.strptime(date_to, "%Y-%m-%d").date()
+    except (TypeError, ValueError):
+        return True
+    return end >= _local_today()
+
+
+def _day_scoped_key(base: str) -> str:
+    """Pin a key to the local day it was computed on."""
+    return f"{base}_asof_{_local_today().isoformat()}"
+
+
+def _window_cache_key(base: str, date_from: Optional[str], date_to: Optional[str]) -> str:
+    """Pricing-aware cache key that also pins an OPEN window to its capture day.
+
+    A day's usage is only complete once the day is over, and the response cache serves a
+    stale entry with no upper bound on its age. The dashboard requests every quick range
+    as an explicit date_from/date_to pair, so viewing "Today" on day D and clicking
+    "Yesterday" on day D+1 build the same key: without this scope the second request is
+    answered from the partial mid-day snapshot the first one left behind, and only the
+    Refresh button (force_refresh) recomputes it.
+
+    Stamping the capture day into open-window keys means a key WITHOUT the stamp can only
+    have been filled after its window closed. Past ranges are therefore always complete,
+    and stay cacheable indefinitely because their inputs no longer change.
+    """
+    if _usage_window_is_open(date_from, date_to):
+        base = _day_scoped_key(base)
+    return _pricing_cache_key(base)
+
+
 def _session_response_cache_key(
     tool: str,
     period: str,
@@ -225,8 +279,10 @@ def _session_response_cache_key(
     date_to: Optional[str],
     include_review_sessions: Optional[bool],
 ) -> str:
-    return _pricing_cache_key(
-        f"sessions_{tool.strip().lower()}_{period}_{date_from}_{date_to}_{include_review_sessions}"
+    return _window_cache_key(
+        f"sessions_{tool.strip().lower()}_{period}_{date_from}_{date_to}_{include_review_sessions}",
+        date_from,
+        date_to,
     )
 
 
@@ -236,8 +292,10 @@ def _active_time_cache_key(
     date_to: Optional[str],
     include_review_sessions: Optional[bool],
 ) -> str:
-    return _pricing_cache_key(
-        f"active_time_{period}_{date_from}_{date_to}_{include_review_sessions}"
+    return _window_cache_key(
+        f"active_time_{period}_{date_from}_{date_to}_{include_review_sessions}",
+        date_from,
+        date_to,
     )
 
 
@@ -259,10 +317,10 @@ def _warm_caches() -> None:
     today = datetime.now().astimezone().strftime("%Y-%m-%d")
     warmers = [
         (
-            _pricing_cache_key(f"usage_today_{today}_{today}"),
+            _window_cache_key(f"usage_today_{today}_{today}", today, today),
             lambda: compute_usage_with_comparison("today", today, today),
         ),
-        (_pricing_cache_key("stats_None"), lambda: compute_stats(None)),
+        (_window_cache_key("stats_None", None, None), lambda: compute_stats(None)),
     ]
     # Mirror the dashboard exactly: its default date picker sends an explicit
     # date_from/date_to pair, not period=today. Keeping this key construction shared
@@ -282,7 +340,7 @@ def _warm_caches() -> None:
             lambda: get_active_time_data("today", today, today, include_review_sessions=None),
         )
     )
-    warmers.append((ACTIVITY_INSIGHTS_CACHE_KEY, get_codex_activity_insights))
+    warmers.append((_day_scoped_key(ACTIVITY_INSIGHTS_CACHE_KEY), get_codex_activity_insights))
     for key, fetch in warmers:
         warm_event = _begin_startup_warm(key)
         try:
@@ -1050,7 +1108,7 @@ def get_usage(
 ) -> Dict[str, Any]:
     _validate_date_params(date_from, date_to)
     try:
-        cache_key = _pricing_cache_key(f"usage_{period}_{date_from}_{date_to}")
+        cache_key = _window_cache_key(f"usage_{period}_{date_from}_{date_to}", date_from, date_to)
         return _cached_route(
             "/api/usage",
             cache_key,
@@ -1078,7 +1136,7 @@ def get_openclaw(period: str = "today") -> Dict[str, Any]:
         return data
 
     try:
-        return _cached_route("/api/openclaw", _pricing_cache_key(f"openclaw_{period}"), fetch)
+        return _cached_route("/api/openclaw", _window_cache_key(f"openclaw_{period}", None, None), fetch)
     except UsageDatabaseSchemaTooNewError as e:
         # 500, not 503: 503 is the dashboard retry signal, and a database
         # written by a newer build never becomes readable on retry. Fail fast
@@ -1101,7 +1159,7 @@ def get_tools(period: str = "today") -> Dict[str, Any]:
             data["timestamp"] = datetime.now().isoformat()
             return data
 
-        return _cached_route("/api/tools", _pricing_cache_key(f"tools_{period}"), fetch)
+        return _cached_route("/api/tools", _window_cache_key(f"tools_{period}", None, None), fetch)
     except UsageDatabaseSchemaTooNewError as e:
         # 500, not 503: 503 is the dashboard retry signal, and a database
         # written by a newer build never becomes readable on retry. Fail fast
@@ -1280,7 +1338,9 @@ def refresh_quota() -> Dict[str, Any]:
 @app.get("/api/codex/sessions")
 def get_codex_sessions(period: str = "today", include_review_sessions: Optional[bool] = None) -> Dict[str, Any]:
     try:
-        cache_key = _pricing_cache_key(f"codex_sessions_{period}_{include_review_sessions}")
+        cache_key = _window_cache_key(
+            f"codex_sessions_{period}_{include_review_sessions}", None, None
+        )
         return _cached_route(
             "/api/codex/sessions",
             cache_key,
@@ -1472,7 +1532,10 @@ async def serve_service_worker(request: Request):
 @app.get("/api/stats")
 def get_stats(year: Optional[int] = None) -> Dict[str, Any]:
     try:
-        return _cached_route("/api/stats", _pricing_cache_key(f"stats_{year}"), lambda: compute_stats(year))
+        cache_key = _window_cache_key(
+            f"stats_{year}", None, f"{year}-12-31" if year else None
+        )
+        return _cached_route("/api/stats", cache_key, lambda: compute_stats(year))
     except UsageDatabaseSchemaTooNewError as e:
         # 500, not 503: 503 is the dashboard retry signal, and a database
         # written by a newer build never becomes readable on retry. Fail fast
@@ -1489,7 +1552,7 @@ def get_activity_insights(refresh: bool = False) -> dict[str, Any]:
     try:
         return _cached_route(
             "/api/activity-insights",
-            ACTIVITY_INSIGHTS_CACHE_KEY,
+            _day_scoped_key(ACTIVITY_INSIGHTS_CACHE_KEY),
             get_codex_activity_insights,
             force_refresh=refresh,
         )

--- a/src/tokdash/static/release-notes.json
+++ b/src/tokdash/static/release-notes.json
@@ -1,6 +1,18 @@
 {
-  "current": "2.4.1",
+  "current": "2.4.2",
   "releases": [
+    {
+      "version": "2.4.2",
+      "date": "2026-08-30",
+      "sections": [
+        {
+          "type": "fixed",
+          "items": [
+            "Yesterday and other past date ranges now recompute once the range has ended, instead of showing the partial figures cached while it was still in progress. Previously only the Refresh button corrected them."
+          ]
+        }
+      ]
+    },
     {
       "version": "2.4.1",
       "date": "2026-08-28",

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -350,7 +350,9 @@ def test_activity_insights_uses_own_versioned_cache_key(monkeypatch):
     assert api.get_activity_insights() is expected
     assert captured == {
         "route_name": "/api/activity-insights",
-        "cache_key": "activity_insights_v1",
+        # Day-scoped: the insights window always includes today, so a snapshot
+        # taken yesterday must not answer today's request.
+        "cache_key": api._day_scoped_key("activity_insights_v1"),
         "fetch_fn": fake_activity,
         "force_refresh": False,
     }
@@ -376,7 +378,9 @@ def test_activity_insights_refresh_forces_recompute(monkeypatch):
     assert api.get_activity_insights(refresh=True) is expected
     assert captured == {
         "route_name": "/api/activity-insights",
-        "cache_key": "activity_insights_v1",
+        # Day-scoped: the insights window always includes today, so a snapshot
+        # taken yesterday must not answer today's request.
+        "cache_key": api._day_scoped_key("activity_insights_v1"),
         "fetch_fn": fake_activity,
         "force_refresh": True,
     }

--- a/tests/test_closed_window_cache_freshness.py
+++ b/tests/test_closed_window_cache_freshness.py
@@ -1,0 +1,228 @@
+"""A past date range is never answered from a snapshot taken while it was still open.
+
+The dashboard sends every quick range as an explicit ``date_from``/``date_to`` pair and
+never sends ``period``, so viewing "Today" on day D and clicking "Yesterday" on day D+1
+used to build the identical response-cache key. The response cache serves a stale entry
+with no upper bound on its age, so the second request was answered from the partial
+mid-day snapshot the first one left behind, and only the Refresh button recomputed it.
+Open windows are now pinned to the local day they were computed on, so a key without
+that stamp can only have been filled after its window closed.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+import tokdash.api as api
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache(monkeypatch):
+    monkeypatch.setenv("TOKDASH_WARM_ON_START", "0")
+    api._clear_cache()
+    yield
+    api._clear_cache()
+
+
+def _days_ago(days: int) -> str:
+    return _date_days_ago(days).isoformat()
+
+
+def _date_days_ago(days: int):
+    return (datetime.now().astimezone() - timedelta(days=days)).date()
+
+
+def _freeze_today(monkeypatch, days_ago: int) -> None:
+    """Pin the module's one clock, which both the stamp and the open/closed test read."""
+    frozen = _date_days_ago(days_ago)
+    monkeypatch.setattr(api, "_local_today", lambda: frozen)
+
+
+def _client() -> TestClient:
+    return TestClient(api.app)
+
+
+def test_a_day_viewed_as_today_is_recomputed_when_it_becomes_yesterday(monkeypatch):
+    day = _days_ago(1)
+    computed: list[str] = []
+
+    def fake_usage(period, date_from, date_to):
+        computed.append(date_to)
+        return {"total_tokens": len(computed), "marker": f"compute-{len(computed)}"}
+
+    monkeypatch.setattr(api, "compute_usage_with_comparison", fake_usage)
+
+    # Day D, mid-afternoon: the dashboard's default view caches a partial day.
+    _freeze_today(monkeypatch, 1)
+    with _client() as client:
+        first = client.get(f"/api/usage?date_from={day}&date_to={day}").json()
+    assert first["marker"] == "compute-1"
+
+    # Day D+1: the Yesterday button asks for the same pair. D is closed now, so the
+    # partial snapshot must not be reused.
+    _freeze_today(monkeypatch, 0)
+    with _client() as client:
+        second = client.get(f"/api/usage?date_from={day}&date_to={day}").json()
+    assert second["marker"] == "compute-2"
+    assert second["response_cache"]["served_from_cache"] is False
+
+
+def test_a_closed_range_is_cached_after_it_closes(monkeypatch):
+    day = _days_ago(3)
+    calls: list[tuple] = []
+
+    def fake_usage(period, date_from, date_to):
+        calls.append((date_from, date_to))
+        return {"total_tokens": 7}
+
+    monkeypatch.setattr(api, "compute_usage_with_comparison", fake_usage)
+
+    with _client() as client:
+        client.get(f"/api/usage?date_from={day}&date_to={day}")
+        again = client.get(f"/api/usage?date_from={day}&date_to={day}").json()
+
+    assert len(calls) == 1, "a settled past range should still be served from cache"
+    assert again["response_cache"]["served_from_cache"] is True
+
+
+def test_todays_range_still_serves_and_revalidates_within_the_day(monkeypatch):
+    today = _days_ago(0)
+    calls: list[tuple] = []
+
+    def fake_usage(period, date_from, date_to):
+        calls.append((date_from, date_to))
+        return {"total_tokens": 1}
+
+    monkeypatch.setattr(api, "compute_usage_with_comparison", fake_usage)
+
+    with _client() as client:
+        client.get(f"/api/usage?date_from={today}&date_to={today}")
+        second = client.get(f"/api/usage?date_from={today}&date_to={today}").json()
+
+    assert len(calls) == 1
+    assert second["response_cache"]["served_from_cache"] is True
+
+
+def test_sessions_and_active_time_keys_follow_the_same_rule(monkeypatch):
+    day = _days_ago(1)
+    _freeze_today(monkeypatch, 1)
+    open_session = api._session_response_cache_key("codex", "today", day, day, None)
+    open_active = api._active_time_cache_key("today", day, day, None)
+
+    _freeze_today(monkeypatch, 0)
+    closed_session = api._session_response_cache_key("codex", "today", day, day, None)
+    closed_active = api._active_time_cache_key("today", day, day, None)
+
+    assert open_session != closed_session
+    assert open_active != closed_active
+
+
+def test_a_window_ending_today_or_later_is_open():
+    assert api._usage_window_is_open(_days_ago(6), _days_ago(0))
+    assert api._usage_window_is_open(_days_ago(0), _days_ago(-5))
+    assert api._usage_window_is_open(None, None), "a period-only query tracks the clock"
+    assert not api._usage_window_is_open(_days_ago(7), _days_ago(1))
+
+
+def test_a_malformed_end_date_is_treated_as_open():
+    """An unparseable date may only cost a recompute, never serve a partial window."""
+    assert api._usage_window_is_open("2026-01-01", "not-a-date")
+
+
+def test_a_past_year_of_stats_is_cached_but_the_current_year_is_day_scoped(monkeypatch):
+    calls: list = []
+
+    def fake_stats(year):
+        calls.append(year)
+        return {"total_tokens": 0, "year": year}
+
+    monkeypatch.setattr(api, "compute_stats", fake_stats)
+    last_year = datetime.now().astimezone().year - 1
+
+    with _client() as client:
+        client.get(f"/api/stats?year={last_year}")
+        client.get(f"/api/stats?year={last_year}")
+    assert calls == [last_year]
+
+    _freeze_today(monkeypatch, 1)
+    with _client() as client:
+        client.get("/api/stats")
+    _freeze_today(monkeypatch, 0)
+    with _client() as client:
+        client.get("/api/stats")
+    assert calls == [last_year, None, None], "the rolling window must recompute the next day"
+
+
+def test_an_unpadded_past_date_is_closed(monkeypatch):
+    """``strptime`` accepts an unpadded ``2026-9-1``, which sorts AFTER ``2026-10-30``
+    as a string. Comparing the raw strings would call a settled September window open
+    all through October, recomputing it on every request."""
+    monkeypatch.setattr(api, "_local_today", lambda: date(2026, 10, 30))
+    assert not api._usage_window_is_open("2026-9-1", "2026-9-1")
+    assert not api._usage_window_is_open("2026-09-01", "2026-09-01")
+    # A padded date on the same day still reads as open, so the padding is all that changed.
+    assert api._usage_window_is_open("2026-10-30", "2026-11-2")
+
+
+# The dashboard's quick ranges all resolve to a date pair, and several of them produce a
+# pair that was ALREADY requested on an earlier day while its last day was still running:
+# "Last week" repeats the span a "Last 7 days" view covered, "Last month" repeats the
+# "This month" pair as viewed on the final day of that month, "Last year" repeats
+# "This year" as viewed on 31 December, and the custom picker can re-select any of them.
+# Each is the same defect as the Yesterday button, so each must recompute once closed.
+@pytest.mark.parametrize(
+    "label, viewed_days_ago, start_days_ago",
+    [
+        ("yesterday after today", 1, 1),
+        ("last week after last 7 days", 1, 7),
+        ("two weeks", 2, 15),
+        ("last month after this month", 2, 32),
+        ("last year after this year", 3, 370),
+    ],
+)
+def test_a_range_viewed_on_its_final_day_is_recomputed_once_closed(
+    monkeypatch, label, viewed_days_ago, start_days_ago
+):
+    date_from = _days_ago(start_days_ago)
+    date_to = _days_ago(viewed_days_ago)
+    computed: list[str] = []
+
+    def fake_usage(period, df, dt):
+        computed.append(f"compute-{len(computed) + 1}")
+        return {"marker": computed[-1]}
+
+    monkeypatch.setattr(api, "compute_usage_with_comparison", fake_usage)
+
+    # Viewed while the last day of the range was still accruing usage.
+    _freeze_today(monkeypatch, viewed_days_ago)
+    with _client() as client:
+        first = client.get(f"/api/usage?date_from={date_from}&date_to={date_to}").json()
+    assert first["marker"] == "compute-1", label
+
+    # The same pair requested after the range closed must not reuse that partial view.
+    _freeze_today(monkeypatch, 0)
+    with _client() as client:
+        second = client.get(f"/api/usage?date_from={date_from}&date_to={date_to}").json()
+    assert second["marker"] == "compute-2", label
+    assert second["response_cache"]["served_from_cache"] is False, label
+
+
+def test_a_rolling_range_keeps_its_own_key_per_day(monkeypatch):
+    """"Last 7 days" covers a different pair each day, so the two must not share a key."""
+    today_pair = (_days_ago(6), _days_ago(0))
+    yesterday_pair = (_days_ago(7), _days_ago(1))
+    assert api._window_cache_key("usage_today", *today_pair) != api._window_cache_key(
+        "usage_today", *yesterday_pair
+    )
+
+
+def test_a_multi_day_range_ending_today_is_open(monkeypatch):
+    _freeze_today(monkeypatch, 0)
+    assert api._usage_window_is_open(_days_ago(27), _days_ago(0))
+    assert api._usage_window_is_open(_days_ago(364), _days_ago(0))
+    assert not api._usage_window_is_open(_days_ago(27), _days_ago(1))

--- a/tests/test_pricing_db_editor_api.py
+++ b/tests/test_pricing_db_editor_api.py
@@ -203,8 +203,10 @@ def test_startup_warmer_populates_initial_overview_date_range(monkeypatch):
         period, date_from, date_to = date_range_calls[0]
         assert period == "today"
         assert date_from == date_to
-        assert api._pricing_cache_key(f"usage_today_{date_from}_{date_to}") in api._cache
-        assert api._pricing_cache_key("stats_None") in api._cache
+        # Both windows include today, so the warmer must stamp them with the current
+        # day exactly as the routes do, or it warms keys no request ever reads.
+        assert api._window_cache_key(f"usage_today_{date_from}_{date_to}", date_from, date_to) in api._cache
+        assert api._window_cache_key("stats_None", None, None) in api._cache
         assert stats_calls == [None]
         assert session_calls == [
             (tool, "today", date_from, date_to, None) for tool in api.SESSION_TOOLS
@@ -215,7 +217,7 @@ def test_startup_warmer_populates_initial_overview_date_range(monkeypatch):
             ) in api._cache
         assert active_time_calls == [("today", date_from, date_to, None)]
         assert activity_calls == [1]
-        assert api.ACTIVITY_INSIGHTS_CACHE_KEY in api._cache
+        assert api._day_scoped_key(api.ACTIVITY_INSIGHTS_CACHE_KEY) in api._cache
     finally:
         api._clear_cache()
 


### PR DESCRIPTION
## Problem

Clicking **Yesterday** showed figures frozen at whatever they were part-way through yesterday. Only the Refresh button corrected them.

The dashboard sends every quick range as an explicit `date_from`/`date_to` pair and never sends `period`, so the route's `period` default of `"today"` means viewing **Today** on day D and clicking **Yesterday** on day D+1 build the *identical* response-cache key. The response cache is stale-while-revalidate with **no upper bound on entry age**, so in a long-lived server process the second request was answered from the ~20h-old partial-day entry the first one left behind, with a background refresh landing too late to be seen. `refresh=1` bypasses the cache, which is why the button was the only fix.

Reproduced as a failing test first: the entry came back with `response_cache: {status: "stale", age_seconds: 72000}`.

## Fix

Cache keys for an **open** window — one that can still gain usage — now carry the local day they were computed on. A key *without* that stamp can therefore only have been filled after its window closed, so a past range is complete by construction, recomputed once and then cached indefinitely.

The rule keys on the window's **end date**, not on the button that produced it, so it covers every range that repeats a pair first requested while it was still open:

| Closed range | Repeats the pair from |
|---|---|
| Yesterday | Today, viewed the day before |
| Last week | Last 7 days, viewed on that week's final day |
| Last month | This month, viewed on the last day of that month |
| Last year | This year, viewed on 31 December |
| Any custom picker range | the same span selected earlier while open |

Applied across `/api/usage`, `/api/sessions`, `/api/active-time`, `/api/openclaw`, `/api/tools`, `/api/codex/sessions`, `/api/stats` (a past year now caches indefinitely; the current year and rolling 365-day view are day-scoped) and `/api/activity-insights`. The startup warmer builds its keys through the same helper, so it cannot drift from the routes and warm keys nothing reads.

Open/closed is decided on **parsed dates**, not raw strings: `strptime` accepts an unpadded `2026-9-1`, which sorts after `2026-10-01` lexically and would otherwise keep a long-closed window recomputing every day.

## Behaviour deliberately unchanged

Today and other ranges including the current day keep the existing TTL, background revalidation and Refresh behaviour — staleness there is now bounded at one day instead of unbounded. The stampede protection from #42 is untouched. The one cost: the first request for an open-window key after local midnight computes in the foreground instead of serving a day-old value; the frontend already retries `503`s and shows a loading state.

## Tests

- New `tests/test_closed_window_cache_freshness.py` (15 tests) — simulates the day rollover through a single patchable clock, parametrized over the range pairs in the table above, plus rolling-range key separation, the unpadded-date regression, and the stats year cases.
- Updated `tests/test_api_smoke.py` and `tests/test_pricing_db_editor_api.py` for the new key shapes.
- Full suite in one process (as CI runs it): **1597 passed, 4 skipped**, exit 0. `compileall` clean.