### PR TITLE
Release v2.4.3

### DIFF
--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -10,68 +10,68 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- Hermes named profiles are now scanned by default. Each profile keeps its own session database at `~/.hermes/profiles/<name>/state.db`, which Tokdash previously ignored, so Overview and Session Explorer silently missed that usage unless every profile was listed by hand in `HERMES_HOME`. Profiles are enumerated under each Hermes home, including homes given via `HERMES_HOME`, and a dir listed twice is scanned once.
-- Yesterday's figures are warmed shortly after the local date rolls over (00:05 by default, `TOKDASH_DAILY_WARM_MINUTE`; disable with `TOKDASH_DAILY_WARM=0`). Every key for a window that can still gain usage goes cold at midnight, and the day that just closed is the one the Yesterday button asks for all day. Its numbers are final, so it is computed once and served from cache from then on. Today is deliberately not warmed at that hour: it holds almost nothing yet, and warming it would put a near-empty snapshot in front of the morning's first request.
+- Hermes named profiles are now scanned by default. Each profile keeps its own session database at `~/.hermes/profiles/<name>/state.db`, which Tokdash previously ignored, so Overview and Session Explorer silently missed that usage unless every profile was listed by hand in `HERMES_HOME`. Profiles are enumerated under each Hermes home, including homes given via `HERMES_HOME`, and a dir listed twice is scanned once. (#54)
+- Yesterday's figures are warmed shortly after the local date rolls over (00:05 by default, `TOKDASH_DAILY_WARM_MINUTE`; disable with `TOKDASH_DAILY_WARM=0`). Every key for a window that can still gain usage goes cold at midnight, and the day that just closed is the one the Yesterday button asks for all day. Its numbers are final, so it is computed once and served from cache from then on. Today is deliberately not warmed at that hour: it holds almost nothing yet, and warming it would put a near-empty snapshot in front of the morning's first request. (#55)
 
 ### Changed
 
-- The heavy-compute cap now scales with the CPUs the process may actually use, from the previous fixed 2 up to 8. It reads the scheduler affinity mask and any cgroup CPU quota — including a quota on the process's own sub-cgroup, which is where a systemd unit's `CPUQuota=` lives — rather than the host's core count, so a large machine drains a cold fan-out quickly while a small VPS, Raspberry Pi or CPU-limited container keeps the old ceiling. Running and waiting requests share one thread budget (`TOKDASH_COMPUTE_THREAD_BUDGET`, default 32), so raising `TOKDASH_COMPUTE_CONCURRENCY` spends the waiter allowance instead of pushing the total past the worker pool and starving `/health` and cache hits.
+- The heavy-compute cap now scales with the CPUs the process may actually use, from the previous fixed 2 up to 8. It reads the scheduler affinity mask and any cgroup CPU quota — including a quota on the process's own sub-cgroup, which is where a systemd unit's `CPUQuota=` lives — rather than the host's core count, so a large machine drains a cold fan-out quickly while a small VPS, Raspberry Pi or CPU-limited container keeps the old ceiling. Running and waiting requests share one thread budget (`TOKDASH_COMPUTE_THREAD_BUDGET`, default 32), so raising `TOKDASH_COMPUTE_CONCURRENCY` spends the waiter allowance instead of pushing the total past the worker pool and starving `/health` and cache hits. (#55)
 
 ### Fixed
 
-- Switching to a date range nothing has computed no longer fails most of the Sessions tab. That tab issues one request per tool, so a cold range asks for ~17 distinct keys at once, and a request that could not get a heavy-compute slot was refused outright instead of queued: measured against a running server, 13 of 15 tools took an instant `503` while the slot each needed freed about a second later, and the dashboard retries only three times before a panel gives up. A cold request with nothing to show now waits briefly for a slot (`TOKDASH_COMPUTE_WAIT_SECONDS`, default 15 seconds, capped at 120), bounded by a waiter allowance so a burst cannot park the whole worker pool. A stale value or a background refresh still answers immediately and never waits, and the cap on concurrent computes is unchanged. The same fan-out that lost 13 panels now completes in about 3.7 seconds.
+- Switching to a date range nothing has computed no longer fails most of the Sessions tab. That tab issues one request per tool, so a cold range asks for ~17 distinct keys at once, and a request that could not get a heavy-compute slot was refused outright instead of queued: measured against a running server, 13 of 15 tools took an instant `503` while the slot each needed freed about a second later, and the dashboard retries only three times before a panel gives up. A cold request with nothing to show now waits briefly for a slot (`TOKDASH_COMPUTE_WAIT_SECONDS`, default 15 seconds, capped at 120), bounded by a waiter allowance so a burst cannot park the whole worker pool. A stale value or a background refresh still answers immediately and never waits, and the cap on concurrent computes is unchanged. The same fan-out that lost 13 panels now completes in about 3.7 seconds. (#55)
 
 ## 2.4.2 - 2026-08-30
 
 ### Fixed
 
-- A past date range is no longer answered from a snapshot taken while that range was still running. The dashboard sends every quick range as an explicit `date_from`/`date_to` pair, so viewing Today on one day and clicking Yesterday on the next built the same response-cache key, and the cache serves a stale entry with no upper bound on its age: the partial mid-day figures came back until the Refresh button forced a recompute. Response-cache keys for a window that can still gain usage now carry the local day they were computed on, so a key without that stamp can only have been filled after its window closed. Yesterday, Last week, Last month, Last year and any custom picker range that repeats an earlier open pair are recomputed once and then cached for good, and the same rule covers `/api/sessions`, `/api/active-time`, `/api/openclaw`, `/api/tools`, `/api/stats` (a past year now caches indefinitely) and `/api/activity-insights`. Today and other ranges that include the current day keep the existing TTL, background revalidation and Refresh behaviour.
+- A past date range is no longer answered from a snapshot taken while that range was still running. The dashboard sends every quick range as an explicit `date_from`/`date_to` pair, so viewing Today on one day and clicking Yesterday on the next built the same response-cache key, and the cache serves a stale entry with no upper bound on its age: the partial mid-day figures came back until the Refresh button forced a recompute. Response-cache keys for a window that can still gain usage now carry the local day they were computed on, so a key without that stamp can only have been filled after its window closed. Yesterday, Last week, Last month, Last year and any custom picker range that repeats an earlier open pair are recomputed once and then cached for good, and the same rule covers `/api/sessions`, `/api/active-time`, `/api/openclaw`, `/api/tools`, `/api/stats` (a past year now caches indefinitely) and `/api/activity-insights`. Today and other ranges that include the current day keep the existing TTL, background revalidation and Refresh behaviour. (#52)
 
 ## 2.4.1 - 2026-08-28
 
 ### Fixed
 
-- Quota provider visibility controls are now scoped to each server's reported harnesses in multi-server mode. The shared show/hide preference updates every rendered server block, including partial loads where only one of several selected servers responds.
+- Quota provider visibility controls are now scoped to each server's reported harnesses in multi-server mode. The shared show/hide preference updates every rendered server block, including partial loads where only one of several selected servers responds. (#51)
 
 ## 2.4.0 - 2026-08-28
 
 ### Added
 
-- Added Japanese, Korean, Spanish, and Portuguese dashboard languages alongside English and Simplified Chinese. The System option follows the browser language, dates and numbers use the selected locale, and each language has a linked README.
-- Added opt-in Z.ai Coding Plan quota tracking. Tokdash discovers Coding Plan keys from ZCode, supported OpenCode/Claude-compatible provider configs, or `ZAI_API_KEY` / `Z_AI_API_KEY`, then reads the provider's 5-hour and weekly credit windows plus legacy MCP limits from Z.ai's quota endpoint without refreshing or writing credentials.
-- Updated the bundled pricing database to 2.0.20, adding 14 model entries across Z.ai, DeepSeek, Qwen, ByteDance, Tencent, Mistral, Meta, and NVIDIA.
+- Added Japanese, Korean, Spanish, and Portuguese dashboard languages alongside English and Simplified Chinese. The System option follows the browser language, dates and numbers use the selected locale, and each language has a linked README. (#49)
+- Added opt-in Z.ai Coding Plan quota tracking. Tokdash discovers Coding Plan keys from ZCode, supported OpenCode/Claude-compatible provider configs, or `ZAI_API_KEY` / `Z_AI_API_KEY`, then reads the provider's 5-hour and weekly credit windows plus legacy MCP limits from Z.ai's quota endpoint without refreshing or writing credentials. (#48, thanks @Werkaninchen)
+- Updated the bundled pricing database to 2.0.20, adding 14 model entries across Z.ai, DeepSeek, Qwen, ByteDance, Tencent, Mistral, Meta, and NVIDIA. (#50)
 
 ### Changed
 
-- Usage refresh reports now appear for every repeat refresh of the displayed range, including timer-driven refreshes, while an explicit dismissal remains in effect until the range changes or the user requests another refresh.
+- Usage refresh reports now appear for every repeat refresh of the displayed range, including timer-driven refreshes, while an explicit dismissal remains in effect until the range changes or the user requests another refresh. (#47, thanks @674019130)
 
 ## 2.3.1 - 2026-08-27
 
 ### Changed
 
-- Sessions panels now carry each harness's brand logo in the panel header, reusing the Overview's identity system. A harness with no sessions in the selected range is hidden instead of rendering an empty panel, and when no harness has sessions in range a single empty-state band replaces them all. A panel whose fetch failed stays visible so its error row is not swallowed.
+- Sessions panels now carry each harness's brand logo in the panel header, reusing the Overview's identity system. A harness with no sessions in the selected range is hidden instead of rendering an empty panel, and when no harness has sessions in range a single empty-state band replaces them all. A panel whose fetch failed stays visible so its error row is not swallowed. (#45)
 
 ### Fixed
 
-- The first dashboard load no longer races the startup cache warmer into a transient `503`. One foreground request per key may join the warm fill already running on its behalf, bounded by `TOKDASH_STARTUP_WARM_JOIN_SECONDS` (default `30` seconds); every other same-key cold miss keeps the existing fail-fast backpressure, and the warmer's own backpressure no longer logs as a warning. The unused period-only Today usage key is no longer warmed, dropping a duplicate of the largest startup aggregation. Direct callers of `/api/usage?period=today` still compute the same data but no longer find it pre-cached.
+- The first dashboard load no longer races the startup cache warmer into a transient `503`. One foreground request per key may join the warm fill already running on its behalf, bounded by `TOKDASH_STARTUP_WARM_JOIN_SECONDS` (default `30` seconds); every other same-key cold miss keeps the existing fail-fast backpressure, and the warmer's own backpressure no longer logs as a warning. The unused period-only Today usage key is no longer warmed, dropping a duplicate of the largest startup aggregation. Direct callers of `/api/usage?period=today` still compute the same data but no longer find it pre-cached. (#42, thanks @674019130)
 
 ## 2.3.0 - 2026-08-26
 
 ### Added
 
-- Added Session Explorer support for Antigravity CLI, Cline, Grok Build, Hermes, Kilo Code and omp. Each integration reuses the source parser's token mapping and pricing rules, exposes per-session turns and active time, and has its own dashboard panel and regression suite.
-- Added a Servers tab for comparing configured Tokdash instances, with reachable/stale state, usage shares, leading tools and models, session counts and quota summaries. Session panels can now be collapsed independently.
-- Refresh now reports source-level changes from the incremental usage scan, including added, updated, removed and unchanged rows.
+- Added Session Explorer support for Antigravity CLI, Cline, Grok Build, Hermes, Kilo Code and omp. Each integration reuses the source parser's token mapping and pricing rules, exposes per-session turns and active time, and has its own dashboard panel and regression suite. (#40)
+- Added a Servers tab for comparing configured Tokdash instances, with reachable/stale state, usage shares, leading tools and models, session counts and quota summaries. Session panels can now be collapsed independently. (#36)
+- Refresh now reports source-level changes from the incremental usage scan, including added, updated, removed and unchanged rows. (#39, thanks @674019130)
 
 ### Changed
 
-- Overview and session-panel runtime KPIs now show agent time consistently. The Servers tab remains available with one configured server so its health and details are still visible.
-- Coding-tool rescans now reuse unchanged source entries and update only changed files while preserving the last complete view when a source read is partial or fails.
+- Overview and session-panel runtime KPIs now show agent time consistently. The Servers tab remains available with one configured server so its health and details are still visible. (#37)
+- Coding-tool rescans now reuse unchanged source entries and update only changed files while preserving the last complete view when a source read is partial or fails. (#39, thanks @674019130)
 
 ### Fixed
 
-- Antigravity conversation titles and projects now refresh when only the summary database WAL changes.
-- Cline now falls back to the session record's working directory when its metadata database has no usable project.
+- Antigravity conversation titles and projects now refresh when only the summary database WAL changes. (#40)
+- Cline now falls back to the session record's working directory when its metadata database has no usable project. (#40)
 - Dashboard refresh requests are queued instead of dropped when another update is in flight, and stale overview breakdowns cannot overwrite the currently selected date range.
 
 ## 2.2.0 - 2026-08-22

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- Hermes named profiles are now scanned by default. Each profile keeps its own session database at `~/.hermes/profiles/<name>/state.db`, which Tokdash previously ignored, so Overview and Session Explorer silently missed that usage unless every profile was listed by hand in `HERMES_HOME`. Profiles are enumerated under each Hermes home, including homes given via `HERMES_HOME`, and a dir listed twice is scanned once. (#54)
+- Hermes named profiles are now scanned by default. Each profile keeps its own session database at `~/.hermes/profiles/<name>/state.db`, which Tokdash previously ignored, so Overview and Session Explorer silently missed that usage unless every profile was listed by hand in `HERMES_HOME`. Profiles are enumerated under each Hermes home, including homes given via `HERMES_HOME`, and a dir listed twice is scanned once. (#54, closes #53, thanks @wangfh5)
 - Yesterday's figures are warmed shortly after the local date rolls over (00:05 by default, `TOKDASH_DAILY_WARM_MINUTE`; disable with `TOKDASH_DAILY_WARM=0`). Every key for a window that can still gain usage goes cold at midnight, and the day that just closed is the one the Yesterday button asks for all day. Its numbers are final, so it is computed once and served from cache from then on. Today is deliberately not warmed at that hour: it holds almost nothing yet, and warming it would put a near-empty snapshot in front of the morning's first request. (#55)
 
 ### Changed

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -6,9 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+## 2.4.3 - 2026-09-01
+
 ### Added
 
 - Hermes named profiles are now scanned by default. Each profile keeps its own session database at `~/.hermes/profiles/<name>/state.db`, which Tokdash previously ignored, so Overview and Session Explorer silently missed that usage unless every profile was listed by hand in `HERMES_HOME`. Profiles are enumerated under each Hermes home, including homes given via `HERMES_HOME`, and a dir listed twice is scanned once.
+- Yesterday's figures are warmed shortly after the local date rolls over (00:05 by default, `TOKDASH_DAILY_WARM_MINUTE`; disable with `TOKDASH_DAILY_WARM=0`). Every key for a window that can still gain usage goes cold at midnight, and the day that just closed is the one the Yesterday button asks for all day. Its numbers are final, so it is computed once and served from cache from then on. Today is deliberately not warmed at that hour: it holds almost nothing yet, and warming it would put a near-empty snapshot in front of the morning's first request.
+
+### Changed
+
+- The heavy-compute cap now scales with the CPUs the process may actually use, from the previous fixed 2 up to 8. It reads the scheduler affinity mask and any cgroup CPU quota — including a quota on the process's own sub-cgroup, which is where a systemd unit's `CPUQuota=` lives — rather than the host's core count, so a large machine drains a cold fan-out quickly while a small VPS, Raspberry Pi or CPU-limited container keeps the old ceiling. Running and waiting requests share one thread budget (`TOKDASH_COMPUTE_THREAD_BUDGET`, default 32), so raising `TOKDASH_COMPUTE_CONCURRENCY` spends the waiter allowance instead of pushing the total past the worker pool and starving `/health` and cache hits.
+
+### Fixed
+
+- Switching to a date range nothing has computed no longer fails most of the Sessions tab. That tab issues one request per tool, so a cold range asks for ~17 distinct keys at once, and a request that could not get a heavy-compute slot was refused outright instead of queued: measured against a running server, 13 of 15 tools took an instant `503` while the slot each needed freed about a second later, and the dashboard retries only three times before a panel gives up. A cold request with nothing to show now waits briefly for a slot (`TOKDASH_COMPUTE_WAIT_SECONDS`, default 15 seconds, capped at 120), bounded by a waiter allowance so a burst cannot park the whole worker pool. A stale value or a background refresh still answers immediately and never waits, and the cap on concurrent computes is unchanged. The same fan-out that lost 13 panels now completes in about 3.7 seconds.
 
 ## 2.4.2 - 2026-08-30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tokdash"
-version = "2.4.2"
+version = "2.4.3"
 description = "Local token & cost dashboard for AI coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tokdash/__init__.py
+++ b/src/tokdash/__init__.py
@@ -1,3 +1,3 @@
 """Tokdash package."""
 
-__version__ = "2.4.2"
+__version__ = "2.4.3"

--- a/src/tokdash/api.py
+++ b/src/tokdash/api.py
@@ -4,6 +4,7 @@ import hashlib
 import ipaddress
 import json
 import logging
+import math
 import os
 import secrets
 import threading
@@ -12,7 +13,7 @@ from collections import OrderedDict
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -314,35 +315,61 @@ def _warm_caches() -> None:
     Disable with TOKDASH_WARM_ON_START=0.
     Failures are swallowed; warming must never crash `serve`.
     """
-    today = datetime.now().astimezone().strftime("%Y-%m-%d")
+    today = _local_today().isoformat()
+    # Composed by name, not by slicing _day_warm_targets(): the warm order is the order
+    # the dashboard needs these in, and stats belongs second, immediately behind the
+    # Overview usage key. Reordering the per-day targets must not silently demote it.
     warmers = [
-        (
-            _window_cache_key(f"usage_today_{today}_{today}", today, today),
-            lambda: compute_usage_with_comparison("today", today, today),
-        ),
+        _usage_warm_target(today),
         (_window_cache_key("stats_None", None, None), lambda: compute_stats(None)),
+        *_session_warm_targets(today),
+        (_day_scoped_key(ACTIVITY_INSIGHTS_CACHE_KEY), get_codex_activity_insights),
     ]
-    # Mirror the dashboard exactly: its default date picker sends an explicit
-    # date_from/date_to pair, not period=today. Keeping this key construction shared
-    # with the route prevents the warmer and browser from drifting apart again.
+    _run_warmers(warmers)
+
+
+def _day_warm_targets(day: str) -> list:
+    """Every (key, fetch) pair the dashboard asks for with ``day`` as the whole range."""
+    return [_usage_warm_target(day), *_session_warm_targets(day)]
+
+
+def _usage_warm_target(day: str):
+    """The Overview usage pair for ``day``.
+
+    Mirror the dashboard exactly: its date picker sends an explicit date_from/date_to
+    pair, not period=today. Building these through the same key helpers the routes use
+    is what stops the warmer and the browser from drifting apart.
+    """
+    return (
+        _window_cache_key(f"usage_today_{day}_{day}", day, day),
+        lambda: compute_usage_with_comparison("today", day, day),
+    )
+
+
+def _session_warm_targets(day: str) -> list:
+    """The per-tool Sessions pairs for ``day``, plus the cross-tool active time."""
+    targets: list = []
     for tool in SESSION_TOOLS:
-        warmers.append(
+        targets.append(
             (
-                _session_response_cache_key(tool, "today", today, today, None),
+                _session_response_cache_key(tool, "today", day, day, None),
                 lambda tool=tool: get_sessions_data(
-                    tool, "today", today, today, include_review_sessions=None
+                    tool, "today", day, day, include_review_sessions=None
                 ),
             )
         )
-    warmers.append(
+    targets.append(
         (
-            _active_time_cache_key("today", today, today, None),
-            lambda: get_active_time_data("today", today, today, include_review_sessions=None),
+            _active_time_cache_key("today", day, day, None),
+            lambda: get_active_time_data("today", day, day, include_review_sessions=None),
         )
     )
-    warmers.append((_day_scoped_key(ACTIVITY_INSIGHTS_CACHE_KEY), get_codex_activity_insights))
+    return targets
+
+
+def _run_warmers(warmers, *, join_seconds: Optional[float] = None) -> None:
     for key, fetch in warmers:
-        warm_event = _begin_startup_warm(key)
+        warm_event = _begin_startup_warm(key, join_seconds)
         try:
             get_cached_or_fetch(key, fetch, _startup_warm=True)
         except Exception:
@@ -351,10 +378,62 @@ def _warm_caches() -> None:
             _finish_startup_warm(key, warm_event)
 
 
+def _warm_previous_day() -> None:
+    """Warm the day that just ended, shortly after the local date rolls over.
+
+    Every open-window key goes cold at midnight, and the day that just closed is the
+    one the Yesterday button asks for all day. Its numbers are final, so this is
+    computed once and then served from cache for the rest of the day. Today is
+    deliberately NOT warmed here: at 00:05 it holds almost nothing, and warming it
+    would put a near-empty snapshot in front of the morning's first request.
+    """
+    yesterday = (_local_today() - timedelta(days=1)).isoformat()
+    # A shorter join than the startup warm: this one runs while the server is live, so a
+    # racing request pays the join before it learns anything. The two waits rarely stack
+    # — a joiner that times out re-enters with _startup_waited=True and, while the warm
+    # still holds the key lock, is refused immediately as same_key_inflight without ever
+    # reaching _acquire_compute_slot; they compound only if the warm released that lock
+    # inside the window having stored nothing, i.e. it raised. The join alone is reason
+    # enough to shorten it: 10s-to-503 beats 30s-to-503 on a live server.
+    _run_warmers(_day_warm_targets(yesterday), join_seconds=DAILY_WARM_JOIN_SECONDS)
+
+
+def _daily_warm_minute() -> int:
+    """Minutes past local midnight for the daily warm, default 5.
+
+    ``0`` is a legitimate setting (warm exactly at midnight), so this cannot use
+    ``_positive_int_env``, which would silently turn it back into the default. A value
+    outside a day falls back to the default rather than wrapping into an unrelated time.
+    """
+    minute = _non_negative_int_env("TOKDASH_DAILY_WARM_MINUTE", _DEFAULT_DAILY_WARM_MINUTE)
+    return minute if minute < 24 * 60 else _DEFAULT_DAILY_WARM_MINUTE
+
+
+def _seconds_until_daily_warm(now: Optional[datetime] = None) -> float:
+    """Seconds until the next local warm time (default 00:05)."""
+    current = now or datetime.now().astimezone()
+    minute = _daily_warm_minute()
+    target = current.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(minutes=minute)
+    if target <= current:
+        target += timedelta(days=1)
+    return max(1.0, (target - current).total_seconds())
+
+
+def _daily_warm_loop() -> None:
+    while True:
+        time.sleep(_seconds_until_daily_warm())
+        try:
+            _warm_previous_day()
+        except Exception:  # pragma: no cover - a warm failure must never kill the loop
+            logger.debug("tokdash daily warm failed", exc_info=True)
+
+
 @asynccontextmanager
 async def _lifespan(_app: "FastAPI"):
     if os.environ.get("TOKDASH_WARM_ON_START", "1") != "0":
         threading.Thread(target=_warm_caches, name="tokdash-warm", daemon=True).start()
+    if os.environ.get("TOKDASH_DAILY_WARM", "1") != "0":
+        threading.Thread(target=_daily_warm_loop, name="tokdash-daily-warm", daemon=True).start()
     yield
 
 
@@ -554,13 +633,17 @@ def _positive_int_env(name: str, default: int) -> int:
 CACHE_TTL = _positive_int_env("TOKDASH_CACHE_TTL", 600)  # seconds
 CACHE_MAX_ENTRIES = _positive_int_env("TOKDASH_CACHE_MAX_ENTRIES", 256)
 STARTUP_WARM_JOIN_SECONDS = _positive_int_env("TOKDASH_STARTUP_WARM_JOIN_SECONDS", 30)
+# The daily rollover warm runs on a live server, so its join budget is deliberately
+# shorter than the startup one; see _warm_previous_day.
+DAILY_WARM_JOIN_SECONDS = _positive_int_env("TOKDASH_DAILY_WARM_JOIN_SECONDS", 10)
+_DEFAULT_DAILY_WARM_MINUTE = 5  # minutes past local midnight
 
 # A startup warmer is the one safe exception to cold-miss fail-fast: the automatic
 # browser load is asking for work that is already running on its behalf. Let at most
 # one foreground request per key wait for that result so a tab storm still cannot
 # occupy the AnyIO worker pool. All ordinary same-key misses retain the old 503 path.
 _startup_warm_guard = threading.Lock()
-_startup_warm_events: dict[str, threading.Event] = {}
+_startup_warm_events: dict[str, tuple[threading.Event, float]] = {}
 _startup_warm_waiters: set[str] = set()
 
 
@@ -579,14 +662,264 @@ class CacheFetchResult:
         return self.status in {"hit", "stale"}
 
 
+def _non_negative_int_env(name: str, default: int) -> int:
+    """Read a non-negative integer env var. Unlike ``_positive_int_env`` an explicit
+    ``0`` is honoured, so a knob whose whole point is "none" stays reachable."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
+def _bounded_float_env(name: str, default: float, *, maximum: float) -> float:
+    """Read a positive, FINITE float env var, clamped to ``maximum``.
+
+    ``float("inf")`` parses, and an unbounded wait would park a worker thread for the
+    life of the process — the exact failure the compute cap exists to prevent.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return min(default, maximum)
+    try:
+        value = float(raw)
+    except ValueError:
+        return min(default, maximum)
+    if not math.isfinite(value) or value <= 0:
+        return min(default, maximum)
+    return min(value, maximum)
+
+
+def _parse_cpu_max(path: Path) -> Optional[int]:
+    """Whole CPUs from a cgroup v2 ``cpu.max``, or None when unlimited or unreadable."""
+    try:
+        fields = path.read_text(encoding="utf-8").split()
+    except OSError:
+        return None
+    if not fields or fields[0] == "max":
+        return None
+    try:
+        quota = int(fields[0])
+        period = int(fields[1]) if len(fields) > 1 else 100000
+    except ValueError:
+        return None
+    if quota <= 0 or period <= 0:
+        return None
+    return max(1, quota // period)
+
+
+def _cgroup_v2_cpu_max_paths(root: Path, proc_self_cgroup: Path) -> list:
+    """``cpu.max`` candidates from this process's own cgroup up to the root.
+
+    A container's cgroup is normally namespaced, so the root IS its limit. A systemd
+    unit with ``CPUQuota=`` is not: it sits in a sub-cgroup such as
+    ``/system.slice/tokdash.service`` whose limit the root's ``cpu.max`` never shows —
+    and ``tokdash setup`` installs exactly such a unit. Any ancestor can also cap the
+    leaf, so every level between the two is a candidate.
+    """
+    paths = [root / "cpu.max"]
+    try:
+        lines = proc_self_cgroup.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return paths
+    for line in lines:
+        parts = line.split(":", 2)
+        if len(parts) != 3 or parts[0] != "0":  # only the unified (v2) line
+            continue
+        relative = parts[2].strip().strip("/")
+        if relative:
+            current = root
+            for segment in relative.split("/"):
+                current = current / segment
+                paths.append(current / "cpu.max")
+        break
+    return paths
+
+
+def _parse_cfs_quota(directory: Path) -> Optional[int]:
+    """Whole CPUs from a cgroup v1 cpu controller dir, or None when unlimited."""
+    try:
+        quota = int((directory / "cpu.cfs_quota_us").read_text(encoding="utf-8").strip())
+        period = int((directory / "cpu.cfs_period_us").read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+    if quota <= 0 or period <= 0:  # -1 means unlimited
+        return None
+    return max(1, quota // period)
+
+
+def _cgroup_v1_cpu_dirs(base: Path, proc_self_cgroup: Path) -> list:
+    """cpu controller dirs from the controller root down to this process's own cgroup.
+
+    v1 has the same sub-cgroup shape as v2 — a systemd unit sits at
+    ``/sys/fs/cgroup/cpu/system.slice/<unit>`` — so reading only the root misses
+    exactly the ``CPUQuota=`` that the v2 walk was added to catch.
+    """
+    dirs = [base]
+    try:
+        lines = proc_self_cgroup.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return dirs
+    for line in lines:
+        parts = line.split(":", 2)
+        if len(parts) != 3 or "cpu" not in parts[1].split(","):
+            continue
+        relative = parts[2].strip().strip("/")
+        if relative:
+            current = base
+            for segment in relative.split("/"):
+                current = current / segment
+                dirs.append(current)
+        break
+    return dirs
+
+
+def _cgroup_cpu_quota(
+    root: Path = Path("/sys/fs/cgroup"),
+    proc_self_cgroup: Path = Path("/proc/self/cgroup"),
+    v1_dir: Optional[Path] = None,
+) -> Optional[int]:
+    """Whole CPUs a cgroup quota allows, or None when unlimited or unreadable.
+
+    ``docker --cpus=2`` and systemd's ``CPUQuota=`` both set a CFS quota, not an
+    affinity mask, so neither ``os.cpu_count()`` nor the affinity mask reflects them.
+    The most restrictive level wins. Paths are parameters so this is testable without
+    a container.
+    """
+    quotas = [
+        quota
+        for quota in (
+            _parse_cpu_max(path)
+            for path in _cgroup_v2_cpu_max_paths(root, proc_self_cgroup)
+        )
+        if quota is not None
+    ]
+    if quotas:
+        return min(quotas)
+    # cgroup v1 (legacy), which has the same sub-cgroup shape as v2.
+    base = (root / "cpu") if v1_dir is None else v1_dir
+    v1_quotas = [
+        quota
+        for quota in (
+            _parse_cfs_quota(directory)
+            for directory in _cgroup_v1_cpu_dirs(base, proc_self_cgroup)
+        )
+        if quota is not None
+    ]
+    return min(v1_quotas) if v1_quotas else None
+
+
+def _available_cpus() -> int:
+    """CPUs this process may actually use.
+
+    ``os.cpu_count()`` reports the whole host, which is wrong in precisely the case
+    this scaling protects: a small container on a big machine. Prefer the
+    process-aware count (3.13+), then the scheduler affinity mask, and fold in a
+    cgroup quota, which neither of those reflects.
+    """
+    count: Optional[int] = None
+    process_cpu_count = getattr(os, "process_cpu_count", None)
+    if process_cpu_count is not None:  # Python 3.13+
+        count = process_cpu_count()
+    if count is None:
+        try:
+            count = len(os.sched_getaffinity(0))
+        except AttributeError:  # not Linux
+            count = None
+    if count is None:
+        count = os.cpu_count()
+    quota = _cgroup_cpu_quota()
+    if quota is not None:
+        count = quota if count is None else min(count, quota)
+    return max(1, count or 1)
+
+
+def _default_compute_concurrency() -> int:
+    """Heavy computes allowed at once, scaled to the machine and capped at 8.
+
+    A flat 2 was safe while a cold key almost always had a stale value to serve
+    meanwhile. It is not safe against a *cold* fan-out: the Sessions tab issues one
+    request per tool, so a range change asks for far more distinct cold keys at once
+    than the cap allows. Scaling lets a large host drain that fan-out quickly while a
+    small VPS, Pi or CPU-limited container keeps the original ceiling.
+    """
+    return max(2, min(8, _available_cpus() // 2))
+
+
 # Bound the number of *heavy* computes (full-history reparses) running at once.
 # Without this, a burst of requests for distinct cache keys each grabs an AnyIO
 # worker token and runs a multi-second parse; the pool saturates (so even cache
 # hits and /health can't get a worker) and RSS balloons. Capping heavy work well
 # below the worker pool keeps headroom for cheap requests.
 # This is the app-side companion to the uvicorn backpressure knobs in cli.py.
-_COMPUTE_CONCURRENCY = _positive_int_env("TOKDASH_COMPUTE_CONCURRENCY", 2)
+_COMPUTE_CONCURRENCY = _positive_int_env(
+    "TOKDASH_COMPUTE_CONCURRENCY", _default_compute_concurrency()
+)
 _compute_semaphore = threading.BoundedSemaphore(_COMPUTE_CONCURRENCY)
+
+# How long a cold request may WAIT for a compute slot, and how many may wait at once.
+# Refusing instantly made sense while a stale value was almost always available to
+# serve instead. Once a closed window has to be computed to be correct, a Sessions
+# fan-out is N distinct cold keys arriving together, and an instant refusal rejected
+# every request past the cap while the slot it needed freed a second later — the
+# browser retries only a few times, so panels failed outright. Waiting preserves the
+# cap (parser stampede and RSS ceiling are unchanged) and lets the fan-out drain.
+# The waiter cap keeps a pathological burst from parking the whole worker pool.
+# Computing + parked threads are budgeted TOGETHER against AnyIO's default 40-thread
+# pool (nothing in this tree raises that limiter; cli.py bounds connections, not
+# threads). Deriving the waiter allowance from the concurrency means raising
+# TOKDASH_COMPUTE_CONCURRENCY spends the same budget rather than pushing the total
+# past the pool and starving /health and cache hits — the very failure the cap exists
+# to prevent. A concurrency at or above the budget leaves no waiters, i.e. the old
+# fail-fast behaviour, which is the safe end of the trade.
+_COMPUTE_THREAD_BUDGET = _positive_int_env("TOKDASH_COMPUTE_THREAD_BUDGET", 32)
+
+
+def _default_max_waiters(concurrency: int, budget: Optional[int] = None) -> int:
+    """Requests allowed to park while ``concurrency`` are computing.
+
+    The two share one thread budget, so raising the concurrency spends the waiter
+    allowance rather than pushing the total past AnyIO's pool. At or above the budget
+    this is 0 — the old fail-fast behaviour, which is the safe end of the trade.
+    """
+    ceiling = _COMPUTE_THREAD_BUDGET if budget is None else budget
+    return max(0, ceiling - concurrency)
+
+
+_COMPUTE_WAIT_SECONDS = _bounded_float_env(
+    "TOKDASH_COMPUTE_WAIT_SECONDS", 15.0, maximum=120.0
+)
+_COMPUTE_MAX_WAITERS = _non_negative_int_env(
+    "TOKDASH_COMPUTE_MAX_WAITERS", _default_max_waiters(_COMPUTE_CONCURRENCY)
+)
+_compute_waiters = 0
+_compute_waiters_guard = threading.Lock()
+
+
+def _acquire_compute_slot(*, wait: bool = True) -> bool:
+    """Take a heavy-compute slot, optionally waiting briefly for one to free up.
+
+    ``wait=False`` keeps the old instant refusal for callers that have something else
+    to serve (a stale value, or an opportunistic background refresh): those must never
+    occupy a worker thread waiting when they can answer immediately.
+    """
+    global _compute_waiters
+    if _compute_semaphore.acquire(blocking=False):
+        return True
+    if not wait:
+        return False
+    with _compute_waiters_guard:
+        if _compute_waiters >= _COMPUTE_MAX_WAITERS:
+            return False
+        _compute_waiters += 1
+    try:
+        return _compute_semaphore.acquire(timeout=_COMPUTE_WAIT_SECONDS)
+    finally:
+        with _compute_waiters_guard:
+            _compute_waiters -= 1
 
 
 def _raise_backpressure(
@@ -608,17 +941,27 @@ def _raise_backpressure(
     raise CacheBackpressureError(message)
 
 
-def _begin_startup_warm(key: str) -> threading.Event:
+def _begin_startup_warm(
+    key: str, join_seconds: Optional[float] = None
+) -> threading.Event:
+    """Register a warm fill one foreground request may join.
+
+    The join budget is stored per entry: a warm that runs on a live server (the daily
+    rollover) must not make a racing request wait the startup allowance on top of its
+    own slot wait.
+    """
     event = threading.Event()
+    budget = STARTUP_WARM_JOIN_SECONDS if join_seconds is None else join_seconds
     with _startup_warm_guard:
-        _startup_warm_events[key] = event
+        _startup_warm_events[key] = (event, budget)
         _startup_warm_waiters.discard(key)
     return event
 
 
 def _finish_startup_warm(key: str, event: threading.Event) -> None:
     with _startup_warm_guard:
-        if _startup_warm_events.get(key) is event:
+        entry = _startup_warm_events.get(key)
+        if entry is not None and entry[0] is event:
             # Publish completion before removing the registry entry. Otherwise a
             # request arriving in the tiny pop-before-set window would see neither
             # a cached join target nor an unlocked cache key and emit a stray 503.
@@ -629,18 +972,20 @@ def _finish_startup_warm(key: str, event: threading.Event) -> None:
     event.set()
 
 
-def _claim_startup_warm_wait(key: str) -> threading.Event | None:
+def _claim_startup_warm_wait(key: str) -> tuple[threading.Event, float] | None:
+    """Claim the right to join an in-flight warm, with that warm's join budget."""
     with _startup_warm_guard:
-        event = _startup_warm_events.get(key)
-        if event is None or key in _startup_warm_waiters:
+        entry = _startup_warm_events.get(key)
+        if entry is None or key in _startup_warm_waiters:
             return None
         _startup_warm_waiters.add(key)
-        return event
+        return entry
 
 
 def _release_startup_warm_wait(key: str, event: threading.Event) -> None:
     with _startup_warm_guard:
-        if _startup_warm_events.get(key) is event:
+        entry = _startup_warm_events.get(key)
+        if entry is not None and entry[0] is event:
             _startup_warm_waiters.discard(key)
 
 
@@ -772,7 +1117,7 @@ def _refresh_stale_in_background(
 ) -> None:
     acquired_compute = False
     try:
-        acquired_compute = _compute_semaphore.acquire(blocking=False)
+        acquired_compute = _acquire_compute_slot(wait=False)
         if not acquired_compute:
             logger.debug("tokdash stale refresh deferred key=%s reason=compute_cap", key)
             return
@@ -847,10 +1192,11 @@ def get_cached_or_fetch(
         if hit is not None:
             return result(hit[1], "stale", now - hit[0])  # serve cached rather than stampede the parser
         if not force_refresh and not _startup_warm and not _startup_waited:
-            warm_event = _claim_startup_warm_wait(key)
-            if warm_event is not None:
+            claimed = _claim_startup_warm_wait(key)
+            if claimed is not None:
+                warm_event, join_seconds = claimed
                 try:
-                    warm_event.wait(timeout=STARTUP_WARM_JOIN_SECONDS)
+                    warm_event.wait(timeout=join_seconds)
                 finally:
                     _release_startup_warm_wait(key, warm_event)
                 # The warmer may have completed successfully, failed, or timed out.
@@ -877,7 +1223,18 @@ def get_cached_or_fetch(
         if latest is not None and locked_now - latest[0] < CACHE_TTL and not force_refresh:
             return result(latest[1], "hit", locked_now - latest[0])
         epoch = _cache_epoch_value()
-        if not _compute_semaphore.acquire(blocking=False):
+        # A stale value beats waiting, so only a cold key with nothing to show parks
+        # for a slot. This is what keeps a Sessions fan-out from failing wholesale.
+        #
+        # NOTE: this waits while still holding the per-key lock, so the window in which
+        # a second request for the SAME key is refused as same_key_inflight grows from
+        # "the compute" to "the compute plus up to _COMPUTE_WAIT_SECONDS". That is
+        # deliberate. A fan-out is distinct keys, so it never collides here; the cost
+        # falls on a repeat of one key, where the caller has nothing to be given anyway
+        # and a 503 is the honest answer. Releasing the lock to wait would instead let
+        # several threads compute the same cold key, which is what single-flight exists
+        # to prevent.
+        if not _acquire_compute_slot(wait=latest is None):
             if latest is not None:
                 return result(latest[1], "stale", locked_now - latest[0])
             _raise_backpressure(

--- a/src/tokdash/static/release-notes.json
+++ b/src/tokdash/static/release-notes.json
@@ -1,6 +1,31 @@
 {
-  "current": "2.4.2",
+  "current": "2.4.3",
   "releases": [
+    {
+      "version": "2.4.3",
+      "date": "2026-09-01",
+      "sections": [
+        {
+          "type": "added",
+          "items": [
+            "Hermes named profiles are scanned by default, so usage kept under ~/.hermes/profiles/<name> no longer goes missing from Overview and Session Explorer.",
+            "Yesterday's figures are warmed just after midnight, so the first Yesterday click of the day is already cached."
+          ]
+        },
+        {
+          "type": "changed",
+          "items": [
+            "The cap on concurrent heavy computes now scales with the CPUs this process may actually use, up to 8, instead of a fixed 2."
+          ]
+        },
+        {
+          "type": "fixed",
+          "items": [
+            "Switching to a date range nothing has computed no longer leaves most Sessions panels failing. Requests that cannot get a compute slot now queue briefly instead of being refused outright."
+          ]
+        }
+      ]
+    },
     {
       "version": "2.4.2",
       "date": "2026-08-30",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,24 @@ def isolated_usage_db(monkeypatch, tmp_path):
 
 
 @pytest.fixture(autouse=True)
+def no_background_warmers(monkeypatch):
+    """Keep the lifespan's warm threads out of every test, on ANY code path.
+
+    ``_lifespan`` has no shutdown side, so a thread it starts outlives the
+    ``TestClient`` block that started it — the daily warmer then sleeps on with the
+    test's monkeypatches long gone, and a suite run straddling the warm minute fires a
+    real full-history ``_warm_previous_day()`` mid-run against whatever data dir is
+    current. Both are daemons, so pytest still exits and the damage is silent.
+
+    This lives in conftest rather than in one test file's fixture because any future
+    ``with TestClient(api.app)`` inherits the same problem. Tests that want a warm call
+    the warmers directly.
+    """
+    monkeypatch.setenv("TOKDASH_WARM_ON_START", "0")
+    monkeypatch.setenv("TOKDASH_DAILY_WARM", "0")
+
+
+@pytest.fixture(autouse=True)
 def no_browser_open(request, monkeypatch):
     """Never let a test spawn a real browser, on ANY code path.
 

--- a/tests/test_cold_fanout_backpressure.py
+++ b/tests/test_cold_fanout_backpressure.py
@@ -222,10 +222,26 @@ def test_the_default_concurrency_scales_with_cores_and_is_bounded(monkeypatch):
 def test_available_cpus_prefers_the_affinity_mask_over_the_host_count(monkeypatch):
     """os.cpu_count() reports the whole host — wrong for a pinned process."""
     monkeypatch.setattr(api.os, "process_cpu_count", None, raising=False)
-    monkeypatch.setattr(api.os, "sched_getaffinity", lambda _pid: set(range(4)))
+    monkeypatch.setattr(
+        api.os, "sched_getaffinity", lambda _pid: set(range(4)), raising=False
+    )
     monkeypatch.setattr(api.os, "cpu_count", lambda: 64)
     monkeypatch.setattr(api, "_cgroup_cpu_quota", lambda: None)
     assert api._available_cpus() == 4
+
+
+def test_available_cpus_falls_back_when_there_is_no_affinity_mask(monkeypatch):
+    """os.sched_getaffinity is Linux-only; macOS and Windows must still get a count.
+
+    The other tests inject the symbol with raising=False, so without this the
+    AttributeError fallback in _available_cpus would only ever run on the platforms
+    where the tests are least likely to be looked at.
+    """
+    monkeypatch.setattr(api.os, "process_cpu_count", None, raising=False)
+    monkeypatch.delattr(api.os, "sched_getaffinity", raising=False)
+    monkeypatch.setattr(api.os, "cpu_count", lambda: 12)
+    monkeypatch.setattr(api, "_cgroup_cpu_quota", lambda: None)
+    assert api._available_cpus() == 12
 
 
 def test_a_cgroup_quota_caps_the_cpu_count(monkeypatch):
@@ -235,7 +251,9 @@ def test_a_cgroup_quota_caps_the_cpu_count(monkeypatch):
     host's cores and take 8 concurrent parses.
     """
     monkeypatch.setattr(api.os, "process_cpu_count", None, raising=False)
-    monkeypatch.setattr(api.os, "sched_getaffinity", lambda _pid: set(range(64)))
+    monkeypatch.setattr(
+        api.os, "sched_getaffinity", lambda _pid: set(range(64)), raising=False
+    )
     monkeypatch.setattr(api.os, "cpu_count", lambda: 64)
     monkeypatch.setattr(api, "_cgroup_cpu_quota", lambda: 2)
     assert api._available_cpus() == 2
@@ -249,7 +267,9 @@ def test_a_quota_lowers_the_resulting_concurrency(monkeypatch):
     An 8-CPU quota giving 4 IS distinguishable from the 8 an unquota'd host returns.
     """
     monkeypatch.setattr(api.os, "process_cpu_count", None, raising=False)
-    monkeypatch.setattr(api.os, "sched_getaffinity", lambda _pid: set(range(64)))
+    monkeypatch.setattr(
+        api.os, "sched_getaffinity", lambda _pid: set(range(64)), raising=False
+    )
     monkeypatch.setattr(api.os, "cpu_count", lambda: 64)
 
     monkeypatch.setattr(api, "_cgroup_cpu_quota", lambda: None)

--- a/tests/test_cold_fanout_backpressure.py
+++ b/tests/test_cold_fanout_backpressure.py
@@ -1,0 +1,489 @@
+"""A cold fan-out drains instead of being rejected wholesale.
+
+The Sessions tab issues one request per tool, so switching to a range nothing has
+computed yet asks for ~17 distinct cold keys at once. While a stale value was almost
+always available, refusing everything past the heavy-compute cap was harmless — the
+caller had something to show. Once a closed window must actually be computed to be
+correct, that refusal rejected the whole fan-out: measured against a live server, 13 of
+15 tools got an instant 503 while the slots they needed freed a second later, and the
+browser retries only three times before giving up.
+
+A cold request with nothing to serve now waits briefly for a slot. The cap itself is
+unchanged, so the parser stampede and RSS ceiling these tests do not measure stay bounded.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+import tokdash.api as api
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    monkeypatch.setenv("TOKDASH_WARM_ON_START", "0")
+    api._clear_cache()
+    yield
+    api._clear_cache()
+
+
+def _slow_fetch(seconds: float, value: str):
+    def fetch():
+        time.sleep(seconds)
+        return value
+    return fetch
+
+
+def test_a_cold_fanout_of_distinct_keys_all_succeed(monkeypatch):
+    """15 cold keys against 2 slots: every one is served, none refused."""
+    monkeypatch.setattr(api, "_compute_semaphore", threading.BoundedSemaphore(2))
+    monkeypatch.setattr(api, "_COMPUTE_WAIT_SECONDS", 30.0)
+
+    results: dict[str, object] = {}
+    errors: list[Exception] = []
+
+    def worker(n: int):
+        try:
+            results[f"k{n}"] = api.get_cached_or_fetch(f"k{n}", _slow_fetch(0.05, f"v{n}"))
+        except Exception as exc:  # noqa: BLE001 - the assertion below reports it
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in range(15)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+
+    assert not errors, f"a cold fan-out was refused: {errors!r}"
+    assert len(results) == 15
+    assert results["k7"] == "v7"
+
+
+def test_concurrency_cap_is_still_enforced_while_waiting(monkeypatch):
+    """Waiting must not let more heavy computes run at once than the cap allows."""
+    monkeypatch.setattr(api, "_compute_semaphore", threading.BoundedSemaphore(2))
+    monkeypatch.setattr(api, "_COMPUTE_WAIT_SECONDS", 30.0)
+
+    live = 0
+    peak = 0
+    guard = threading.Lock()
+
+    def fetch():
+        nonlocal live, peak
+        with guard:
+            live += 1
+            peak = max(peak, live)
+        time.sleep(0.05)
+        with guard:
+            live -= 1
+        return "v"
+
+    threads = [
+        threading.Thread(target=lambda n=n: api.get_cached_or_fetch(f"cap{n}", fetch))
+        for n in range(10)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+
+    assert peak <= 2, f"{peak} heavy computes ran at once against a cap of 2"
+
+
+def test_a_refresh_over_a_cached_value_never_waits_for_a_slot(monkeypatch):
+    """The `wait=latest is None` guard, on the one path that actually reaches it.
+
+    An ordinary stale read returns from the background-refresh branch long before the
+    cold path, so it exercises nothing here. Only `refresh=1` — the Refresh button —
+    skips that branch and arrives with a cached value in hand, and it must hand that
+    value back rather than park a worker for a slot it does not need.
+    """
+    monkeypatch.setattr(api, "_compute_semaphore", threading.BoundedSemaphore(1))
+    monkeypatch.setattr(api, "_COMPUTE_WAIT_SECONDS", 30.0)
+    api._cache["refresh-key"] = (datetime.now().timestamp(), "cached")
+
+    assert api._compute_semaphore.acquire(blocking=False)  # hold the only slot
+    try:
+        started = time.monotonic()
+        value = api.get_cached_or_fetch(
+            "refresh-key", _slow_fetch(5, "new"), force_refresh=True
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        api._compute_semaphore.release()
+
+    assert value == "cached"
+    assert elapsed < 2.0, "a caller holding a value must not wait for a compute slot"
+
+
+def test_an_ordinary_stale_read_still_returns_immediately(monkeypatch):
+    """Guards the pre-existing fast path the test above used to be mistaken for."""
+    monkeypatch.setattr(api, "_compute_semaphore", threading.BoundedSemaphore(1))
+    monkeypatch.setattr(api, "_COMPUTE_WAIT_SECONDS", 30.0)
+    api._cache["stale-key"] = (datetime.now().timestamp() - (api.CACHE_TTL + 10), "old")
+
+    assert api._compute_semaphore.acquire(blocking=False)
+    try:
+        started = time.monotonic()
+        assert api.get_cached_or_fetch("stale-key", _slow_fetch(5, "new")) == "old"
+        assert time.monotonic() - started < 2.0
+    finally:
+        api._compute_semaphore.release()
+
+
+def test_a_cold_request_gives_up_after_the_wait_and_reports_backpressure(monkeypatch):
+    """The timed acquire timing out — the new failure path.
+
+    The waiter-cap test short-circuits before `acquire(timeout=...)` is ever called,
+    so without this the give-up branch is unexercised.
+    """
+    monkeypatch.setattr(api, "_compute_semaphore", threading.BoundedSemaphore(1))
+    monkeypatch.setattr(api, "_COMPUTE_WAIT_SECONDS", 0.3)
+    monkeypatch.setattr(api, "_COMPUTE_MAX_WAITERS", 4)
+
+    assert api._compute_semaphore.acquire(blocking=False)  # never released in time
+    try:
+        started = time.monotonic()
+        with pytest.raises(api.CacheBackpressureError):
+            api.get_cached_or_fetch("never-free", _slow_fetch(0.01, "v"))
+        elapsed = time.monotonic() - started
+    finally:
+        api._compute_semaphore.release()
+
+    assert elapsed >= 0.3, "it must actually wait the budget before giving up"
+    assert elapsed < 5.0
+
+
+def test_the_waiter_cap_still_fails_fast(monkeypatch):
+    """A pathological burst must not park unbounded worker threads."""
+    monkeypatch.setattr(api, "_compute_semaphore", threading.BoundedSemaphore(1))
+    monkeypatch.setattr(api, "_COMPUTE_WAIT_SECONDS", 30.0)
+    monkeypatch.setattr(api, "_COMPUTE_MAX_WAITERS", 0)
+
+    assert api._compute_semaphore.acquire(blocking=False)
+    try:
+        with pytest.raises(api.CacheBackpressureError):
+            api.get_cached_or_fetch("burst", _slow_fetch(0.01, "v"))
+    finally:
+        api._compute_semaphore.release()
+
+
+def test_the_waiter_count_returns_to_zero_after_a_timeout(monkeypatch):
+    """Without the decrement the counter ratchets until every cold request is refused.
+
+    The waiter-cap test cannot catch that: it sets the cap to 0, which returns before
+    the counter is ever touched. Here the cap is 1, so a leaked increment would make
+    the SECOND attempt bail out instantly instead of waiting its budget.
+    """
+    monkeypatch.setattr(api, "_compute_semaphore", threading.BoundedSemaphore(1))
+    monkeypatch.setattr(api, "_COMPUTE_WAIT_SECONDS", 0.2)
+    monkeypatch.setattr(api, "_COMPUTE_MAX_WAITERS", 1)
+    assert api._compute_waiters == 0
+
+    assert api._compute_semaphore.acquire(blocking=False)  # never freed
+    try:
+        for attempt in range(3):
+            started = time.monotonic()
+            with pytest.raises(api.CacheBackpressureError):
+                api.get_cached_or_fetch(f"ratchet-{attempt}", _slow_fetch(0.01, "v"))
+            assert time.monotonic() - started >= 0.2, (
+                f"attempt {attempt} was refused without waiting: "
+                "the waiter count did not return to zero"
+            )
+    finally:
+        api._compute_semaphore.release()
+    assert api._compute_waiters == 0
+
+
+def test_a_background_stale_refresh_never_waits(monkeypatch):
+    """The opportunistic refresh already has a value to serve, so it must not park."""
+    monkeypatch.setattr(api, "_compute_semaphore", threading.BoundedSemaphore(1))
+    monkeypatch.setattr(api, "_COMPUTE_WAIT_SECONDS", 30.0)
+    assert api._compute_semaphore.acquire(blocking=False)
+    try:
+        started = time.monotonic()
+        assert api._acquire_compute_slot(wait=False) is False
+        assert time.monotonic() - started < 1.0
+    finally:
+        api._compute_semaphore.release()
+
+
+def test_the_default_concurrency_scales_with_cores_and_is_bounded(monkeypatch):
+    for cores, expected in [(1, 2), (2, 2), (4, 2), (8, 4), (16, 8), (24, 8), (128, 8)]:
+        monkeypatch.setattr(api, "_available_cpus", lambda cores=cores: cores)
+        assert api._default_compute_concurrency() == expected, cores
+
+
+def test_available_cpus_prefers_the_affinity_mask_over_the_host_count(monkeypatch):
+    """os.cpu_count() reports the whole host — wrong for a pinned process."""
+    monkeypatch.setattr(api.os, "process_cpu_count", None, raising=False)
+    monkeypatch.setattr(api.os, "sched_getaffinity", lambda _pid: set(range(4)))
+    monkeypatch.setattr(api.os, "cpu_count", lambda: 64)
+    monkeypatch.setattr(api, "_cgroup_cpu_quota", lambda: None)
+    assert api._available_cpus() == 4
+
+
+def test_a_cgroup_quota_caps_the_cpu_count(monkeypatch):
+    """The docstring's own case: a 2-CPU container on a big host.
+
+    A quota is not an affinity mask, so without this the container would report the
+    host's cores and take 8 concurrent parses.
+    """
+    monkeypatch.setattr(api.os, "process_cpu_count", None, raising=False)
+    monkeypatch.setattr(api.os, "sched_getaffinity", lambda _pid: set(range(64)))
+    monkeypatch.setattr(api.os, "cpu_count", lambda: 64)
+    monkeypatch.setattr(api, "_cgroup_cpu_quota", lambda: 2)
+    assert api._available_cpus() == 2
+
+
+def test_a_quota_lowers_the_resulting_concurrency(monkeypatch):
+    """The quota must change the ANSWER, not just the CPU count.
+
+    Asserting concurrency == 2 under a 2-CPU quota proves nothing: the max(2, ...)
+    floor returns 2 for any count <= 4 whether the quota was respected or ignored.
+    An 8-CPU quota giving 4 IS distinguishable from the 8 an unquota'd host returns.
+    """
+    monkeypatch.setattr(api.os, "process_cpu_count", None, raising=False)
+    monkeypatch.setattr(api.os, "sched_getaffinity", lambda _pid: set(range(64)))
+    monkeypatch.setattr(api.os, "cpu_count", lambda: 64)
+
+    monkeypatch.setattr(api, "_cgroup_cpu_quota", lambda: None)
+    assert api._default_compute_concurrency() == 8, "unquota'd 64-core host"
+
+    monkeypatch.setattr(api, "_cgroup_cpu_quota", lambda: 8)
+    assert api._default_compute_concurrency() == 4, "the quota must lower it"
+
+
+def _cgroup_tree(tmp_path, root_cpu_max: str, leaf_cpu_max: str | None = None):
+    """A fake cgroup v2 root, with the process in /system.slice/tokdash.service."""
+    root = tmp_path / "cgroup"
+    leaf = root / "system.slice" / "tokdash.service"
+    leaf.mkdir(parents=True)
+    (root / "cpu.max").write_text(root_cpu_max, encoding="utf-8")
+    if leaf_cpu_max is not None:
+        (leaf / "cpu.max").write_text(leaf_cpu_max, encoding="utf-8")
+    proc = tmp_path / "self-cgroup"
+    proc.write_text("0::/system.slice/tokdash.service\n", encoding="utf-8")
+    return root, proc
+
+
+def test_a_quota_on_the_processes_own_subcgroup_is_found(tmp_path):
+    """The systemd CPUQuota= case: the root says "max", the unit's own cgroup caps it.
+
+    `tokdash setup` installs a systemd unit, so this is a real deployment shape, not a
+    hypothetical — reading only the root would miss it entirely.
+    """
+    root, proc = _cgroup_tree(tmp_path, "max 100000\n", "400000 100000\n")
+    assert api._cgroup_cpu_quota(root, proc) == 4
+
+
+def test_the_most_restrictive_cgroup_level_wins(tmp_path):
+    root, proc = _cgroup_tree(tmp_path, "800000 100000\n", "200000 100000\n")
+    assert api._cgroup_cpu_quota(root, proc) == 2
+
+
+def test_a_namespaced_container_quota_at_the_root_is_found(tmp_path):
+    """docker --cpus=2: the cgroup is namespaced, so the root carries the limit."""
+    root, proc = _cgroup_tree(tmp_path, "200000 100000\n")
+    assert api._cgroup_cpu_quota(root, proc) == 2
+
+
+def test_an_unlimited_cgroup_reports_no_quota(tmp_path):
+    root, proc = _cgroup_tree(tmp_path, "max 100000\n", "max 100000\n")
+    assert api._cgroup_cpu_quota(root, proc) is None
+
+
+def test_a_missing_cgroup_tree_reports_no_quota(tmp_path):
+    missing = tmp_path / "absent"
+    assert api._cgroup_cpu_quota(missing, missing) is None
+
+
+def test_a_v1_quota_on_the_processes_own_subcgroup_is_found(tmp_path):
+    """v1 has the same sub-cgroup shape, so the walk must apply there too."""
+    missing = tmp_path / "absent"
+    base = tmp_path / "cpu"
+    unit = base / "system.slice" / "tokdash.service"
+    unit.mkdir(parents=True)
+    (base / "cpu.cfs_quota_us").write_text("-1\n", encoding="utf-8")  # root unlimited
+    (base / "cpu.cfs_period_us").write_text("100000\n", encoding="utf-8")
+    (unit / "cpu.cfs_quota_us").write_text("300000\n", encoding="utf-8")
+    (unit / "cpu.cfs_period_us").write_text("100000\n", encoding="utf-8")
+    proc = tmp_path / "self-cgroup"
+    proc.write_text("4:cpu,cpuacct:/system.slice/tokdash.service\n", encoding="utf-8")
+
+    assert api._cgroup_cpu_quota(missing, proc, base) == 3
+
+
+def test_the_legacy_v1_quota_is_still_read(tmp_path):
+    missing = tmp_path / "absent"
+    v1 = tmp_path / "v1"
+    v1.mkdir()
+    (v1 / "cpu.cfs_quota_us").write_text("400000\n", encoding="utf-8")
+    (v1 / "cpu.cfs_period_us").write_text("100000\n", encoding="utf-8")
+    assert api._cgroup_cpu_quota(missing, missing, v1) == 4
+
+    (v1 / "cpu.cfs_quota_us").write_text("-1\n", encoding="utf-8")  # unlimited
+    assert api._cgroup_cpu_quota(missing, missing, v1) is None
+
+
+def test_the_waiter_allowance_is_derived_from_the_concurrency():
+    """Computing + parked threads share one budget, so an override cannot starve
+    AnyIO's pool — the failure the compute cap exists to prevent.
+
+    Checked as a function of an explicit budget rather than against the imported
+    constants: those depend on the ambient machine and on whatever TOKDASH_* the runner
+    exports, so an assertion over them passes under a wrong formula too.
+    """
+    assert api._default_max_waiters(2, 32) == 30
+    assert api._default_max_waiters(8, 32) == 24
+    assert api._default_max_waiters(31, 32) == 1
+    assert api._default_max_waiters(32, 32) == 0
+    assert api._default_max_waiters(64, 32) == 0, "never negative"
+
+
+def test_the_wait_budget_rejects_infinity_and_clamps(monkeypatch):
+    monkeypatch.setenv("TOKDASH_COMPUTE_WAIT_SECONDS", "inf")
+    assert api._bounded_float_env("TOKDASH_COMPUTE_WAIT_SECONDS", 15.0, maximum=120.0) == 15.0
+    monkeypatch.setenv("TOKDASH_COMPUTE_WAIT_SECONDS", "nan")
+    assert api._bounded_float_env("TOKDASH_COMPUTE_WAIT_SECONDS", 15.0, maximum=120.0) == 15.0
+    monkeypatch.setenv("TOKDASH_COMPUTE_WAIT_SECONDS", "9999")
+    assert api._bounded_float_env("TOKDASH_COMPUTE_WAIT_SECONDS", 15.0, maximum=120.0) == 120.0
+    monkeypatch.setenv("TOKDASH_COMPUTE_WAIT_SECONDS", "2.5")
+    assert api._bounded_float_env("TOKDASH_COMPUTE_WAIT_SECONDS", 15.0, maximum=120.0) == 2.5
+
+
+def test_the_daily_warm_minute_honours_zero_and_rejects_out_of_range(monkeypatch):
+    """Midnight-exactly is a legitimate setting, and a bad value must not wrap."""
+    monkeypatch.setenv("TOKDASH_DAILY_WARM_MINUTE", "0")
+    assert api._daily_warm_minute() == 0
+    monkeypatch.setenv("TOKDASH_DAILY_WARM_MINUTE", "1445")
+    assert api._daily_warm_minute() == 5, "1445 must not wrap to 00:05's neighbour"
+    monkeypatch.setenv("TOKDASH_DAILY_WARM_MINUTE", "90")
+    assert api._daily_warm_minute() == 90
+    monkeypatch.setenv("TOKDASH_DAILY_WARM_MINUTE", "-1")
+    assert api._daily_warm_minute() == 5
+
+
+def test_an_explicit_env_override_still_wins(monkeypatch):
+    monkeypatch.setenv("TOKDASH_COMPUTE_CONCURRENCY", "3")
+    assert api._positive_int_env("TOKDASH_COMPUTE_CONCURRENCY", api._default_compute_concurrency()) == 3
+
+
+# --- the scheduled warm -------------------------------------------------------
+
+def test_the_daily_warm_fires_just_after_local_midnight():
+    for now, expected in [
+        ("2026-08-31 23:50", "2026-09-01 00:05"),
+        ("2026-08-31 00:01", "2026-08-31 00:05"),
+        ("2026-08-31 12:00", "2026-09-01 00:05"),
+    ]:
+        current = datetime.fromisoformat(now).astimezone()
+        fires_at = current + timedelta(seconds=api._seconds_until_daily_warm(current))
+        assert fires_at.strftime("%Y-%m-%d %H:%M") == expected
+
+
+def test_the_daily_warm_never_returns_a_zero_delay():
+    """A zero would spin the loop; the target is always pushed to the next day."""
+    at_target = datetime.fromisoformat("2026-08-31 00:05").astimezone()
+    assert api._seconds_until_daily_warm(at_target) > 1.0
+
+
+def test_the_daily_warm_fills_yesterdays_keys_and_not_todays(monkeypatch):
+    today = api._local_today()
+    yesterday = (today - timedelta(days=1)).isoformat()
+
+    monkeypatch.setattr(api, "compute_usage_with_comparison", lambda p, f, t: {"d": t})
+    monkeypatch.setattr(api, "get_sessions_data", lambda tool, p, f, t, **kw: {"tool": tool})
+    monkeypatch.setattr(api, "get_active_time_data", lambda p, f, t, **kw: {"d": t})
+
+    api._warm_previous_day()
+
+    for key, _ in api._day_warm_targets(yesterday):
+        assert key in api._cache, f"yesterday's key was not warmed: {key}"
+    # Today holds almost nothing at 00:05; warming it would put a near-empty
+    # snapshot in front of the morning's first request.
+    for key, _ in api._day_warm_targets(today.isoformat()):
+        assert key not in api._cache
+
+
+def test_a_request_after_the_daily_warm_is_served_from_cache(monkeypatch):
+    """Pin the contract through the route, not by re-deriving keys with the helpers.
+
+    Asserting the warmer's own key helpers match the warmer proves nothing; what
+    matters is that a real Yesterday request lands on what was warmed, so a drift
+    between warmer and route shows up here as a miss.
+    """
+    from fastapi.testclient import TestClient
+
+    yesterday = (api._local_today() - timedelta(days=1)).isoformat()
+    computes: list[tuple] = []
+
+    def fake_usage(period, date_from, date_to):
+        computes.append((date_from, date_to))
+        return {"total_tokens": 1}
+
+    monkeypatch.setattr(api, "compute_usage_with_comparison", fake_usage)
+    monkeypatch.setattr(api, "get_sessions_data", lambda tool, p, f, t, **kw: {"tool": tool})
+    monkeypatch.setattr(api, "get_active_time_data", lambda p, f, t, **kw: {"d": t})
+
+    api._warm_previous_day()
+    assert computes == [(yesterday, yesterday)]
+
+    with TestClient(api.app) as client:
+        body = client.get(f"/api/usage?date_from={yesterday}&date_to={yesterday}").json()
+
+    assert body["response_cache"]["status"] == "hit", "the warm did not land on the route's key"
+    assert computes == [(yesterday, yesterday)], "the request recomputed despite the warm"
+
+
+def test_stats_is_warmed_second_behind_the_overview_usage_key(monkeypatch):
+    """Composing by name must keep the dashboard's order; slicing let it drift."""
+    order: list[str] = []
+    monkeypatch.setattr(api, "_run_warmers", lambda warmers, **kw: order.extend(k for k, _ in warmers))
+    monkeypatch.setattr(api, "compute_stats", lambda _year=None: {})
+
+    api._warm_caches()
+
+    today = api._local_today().isoformat()
+    assert order[0] == api._usage_warm_target(today)[0]
+    assert order[1] == api._window_cache_key("stats_None", None, None)
+    assert order[2:-1] == [key for key, _ in api._session_warm_targets(today)]
+    assert order[-1] == api._day_scoped_key(api.ACTIVITY_INSIGHTS_CACHE_KEY)
+
+
+def test_the_daily_warm_join_is_shorter_than_the_startup_one():
+    """A warm on a live server must not impose the startup join on a racing request.
+
+    That request pays the join AND then up to _COMPUTE_WAIT_SECONDS for a slot, so the
+    startup allowance on top would outlast most browser timeouts.
+    """
+    assert api.DAILY_WARM_JOIN_SECONDS < api.STARTUP_WARM_JOIN_SECONDS
+
+
+def test_a_warm_carries_its_own_join_budget():
+    event = api._begin_startup_warm("budget-key", 3.0)
+    try:
+        claimed = api._claim_startup_warm_wait("budget-key")
+        assert claimed is not None
+        assert claimed[0] is event
+        assert claimed[1] == 3.0
+    finally:
+        api._finish_startup_warm("budget-key", event)
+    assert api._claim_startup_warm_wait("budget-key") is None
+
+
+def test_a_testclient_block_leaves_no_warm_thread_running():
+    """conftest's no_background_warmers must hold: _lifespan has no shutdown side, so a
+    thread started here would outlive the block with the test's patches long gone."""
+    from fastapi.testclient import TestClient
+
+    before = {t.name for t in threading.enumerate()}
+    with TestClient(api.app) as client:
+        client.get("/health")
+    leaked = {t.name for t in threading.enumerate()} - before
+    assert not {name for name in leaked if name.startswith("tokdash-")}, leaked

--- a/tests/test_overload_resilience.py
+++ b/tests/test_overload_resilience.py
@@ -325,7 +325,14 @@ def test_failed_inflight_compute_does_not_poison_later_retry():
 
 
 def test_heavy_compute_semaphore_bounds_concurrency(monkeypatch):
-    """Distinct cold keys over the cap fail fast instead of blocking workers."""
+    """Distinct cold keys over the cap queue for a slot; the cap is never exceeded.
+
+    These used to fail fast, which was safe while a cold key almost always had a stale
+    value to serve meanwhile. Once a closed date range has to be computed to be correct,
+    the Sessions tab's one-request-per-tool fan-out is all cold keys at once, and
+    refusing everything past the cap rejected most of the tab. What must still hold is
+    the cap itself: waiting may not let a third heavy compute run.
+    """
     monkeypatch.setattr(api, "_compute_semaphore", threading.BoundedSemaphore(2))
     counter_lock = threading.Lock()
     state = {"cur": 0, "peak": 0}
@@ -357,10 +364,9 @@ def test_heavy_compute_semaphore_bounds_concurrency(monkeypatch):
     release.set()
     for t in threads:
         t.join(timeout=5)
-    assert state["peak"] == 2
-    assert results == ["v"] * 2
-    assert len(errors) == 4
-    assert all(isinstance(e, api.CacheBackpressureError) for e in errors)
+    assert state["peak"] == 2  # queueing must not raise the ceiling
+    assert results == ["v"] * 6, "a cold fan-out must drain rather than be refused"
+    assert errors == []
 
 
 def test_positive_int_env_defaults_and_validation(monkeypatch):


### PR DESCRIPTION
## Problem

Switching to a date range nothing has computed fails most of the Sessions tab.

That tab issues one request per tool, so a cold range asks for **~17 distinct keys at once**. A request that couldn't take a heavy-compute slot was refused outright rather than queued. Measured against a running server:

| Scenario | Before | After |
|---|---|---|
| 15 concurrent cold `/api/sessions` | **13 × instant 503**, 2 succeed | **15/15 in 3.7s** |
| Fully warm | 27ms | 27ms |

The dashboard retries a 503 only three times (~450ms/~900ms backoff), so with 15 tools needing ~8 rounds against a cap of 2, most panels gave up. Individual computes were only ~1s — nothing was slow except the queueing policy.

Refusing was safe while a cold key almost always had a stale value to serve meanwhile. It stopped being safe in 2.4.2, once a closed window had to actually be computed to be correct.

## Fix

A cold request **with nothing to show** now waits briefly for a slot (`TOKDASH_COMPUTE_WAIT_SECONDS`, default 15s, clamped to 120), bounded by a waiter allowance so a burst can't park the whole worker pool. A stale value or a background refresh still answers immediately and never waits. **The concurrency cap is unchanged**, so the parser stampede and RSS ceiling it protects are too.

The wait holds the per-key lock, which lengthens the window where a repeat of the *same* key is refused as `same_key_inflight`. Deliberate and commented: releasing the lock to wait would let several threads compute one cold key, which is what single-flight exists to prevent.

**Cap scaling** — now derived from the CPUs the process may actually use (affinity mask + cgroup quota, walking from the process's own sub-cgroup to the root, since a systemd unit's `CPUQuota=` lives there and `tokdash setup` installs such a unit), from a fixed 2 up to 8. Running and waiting requests share one thread budget (`TOKDASH_COMPUTE_THREAD_BUDGET`, default 32), so raising `TOKDASH_COMPUTE_CONCURRENCY` spends the waiter allowance instead of starving AnyIO's pool.

**Daily warm** — yesterday's 17 keys are warmed just after the local date rolls over (`TOKDASH_DAILY_WARM_MINUTE`, default 5; `TOKDASH_DAILY_WARM=0` disables). Today is deliberately not warmed then: it holds almost nothing at 00:05, and warming it would put a near-empty snapshot in front of the morning's first request.

## Also in this release

`b2027e7` (#54), the Hermes named-profile scan, which landed after the v2.4.2 tag and was sitting under `Unreleased`. Its changelog entry moves into 2.4.3.

## Tests

New `tests/test_cold_fanout_backpressure.py` (31 tests). Each of the load-bearing ones was checked by mutation — break the code, confirm the test fails, restore:

- fan-out drains; cap still never exceeded while waiting
- the `wait=latest is None` guard, via the `force_refresh` path that actually reaches it
- the timed acquire timing out (the give-up branch)
- the waiter counter returning to zero (a dropped decrement ratchets until everything is refused)
- CPU detection: affinity over host count, cgroup v2 and v1 sub-cgroup quotas, most-restrictive-wins
- the 00:05 schedule, and env knobs rejecting `inf`/out-of-range while honouring `0`

`tests/conftest.py` gains `no_background_warmers`: `_lifespan` has no shutdown side, so a warm thread outlived the `TestClient` block that started it, and a suite run straddling the warm minute would fire a real full-history warm mid-run.

`test_heavy_compute_semaphore_bounds_concurrency` changes contract — it asserted cold keys over the cap fail fast. Both `peak == 2` assertions still pass, so the cap invariant holds; only the fail-fast outcome changed, and it now asserts the fan-out drains.

Full suite: 1635 passed, 4 skipped locally.

## Known flake, not from this change

`test_quota_performance.py::test_quota_history_route_bounded_and_fast_on_100k_rows` is a wall-clock threshold (1.0s) that tipped to 1.078s on a loaded dev box (load average ~6.9; suite wall time 115s → 148s). It passes 3/3 in isolation, and `get_quota_history` bypasses the response cache entirely, so this diff cannot reach it. Flagging rather than hiding it; CI is the real gate.