### PR TITLE
Fix Refresh reporting success while serving cached data

### DIFF
--- a/src/tokdash/api.py
+++ b/src/tokdash/api.py
@@ -1114,10 +1114,27 @@ def _refresh_stale_in_background(
     fetch_fn,
     lock: threading.Lock,
     epoch: int,
+    *,
+    wait_for_slot: bool = False,
 ) -> None:
+    """Recompute ``key`` off the request path. Owns ``lock`` and always releases it.
+
+    ``wait_for_slot`` picks which failure is worse when the compute cap is full:
+
+    - False (opportunistic stale-while-revalidate): give up instantly. A value was
+      already handed to the caller and the next read schedules another attempt, so
+      parking a thread buys nothing.
+    - True (the compute-cap handoff below): the caller's own non-blocking acquire
+      just failed, and it is returning stale with no compute in flight for this key.
+      Refusing again would leave nothing recomputing it, so repeated Refresh clicks
+      could never make progress. Waiting here costs a daemon thread, not a request
+      worker. ``_acquire_compute_slot`` still enforces ``_COMPUTE_MAX_WAITERS``, so a
+      burst cannot park an unbounded number of them — and where that cap is 0 this
+      degrades back to an instant deferral rather than overrunning the thread budget.
+    """
     acquired_compute = False
     try:
-        acquired_compute = _acquire_compute_slot(wait=False)
+        acquired_compute = _acquire_compute_slot(wait=wait_for_slot)
         if not acquired_compute:
             logger.debug("tokdash stale refresh deferred key=%s reason=compute_cap", key)
             return
@@ -1131,6 +1148,35 @@ def _refresh_stale_in_background(
         if acquired_compute:
             _compute_semaphore.release()
         _release_key_lock(key, lock)
+
+
+def _schedule_stale_refresh(
+    key: str,
+    fetch_fn,
+    lock: threading.Lock,
+    epoch: int,
+    *,
+    wait_for_slot: bool = False,
+) -> bool:
+    """Hand ``lock`` to a daemon that recomputes ``key``.
+
+    Returns True when the daemon owns the key lock from here on, False when the
+    thread never started and the caller still has to release it. Never releases the
+    lock itself: ``_release_key_lock`` raises on an already-unlocked mutex, so a
+    single owner at every moment is what keeps the two exits from colliding.
+    """
+    try:
+        threading.Thread(
+            target=_refresh_stale_in_background,
+            args=(key, fetch_fn, lock, epoch),
+            kwargs={"wait_for_slot": wait_for_slot},
+            name="tokdash-cache-refresh",
+            daemon=True,
+        ).start()
+        return True
+    except Exception:
+        logger.warning("tokdash failed to start stale refresh key=%s", key, exc_info=True)
+        return False
 
 
 def get_cached_or_fetch(
@@ -1174,16 +1220,8 @@ def get_cached_or_fetch(
                 _release_key_lock(key, lock)
                 return result(latest[1], "hit", locked_now - latest[0])
             epoch = _cache_epoch_value()
-            try:
-                threading.Thread(
-                    target=_refresh_stale_in_background,
-                    args=(key, fetch_fn, lock, epoch),
-                    name="tokdash-cache-refresh",
-                    daemon=True,
-                ).start()
-            except Exception:
+            if not _schedule_stale_refresh(key, fetch_fn, lock, epoch):
                 _release_key_lock(key, lock)
-                logger.warning("tokdash failed to start stale refresh key=%s", key, exc_info=True)
         return result(hit[1], "stale", now - hit[0])
 
     lock, acquired = _try_key_lock(key)
@@ -1216,6 +1254,7 @@ def get_cached_or_fetch(
             had_stale=False,
             warn=not _startup_warm,
         )
+    handed_off = False
     try:
         # Re-check under the lock: a prior holder may have just stored a fresh value.
         latest = _cache_get(key)
@@ -1236,6 +1275,22 @@ def get_cached_or_fetch(
         # to prevent.
         if not _acquire_compute_slot(wait=latest is None):
             if latest is not None:
+                # Return the cached value now — a caller holding a value must never
+                # park a request worker for a slot — but hand this key's single-flight
+                # lock to a background recompute first. Returning bare left NOTHING
+                # computing this key and nothing scheduled, so `refresh=1` could be
+                # clicked forever and only ever get the same body back. The daemon does
+                # the waiting the request refuses to do.
+                #
+                # This widens the same_key_inflight window the NOTE above weighs, but
+                # not for anyone: reaching here requires a cached value, and every
+                # concurrent caller for a key that HAS one (plain read or forced
+                # refresh) is served that value off the failed _try_key_lock rather
+                # than refused. Only a cold key 503s there, and a cold key cannot
+                # reach this branch.
+                handed_off = _schedule_stale_refresh(
+                    key, fetch_fn, lock, epoch, wait_for_slot=True
+                )
                 return result(latest[1], "stale", locked_now - latest[0])
             _raise_backpressure(
                 "Too many cold requests; retry shortly",
@@ -1251,7 +1306,8 @@ def get_cached_or_fetch(
         _cache_set_if_epoch(key, fresh, epoch)
         return result(fresh, "recomputed", 0.0)
     finally:
-        _release_key_lock(key, lock)
+        if not handed_off:
+            _release_key_lock(key, lock)
 
 
 def _format_pricing_db(data: Dict[str, Any]) -> str:

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -352,6 +352,8 @@
     }
     .refresh-report[data-status="preserved"] .refresh-report-mark,
     .refresh-report[data-status="partial"] .refresh-report-mark,
+    .refresh-report[data-status="cached"] .refresh-report-mark,
+    .refresh-report[data-status="cachedPreserved"] .refresh-report-mark,
     .refresh-report[data-status="failed"] .refresh-report-mark {
       color: #B45309;
       background: color-mix(in srgb, #D97706 13%, transparent);
@@ -4061,6 +4063,21 @@
       ['by_tool','apps','coding_apps'].forEach(mergeObject);
       ['coding_models','top_models','openclaw_models','combined_models'].forEach(mergeArray);
       out.timestamp = rows.map((row) => row.timestamp).filter(Boolean).sort()[0] || null;
+      // response_cache rides in on the rows[0] deep copy above and is otherwise never
+      // re-derived, so a combined view reported the FIRST server's freshness for
+      // everyone's data — the refresh report could read "complete" off a recomputed
+      // rows[0] while displaying rows[1]'s older cached body. Merge it like every
+      // other field, on the same weakest-link rule out.timestamp just used: cached if
+      // ANY server was served cache, aged by the oldest body in the mix. `status` is
+      // deliberately dropped — it describes one fetch, and nothing reads it here.
+      const cacheMetas = rows.map((row) => row.response_cache).filter(Boolean);
+      if (cacheMetas.length) {
+        const ages = cacheMetas.map((meta) => Number(meta.age_seconds)).filter(Number.isFinite);
+        out.response_cache = {
+          served_from_cache: cacheMetas.some((meta) => !!meta.served_from_cache),
+          age_seconds: ages.length ? Math.max(...ages) : null,
+        };
+      }
       out.comparison = { ...(out.comparison || {}) };
       [['cost','total_cost'],['tokens','total_tokens'],['messages','total_messages']].forEach(([prefix, totalField]) => {
         const prevField = `${prefix}_prev`;
@@ -4328,6 +4345,9 @@
         refreshReportPreserved: 'Refresh complete · previous data kept',
         refreshReportPartial: 'Refresh incomplete',
         refreshReportFailed: 'Refresh failed · previous data kept',
+        refreshReportCached: 'Nothing refreshed · served from cache',
+        refreshReportCachedAge: 'cached data {age} old',
+        refreshReportCachedPreserved: 'Nothing refreshed · served from cache · previous data kept',
         refreshReportTokens: 'Tokens',
         refreshReportCost: 'Cost',
         refreshReportMessages: 'Messages',
@@ -4725,6 +4745,9 @@
         refreshReportPreserved: '刷新完成 · 已保留旧数据',
         refreshReportPartial: '刷新不完整',
         refreshReportFailed: '刷新失败 · 已保留旧数据',
+        refreshReportCached: '未刷新 · 返回的是缓存',
+        refreshReportCachedAge: '缓存数据已有 {age}',
+        refreshReportCachedPreserved: '未刷新 · 返回的是缓存 · 已保留旧数据',
         refreshReportTokens: 'Tokens',
         refreshReportCost: '费用',
         refreshReportMessages: '消息数',
@@ -5123,6 +5146,9 @@
         refreshReportPreserved: 'スキャン完了 · 前回のデータを保持',
         refreshReportPartial: 'スキャン不完全',
         refreshReportFailed: 'スキャン失敗 · 前回のデータを保持',
+        refreshReportCached: 'スキャン未実行 · キャッシュを返しました',
+        refreshReportCachedAge: 'キャッシュは {age} 前のデータ',
+        refreshReportCachedPreserved: 'スキャン未実行 · キャッシュを返しました · 前回のデータを保持',
         refreshReportTokens: 'トークン',
         refreshReportCost: 'コスト',
         refreshReportMessages: 'メッセージ数',
@@ -5521,6 +5547,9 @@
         refreshReportPreserved: '스캔 완료 · 이전 데이터 유지',
         refreshReportPartial: '스캔 불완전',
         refreshReportFailed: '스캔 실패 · 이전 데이터 유지',
+        refreshReportCached: '스캔 안 함 · 캐시를 반환했습니다',
+        refreshReportCachedAge: '캐시 데이터 {age} 경과',
+        refreshReportCachedPreserved: '스캔 안 함 · 캐시를 반환했습니다 · 이전 데이터 유지',
         refreshReportTokens: '토큰',
         refreshReportCost: '비용',
         refreshReportMessages: '메시지',
@@ -5919,6 +5948,9 @@
         refreshReportPreserved: 'Escaneo completo · se conservaron los datos anteriores',
         refreshReportPartial: 'Escaneo incompleto',
         refreshReportFailed: 'Fallo del escaneo · se conservaron los datos anteriores',
+        refreshReportCached: 'Sin escaneo · datos de la caché',
+        refreshReportCachedAge: 'datos en caché de hace {age}',
+        refreshReportCachedPreserved: 'Sin escaneo · datos de la caché · se conservaron los datos anteriores',
         refreshReportTokens: 'Tokens',
         refreshReportCost: 'Coste',
         refreshReportMessages: 'Mensajes',
@@ -6317,6 +6349,9 @@
         refreshReportPreserved: 'Varredura completa · dados anteriores mantidos',
         refreshReportPartial: 'Varredura incompleta',
         refreshReportFailed: 'Varredura falhou · dados anteriores mantidos',
+        refreshReportCached: 'Sem varredura · dados do cache',
+        refreshReportCachedAge: 'dados em cache de {age} atrás',
+        refreshReportCachedPreserved: 'Sem varredura · dados do cache · dados anteriores mantidos',
         refreshReportTokens: 'Tokens',
         refreshReportCost: 'Custo',
         refreshReportMessages: 'Mensagens',
@@ -7357,16 +7392,48 @@
       });
       const retained = Array.isArray(details.retained) ? details.retained : [];
       const unavailable = Array.isArray(details.unavailable) ? details.unavailable : [];
+      // A refresh the server answered out of its response cache did not refresh
+      // anything. The backend already says so (response_cache.served_from_cache, set
+      // for both `hit` and `stale`); reporting `complete` over it is the lie this
+      // panel used to tell while the timestamp beside it said "cached".
+      const cacheMeta = after?.response_cache || null;
+      const servedFromCache = !!cacheMeta?.served_from_cache;
+      // Only a FORCED refresh can be "you asked for work and got none". An automatic
+      // five-minute tick answered from cache is the TTL doing its job, and both `hit`
+      // and `stale` set served_from_cache — so gating on that flag alone reopened this
+      // panel, in amber, on essentially every tick of a healthy dashboard. The panel
+      // opens on ticks too (shouldReportRefresh only needs a previous payload), so the
+      // flag is not enough on its own to tell "refused work" from "cache working".
+      const cachedDespiteRequest = !!details.forced && servedFromCache;
+      // `preserved` cannot simply outrank `cached`: it reads "Refresh complete ·
+      // previous data kept", so it claims completion in its first two words. When a
+      // cached body ALSO retained rows both facts are true and the user needs both,
+      // so they compose into one title instead of one shadowing the other. `partial`
+      // and `failed` already say plainly that nothing completed, so they still win.
       const status = details.failed
         ? 'failed'
         : unavailable.length
           ? 'partial'
           : retained.length
-            ? 'preserved'
-            : 'complete';
+            ? (cachedDespiteRequest ? 'cachedPreserved' : 'preserved')
+            : cachedDespiteRequest
+              ? 'cached'
+              : 'complete';
+      // The age describes the body being reported as cached, so it follows the
+      // VERDICT rather than the flag. Keyed off cachedDespiteRequest it outlived the
+      // ladder into `failed` and `partial`, and the panel appended "cached data 1h 11m
+      // old" to a refresh that had errored — the same class of lie as the bug this all
+      // started with. On the failure path `after` IS the previous payload, so that age
+      // is doubly wrong: nothing was served from cache, and the number is whatever was
+      // recorded at the last good load. `>= 1` still guards the note itself, since a
+      // sub-second age stays reachable on a genuinely cached forced refresh.
+      const rawAge = Number(cacheMeta?.age_seconds);
+      const ageSeconds = (status === 'cached' || status === 'cachedPreserved')
+        && Number.isFinite(rawAge) ? rawAge : null;
       return {
         status,
         baseline,
+        ageSeconds,
         windowKey: details.windowKey || '',
         rangeLabel: details.rangeLabel || '',
         completedAt: details.completedAt || new Date().toISOString(),
@@ -7411,15 +7478,21 @@
         preserved: 'refreshReportPreserved',
         partial: 'refreshReportPartial',
         failed: 'refreshReportFailed',
+        cached: 'refreshReportCached',
+        cachedPreserved: 'refreshReportCachedPreserved',
       };
       document.getElementById('refreshReportTitle').textContent = t(titleKeys[report.status] || 'refreshReportComplete');
       const completed = new Date(report.completedAt);
       const time = Number.isNaN(completed.getTime())
         ? ''
         : completed.toLocaleTimeString(langLocale(), { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-      document.getElementById('refreshReportMeta').textContent = t('refreshReportRange')
+      const meta = t('refreshReportRange')
         .replace('{range}', report.rangeLabel || refreshReportRangeLabel())
         .replace('{time}', time);
+      const ageNote = Number.isFinite(report.ageSeconds) && report.ageSeconds >= 1
+        ? t('refreshReportCachedAge').replace('{age}', formatDuration(report.ageSeconds * 1000))
+        : '';
+      document.getElementById('refreshReportMeta').textContent = ageNote ? `${meta} · ${ageNote}` : meta;
       document.getElementById('refreshReportTokens').textContent = signedRefreshValue(report.tokens, (value) => formatTokenCount(value));
       document.getElementById('refreshReportCost').textContent = signedRefreshValue(report.cost, (value) => formatCurrency(value));
       document.getElementById('refreshReportMessages').textContent = signedRefreshValue(report.messages, (value) => formatNumber(value));
@@ -8865,6 +8938,7 @@
           const scan = lastUsageResponse?._scan_reconciliation || {};
           showUsageRefreshReport(buildUsageRefreshReport(previousUsageForReport, lastUsageResponse, {
             failed: !!usageFetchError,
+            forced: forceRefresh,
             windowKey,
             rangeLabel: reportRangeLabel,
             retained: scan.retained,
@@ -8895,6 +8969,7 @@
           const scan = usageReconciliation || reconcileUsageRows([], windowKey, usageServers);
           showUsageRefreshReport(buildUsageRefreshReport(previousUsageForReport, previousUsageForReport, {
             failed: true,
+            forced: forceRefresh,
             windowKey,
             rangeLabel: reportRangeLabel,
             retained: scan.retained,

--- a/tests/test_cold_fanout_backpressure.py
+++ b/tests/test_cold_fanout_backpressure.py
@@ -24,11 +24,28 @@ pytest.importorskip("fastapi")
 import tokdash.api as api
 
 
+def _drain_compute_waiters(timeout: float = 10.0) -> None:
+    """Let a test's queued recompute stop counting as a waiter before the next starts.
+
+    The compute-cap handoff hands the key lock to a `tokdash-cache-refresh` daemon,
+    so a test can now end while one is still parked for a slot — and a parked daemon
+    holds a `_compute_waiters` increment that the counter assertions further down read
+    as a leak. It is released the moment the test frees the slot, so this is normally
+    a single comparison. The bound only stops a wedged daemon from hanging the suite;
+    it asserts nothing, so such a daemon costs 10s of teardown and is caught by the
+    counter assertions in the tests that follow, not by this helper.
+    """
+    deadline = time.monotonic() + timeout
+    while api._compute_waiters and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+
 @pytest.fixture(autouse=True)
 def _reset(monkeypatch):
     monkeypatch.setenv("TOKDASH_WARM_ON_START", "0")
     api._clear_cache()
     yield
+    _drain_compute_waiters()
     api._clear_cache()
 
 
@@ -119,6 +136,85 @@ def test_a_refresh_over_a_cached_value_never_waits_for_a_slot(monkeypatch):
 
     assert value == "cached"
     assert elapsed < 2.0, "a caller holding a value must not wait for a compute slot"
+
+
+def test_a_capped_refresh_returns_at_once_but_leaves_a_recompute_queued(monkeypatch):
+    """The other half of the contract above: not waiting must not mean not working.
+
+    Returning the cached value instantly is right, but the request used to return
+    with NOTHING computing this key and nothing scheduled — the compute cap is the
+    one branch where no other thread is already filling it. Refresh could then be
+    clicked forever and only ever hand back the same body. The instant return stays;
+    a daemon now inherits the key lock and does the waiting the request refuses to do.
+    """
+    monkeypatch.setattr(api, "_compute_semaphore", threading.BoundedSemaphore(1))
+    monkeypatch.setattr(api, "_COMPUTE_WAIT_SECONDS", 30.0)
+    monkeypatch.setattr(api, "_COMPUTE_MAX_WAITERS", 4)
+    api._cache["queued-key"] = (datetime.now().timestamp(), "cached")
+
+    computed = threading.Event()
+
+    def fetch():
+        computed.set()
+        return "fresh"
+
+    assert api._compute_semaphore.acquire(blocking=False)  # hold the only slot
+    try:
+        started = time.monotonic()
+        value = api.get_cached_or_fetch("queued-key", fetch, force_refresh=True)
+        elapsed = time.monotonic() - started
+    finally:
+        api._compute_semaphore.release()
+
+    assert value == "cached"
+    assert elapsed < 2.0, "the queued recompute must not be paid for on the request path"
+    assert computed.wait(timeout=10), "the capped refresh scheduled no recompute"
+
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and api._cache["queued-key"][1] != "fresh":
+        time.sleep(0.01)
+    assert api._cache["queued-key"][1] == "fresh", "the queued recompute never reached the cache"
+
+
+def test_a_queued_refresh_respects_the_waiter_cap_and_frees_the_key_lock(monkeypatch):
+    """With no waiter allowance the daemon must give up at once and hand the lock back.
+
+    _COMPUTE_MAX_WAITERS is `budget - concurrency`, so it is 0 whenever concurrency is
+    raised to the thread budget — a shipped configuration, not a hypothetical. The
+    queued refresh has to survive being refused, because it holds the key's
+    single-flight lock and a leak there wedges the key until the process restarts.
+    """
+    monkeypatch.setattr(api, "_compute_semaphore", threading.BoundedSemaphore(1))
+    monkeypatch.setattr(api, "_COMPUTE_WAIT_SECONDS", 30.0)
+    monkeypatch.setattr(api, "_COMPUTE_MAX_WAITERS", 0)
+    api._cache["capped-key"] = (datetime.now().timestamp(), "cached")
+
+    calls = []
+
+    def fetch():
+        calls.append(1)
+        return "fresh"
+
+    assert api._compute_semaphore.acquire(blocking=False)
+    try:
+        started = time.monotonic()
+        assert api.get_cached_or_fetch("capped-key", fetch, force_refresh=True) == "cached"
+        assert time.monotonic() - started < 2.0
+
+        # Still holding the only slot, so the daemon can only get one by parking —
+        # which the cap forbids. It must refuse instantly and release the key lock.
+        lock = api._key_locks.get("capped-key")
+        assert lock is not None
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and lock.locked():
+            time.sleep(0.01)
+        assert not lock.locked(), "the queued refresh parked past the waiter cap or leaked the key lock"
+        assert not calls, "a refusal must not run the fetch"
+    finally:
+        api._compute_semaphore.release()
+
+    # Lock handed back: the key is computable again rather than wedged as in-flight.
+    assert api.get_cached_or_fetch("capped-key", fetch, force_refresh=True) == "fresh"
 
 
 def test_an_ordinary_stale_read_still_returns_immediately(monkeypatch):

--- a/tests/test_usage_refresh_frontend.py
+++ b/tests/test_usage_refresh_frontend.py
@@ -39,6 +39,7 @@ def _run(tmp_path: Path, script: str) -> dict:
             "function reconcileUsageRows(rows, windowKey, servers = selectedServers(), cache = lastUsageRowsByServer) {",
             "function usageToolFingerprint(entry) {",
             "function buildUsageRefreshReport(before, after, details = {}) {",
+            "function combineUsagePayloads(list) {",
         )
     )
     harness = tmp_path / "refresh.js"
@@ -176,3 +177,204 @@ def test_refresh_report_is_accessible_and_the_scan_stays_incremental() -> None:
     assert updater.count("if (shouldReportRefresh) {") == 2
     assert html.count("hideUsageRefreshReport({ focusButton: true, dismissed: true });") == 2
     assert "localStorage" not in reconcile
+
+
+def test_refresh_report_calls_a_cached_response_cached_not_complete(tmp_path: Path) -> None:
+    """The reported bug: `refresh=1` answered from cache still read "Refresh complete".
+
+    The backend flags it on every cached path (`served_from_cache` is true for both
+    `hit` and `stale`), and the timestamp beside the panel already said "cached" —
+    only this report ignored it. It also has to keep `age_seconds`, which shipped in
+    the same object and was thrown away.
+    """
+    out = _run(
+        tmp_path,
+        """
+const before = { total_tokens: 10, total_cost: 1, total_messages: 2, by_tool: {} };
+const cachedAfter = {
+  total_tokens: 10, total_cost: 1, total_messages: 2, by_tool: {},
+  response_cache: { status: 'stale', served_from_cache: true, age_seconds: 4300 },
+};
+const freshAfter = {
+  total_tokens: 12, total_cost: 1, total_messages: 3, by_tool: {},
+  response_cache: { status: 'recomputed', served_from_cache: false, age_seconds: 0 },
+};
+const noMetaAfter = { total_tokens: 12, total_cost: 1, total_messages: 3, by_tool: {} };
+// The Refresh button. `{}` is the timer tick and is pinned by its own test below.
+const forced = (extra = {}) => ({ forced: true, ...extra });
+const oneRetainedRow = [{ server: { id: 'local' }, reason: 'source-errors', sources: ['codex'] }];
+const cached = buildUsageRefreshReport(before, cachedAfter, forced());
+const recomputed = buildUsageRefreshReport(before, freshAfter, forced());
+const noMeta = buildUsageRefreshReport(before, noMetaAfter, forced());
+const failed = buildUsageRefreshReport(before, cachedAfter, forced({ failed: true, error: 'boom' }));
+const retainedCached = buildUsageRefreshReport(before, cachedAfter, forced({ retained: oneRetainedRow }));
+const retainedFresh = buildUsageRefreshReport(before, freshAfter, forced({ retained: oneRetainedRow }));
+const unavailableCached = buildUsageRefreshReport(before, cachedAfter, forced({ unavailable: oneRetainedRow }));
+process.stdout.write(JSON.stringify({
+  cached: [cached.status, cached.ageSeconds],
+  recomputed: [recomputed.status, recomputed.ageSeconds],
+  noMeta: [noMeta.status, noMeta.ageSeconds],
+  failed: [failed.status, failed.ageSeconds],
+  retainedCached: [retainedCached.status, retainedCached.ageSeconds],
+  retainedFresh: retainedFresh.status,
+  unavailableCached: [unavailableCached.status, unavailableCached.ageSeconds],
+}));
+""",
+    )
+
+    assert out == {
+        # A forced refresh handed a 4300-second-old body must say both things.
+        "cached": ["cached", 4300],
+        "recomputed": ["complete", None],
+        # An older server that ships no response_cache stays on the old verdict.
+        "noMeta": ["complete", None],
+        # `preserved` is NOT one of these: it reads "Refresh complete · previous
+        # data kept", so it claims completion. Cached + retained composes instead,
+        # because both facts are true and the user needs both.
+        "retainedCached": ["cachedPreserved", 4300],
+        "retainedFresh": "preserved",
+        # These two say plainly that nothing completed, so they still outrank cached —
+        # and the age must follow the verdict out, or the panel appends "cached data
+        # 1h 11m old" to a refresh that errored and was never served from cache.
+        "failed": ["failed", None],
+        "unavailableCached": ["partial", None],
+    }
+
+
+def test_the_cached_status_is_wired_into_the_panel_and_every_locale() -> None:
+    """A status with no titleKeys entry falls back to 'Refresh complete' — the bug."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    for status in ("cached", "cachedPreserved"):
+        assert f"{status}: 'refreshReport" in html, f"{status} has no title key"
+        assert f'.refresh-report[data-status="{status}"]' in html, f"{status} has no styling"
+    assert html.count("refreshReportCached:") == 6
+    assert html.count("refreshReportCachedAge:") == 6
+    assert html.count("refreshReportCachedPreserved:") == 6
+    assert "refreshReportCached: 'Nothing refreshed · served from cache'" in html
+    # The composed title must not inherit "Refresh complete" from refreshReportPreserved.
+    assert "refreshReportCachedPreserved: 'Nothing refreshed · served from cache · previous data kept'" in html
+    # The age note must follow the age, not one status name, or the composed status
+    # silently loses it. showUsageRefreshReport is DOM-bound, so this is pinned here.
+    assert "const ageNote = Number.isFinite(report.ageSeconds) && report.ageSeconds >= 1" in html, (
+        "formatDuration renders '—' below half a second, so a sub-second age would "
+        "read 'cached data — old'"
+    )
+    # The verdict is only honest if the builder is told whether work was requested.
+    updater = _extract_js_function(
+        html,
+        "async function updateDashboard(customDays = null, dateFrom = null, dateTo = null, options = {}) {",
+    )
+    assert updater.count("forced: forceRefresh,") == 2, "both report call sites must pass the flag"
+    assert "Refresh complete" not in html.split("refreshReportCachedPreserved:")[1].split("\n")[0]
+
+
+def test_combined_payloads_merge_response_cache_instead_of_inheriting_row_zero(tmp_path: Path) -> None:
+    """Multi-server: the cached verdict must cover every row, not just rows[0].
+
+    combineUsagePayloads deep-copies rows[0] and then re-derives every field that
+    matters — totals summed, timestamp taken from the oldest row. response_cache was
+    not among them, so a recomputed rows[0] beside a cache-served rows[1] reported
+    "complete" while the panel displayed rows[1]'s older timestamp. It merges on the
+    same weakest-link rule the timestamp uses.
+    """
+    out = _run(
+        tmp_path,
+        """
+const fresh = (n, ts) => ({
+  total_tokens: n, total_cost: 0, total_messages: 0, by_tool: {}, timestamp: ts,
+  response_cache: { status: 'recomputed', served_from_cache: false, age_seconds: 0 },
+});
+const stale = (n, ts, age) => ({
+  total_tokens: n, total_cost: 0, total_messages: 0, by_tool: {}, timestamp: ts,
+  response_cache: { status: 'stale', served_from_cache: true, age_seconds: age },
+});
+const bare = (n, ts) => ({ total_tokens: n, total_cost: 0, total_messages: 0, by_tool: {}, timestamp: ts });
+const meta = (payload) => {
+  const cache = payload.response_cache;
+  return cache ? [!!cache.served_from_cache, cache.age_seconds] : null;
+};
+const before = { total_tokens: 0, total_cost: 0, total_messages: 0, by_tool: {} };
+
+// rows[0] recomputed, rows[1] served cache: the old copy inherited rows[0] and lied.
+const mixed = combineUsagePayloads([fresh(5, '2026-09-01T10:00:00Z'), stale(7, '2026-09-01T09:00:00Z', 4300)]);
+// Both cached: the age is the oldest body in the mix, not the first one.
+const bothCached = combineUsagePayloads([stale(5, '2026-09-01T10:00:00Z', 60), stale(7, '2026-09-01T09:00:00Z', 4300)]);
+const bothFresh = combineUsagePayloads([fresh(5, '2026-09-01T10:00:00Z'), fresh(7, '2026-09-01T09:00:00Z')]);
+// An older server sends no response_cache at all; unknown must not read as cached.
+const noMeta = combineUsagePayloads([bare(5, '2026-09-01T10:00:00Z'), bare(7, '2026-09-01T09:00:00Z')]);
+const single = combineUsagePayloads([stale(5, '2026-09-01T10:00:00Z', 4300)]);
+
+process.stdout.write(JSON.stringify({
+  mixed: meta(mixed),
+  mixedTotal: mixed.total_tokens,
+  mixedTimestamp: mixed.timestamp,
+  mixedStatus: buildUsageRefreshReport(before, mixed, { forced: true }).status,
+  bothCached: meta(bothCached),
+  bothFresh: meta(bothFresh),
+  bothFreshStatus: buildUsageRefreshReport(before, bothFresh, { forced: true }).status,
+  noMeta: meta(noMeta),
+  single: meta(single),
+}));
+""",
+    )
+
+    assert out == {
+        # Any server served from cache makes the combined body a cached one.
+        "mixed": [True, 4300],
+        # The rest of the merge is untouched: totals still sum, timestamp still oldest.
+        "mixedTotal": 12,
+        "mixedTimestamp": "2026-09-01T09:00:00Z",
+        "mixedStatus": "cached",
+        "bothCached": [True, 4300],
+        "bothFresh": [False, 0],
+        "bothFreshStatus": "complete",
+        # No row claims a cache, so the combined body claims none either.
+        "noMeta": None,
+        # The single-row fast path returns the row verbatim, cache metadata included.
+        "single": [True, 4300],
+    }
+
+
+def test_an_automatic_refresh_tick_served_from_cache_stays_complete(tmp_path: Path) -> None:
+    """The cached verdict is about refused work, not about the cache being used.
+
+    shouldReportRefresh only needs a previous payload, so the panel reopens on every
+    five-minute tick, and after the first successful load essentially every tick is
+    answered from cache — both `hit` and `stale` set served_from_cache. Deriving the
+    verdict from that flag alone therefore repainted the panel amber, reading "nothing
+    refreshed", while the TTL was simply doing its job. Only a forced refresh can be
+    "you asked for work and got none".
+    """
+    out = _run(
+        tmp_path,
+        """
+const before = { total_tokens: 10, total_cost: 1, total_messages: 2, by_tool: {} };
+const body = (age) => ({
+  total_tokens: 10, total_cost: 1, total_messages: 2, by_tool: {},
+  response_cache: { status: 'hit', served_from_cache: true, age_seconds: age },
+});
+const retainedRow = [{ server: { id: 'local' }, reason: 'source-errors', sources: ['codex'] }];
+const report = (details) => buildUsageRefreshReport(before, body(120), details);
+process.stdout.write(JSON.stringify({
+  // A timer tick: same cached body, no forced flag.
+  tick: [report({}).status, report({}).ageSeconds],
+  tickRetained: report({ retained: retainedRow }).status,
+  // Identical body, but the user pressed Refresh.
+  clicked: [report({ forced: true }).status, report({ forced: true }).ageSeconds],
+  clickedRetained: report({ forced: true, retained: retainedRow }).status,
+  // An explicit false must behave like an absent flag, not like a forced refresh.
+  explicitFalse: report({ forced: false }).status,
+}));
+""",
+    )
+
+    assert out == {
+        # The cache doing its job is not a warning, and carries no age note.
+        "tick": ["complete", None],
+        "tickRetained": "preserved",
+        # The same body the user actually asked to have refreshed is.
+        "clicked": ["cached", 120],
+        "clickedRetained": "cachedPreserved",
+        "explicitFalse": "complete",
+    }


### PR DESCRIPTION
Clicking Refresh could report 刷新完成 with an unchanged, hours-old timestamp and the (缓存) marker beside it — the panel claiming success while nothing had been recomputed.

Two separate defects.

## Backend: the compute-cap path scheduled nothing

`get_cached_or_fetch` returns the cached body instantly when a forced refresh finds the heavy-compute cap full. That part is deliberate and stays — a caller holding a value must not park a request worker for a slot. But it returned with *nothing* computing that key and nothing queued, so Refresh could be clicked forever and only ever hand back the same body.

The request now hands its single-flight key lock to a daemon that does the waiting it refuses to do. `_acquire_compute_slot` still enforces `_COMPUTE_MAX_WAITERS`, so this degrades to an instant deferral where that cap is 0.

The same-key contention path is untouched: a compute is already in flight there, and the caller simply isn't the one who gets it.

## Frontend: the report ignored `response_cache`

`buildUsageRefreshReport` derived its verdict from `failed`/`unavailable`/`retained` only, so a cache-served response read "Refresh complete" while `updateTimestamp`, reading the same object, appended "(cached)".

- Derive the verdict from `served_from_cache`.
- Compose `cached` with `preserved` rather than ranking them. `preserved` reads "Refresh complete · previous data kept" — it claims completion in its first two words, so it cannot outrank `cached`. Both facts are true when they co-occur and the user needs both.
- Gate both on a forced refresh. Every 5-minute tick is answered from cache once the dashboard is warm (both `hit` and `stale` set the flag), and the panel reopens on ticks — gating on the flag alone repainted it amber saying "nothing refreshed" while the TTL was simply working.
- Carry `age_seconds`, keyed off the verdict so it cannot leak onto a `failed` or `partial` report.
- Merge `response_cache` in `combineUsagePayloads` on the same weakest-link rule `out.timestamp` already uses, so a multi-server view reports every row's freshness instead of inheriting `rows[0]`'s.

## Verification

- The two tests that pin the instant-return contract (`test_force_refresh_returns_cached_value_under_same_key_contention`, `test_a_refresh_over_a_cached_value_never_waits_for_a_slot`) pass unmodified — zero deleted lines across `tests/`.
- New coverage: the queued recompute lands in the cache; it respects the waiter cap and never leaks the key lock; the status ladder across the cached × retained × failed × forced matrix; the multi-server merge.
- Full suite green file-by-file in fresh processes: 92 `rc=0`, 1 `rc=5` (`conftest.py`, no tests collected).
