### PR TITLE
Add seeded dense data for dashboard development

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,6 +30,15 @@ Run from source:
 python3 main.py
 ```
 
+For UI work, start the real dashboard against a dense synthetic dataset:
+```bash
+python3 main.py --dev-fixture dense --dev-seed 17
+```
+
+Omit `--dev-seed` for a new dataset on each server start, then copy the printed seed
+to reproduce it. Fixture mode skips the usage and quota background workers, does not
+read local history or credentials, and rejects mutating HTTP requests.
+
 Run tests:
 ```bash
 pytest -q

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,7 +38,10 @@ python3 main.py --dev-fixture dense --dev-seed 17
 Omit `--dev-seed` for a new dataset on each server start, then copy the printed seed
 to reproduce it. Fixture mode skips the usage and quota background workers, does not
 read local history, credentials, pricing overrides, or quota snapshots, and rejects
-mutating HTTP requests.
+mutating HTTP requests. Overview, `/api/tools` and `/api/openclaw` -- header and day
+grid alike -- scale with the window they were asked for and agree about it, and
+`/api/active-time` answers the review-sessions toggle. The session lists are the
+exception: they serve a fixed set of rows whatever window you ask for.
 
 Both flags are only accepted by `serve` — `tokdash export --dev-fixture dense` is a
 usage error rather than a silent export of your real usage. `/api/insights` returns

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -37,7 +37,12 @@ python3 main.py --dev-fixture dense --dev-seed 17
 
 Omit `--dev-seed` for a new dataset on each server start, then copy the printed seed
 to reproduce it. Fixture mode skips the usage and quota background workers, does not
-read local history or credentials, and rejects mutating HTTP requests.
+read local history, credentials, pricing overrides, or quota snapshots, and rejects
+mutating HTTP requests.
+
+Both flags are only accepted by `serve` — `tokdash export --dev-fixture dense` is a
+usage error rather than a silent export of your real usage. `/api/insights` returns
+409 while a fixture is active instead of serving real history to a report consumer.
 
 Run tests:
 ```bash

--- a/src/tokdash/api.py
+++ b/src/tokdash/api.py
@@ -1940,7 +1940,9 @@ def get_active_time(
         from .dev_fixtures import dense_active_time
 
         return dense_active_time(
-            resolve_period(period, date_from, date_to), seed=_dev_fixture_seed()
+            resolve_period(period, date_from, date_to),
+            include_review_sessions,
+            seed=_dev_fixture_seed(),
         )
 
     def fetch():

--- a/src/tokdash/api.py
+++ b/src/tokdash/api.py
@@ -63,6 +63,21 @@ SUPPORTED_BASE_PATHS = ("/tokdash",)
 ACTIVITY_INSIGHTS_CACHE_KEY = "activity_insights_v1"
 
 
+def _dev_fixture_mode(app_obj: Optional[FastAPI] = None) -> str:
+    """Return the explicitly enabled visual-development fixture, if any."""
+    target = app_obj or app
+    return str(getattr(target.state, "dev_fixture", "") or "").strip().lower()
+
+
+def _dev_fixture_seed(app_obj: Optional[FastAPI] = None) -> int:
+    """Return the seed pinned for this fixture server process."""
+    target = app_obj or app
+    try:
+        return int(getattr(target.state, "dev_fixture_seed", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _normalize_public_base_path(value: str | None) -> str:
     raw = (value or "").strip()
     if not raw or raw == "/":
@@ -437,9 +452,12 @@ def _daily_warm_loop() -> None:
 
 @asynccontextmanager
 async def _lifespan(_app: "FastAPI"):
-    if os.environ.get("TOKDASH_WARM_ON_START", "1") != "0":
+    # Fixture mode renders synthetic API payloads and must never start work against
+    # real history in the background. Production behavior is unchanged unless the
+    # explicit CLI switch set app.state.dev_fixture before uvicorn starts.
+    if not _dev_fixture_mode(_app) and os.environ.get("TOKDASH_WARM_ON_START", "1") != "0":
         threading.Thread(target=_warm_caches, name="tokdash-warm", daemon=True).start()
-    if os.environ.get("TOKDASH_DAILY_WARM", "1") != "0":
+    if not _dev_fixture_mode(_app) and os.environ.get("TOKDASH_DAILY_WARM", "1") != "0":
         threading.Thread(target=_daily_warm_loop, name="tokdash-daily-warm", daemon=True).start()
     yield
 
@@ -603,6 +621,11 @@ def mutation_denied_reason(
 
 @app.middleware("http")
 async def _write_guard(request: Request, call_next):
+    if request.method.upper() in _MUTATING_METHODS and _dev_fixture_mode(request.app):
+        return JSONResponse(
+            {"detail": "Writes are disabled while a synthetic development fixture is active."},
+            status_code=409,
+        )
     reason = mutation_denied_reason(request.method, request.headers)
     if reason is not None:
         return JSONResponse({"detail": reason}, status_code=403)
@@ -1527,6 +1550,12 @@ def get_usage(
     refresh: bool = False,
 ) -> Dict[str, Any]:
     _validate_date_params(date_from, date_to)
+    if _dev_fixture_mode() == "dense":
+        from .dev_fixtures import dense_usage
+
+        return dense_usage(
+            resolve_period(period, date_from, date_to), seed=_dev_fixture_seed()
+        )
     try:
         cache_key = _window_cache_key(f"usage_{period}_{date_from}_{date_to}", date_from, date_to)
         return _cached_route(
@@ -1600,6 +1629,10 @@ def get_quota() -> Dict[str, Any]:
     M1 is intentionally local-only: this route never performs provider network I/O.
     """
 
+    if _dev_fixture_mode() == "dense":
+        from .dev_fixtures import dense_quota
+
+        return dense_quota(seed=_dev_fixture_seed())
     try:
         from .sources.quota import quota_state
 
@@ -1623,6 +1656,10 @@ def get_quota_history(
     end: Optional[int] = None,
     max_points: Optional[int] = 300,
 ) -> Dict[str, Any]:
+    if _dev_fixture_mode() == "dense":
+        from .dev_fixtures import dense_quota_history
+
+        return dense_quota_history(granularity, seed=_dev_fixture_seed())
     try:
         from .sources.quota.config import network_enabled
         from .usage_store import UsageEntryStore
@@ -1724,6 +1761,13 @@ def set_quota_settings(payload: Dict[str, Any]) -> Dict[str, Any]:
 # config-write endpoints stay loopback-guarded.
 @app.get("/api/quota/refresh")
 def refresh_quota() -> Dict[str, Any]:
+    if _dev_fixture_mode() == "dense":
+        return {
+            "snapshots": 14,
+            "inserted": 0,
+            "fixture": "dense",
+            "seed": _dev_fixture_seed(),
+        }
     from .sources.quota import config as quota_config
 
     if not quota_config.quota_tracking_enabled():
@@ -1798,6 +1842,12 @@ def get_sessions(
     include_review_sessions: Optional[bool] = None,
 ) -> Dict[str, Any]:
     _validate_date_params(date_from, date_to)
+    if _dev_fixture_mode() == "dense":
+        from .dev_fixtures import dense_sessions
+
+        return dense_sessions(
+            tool, include_review_sessions, seed=_dev_fixture_seed()
+        )
     try:
         cache_key = _session_response_cache_key(
             tool,
@@ -1846,6 +1896,13 @@ def get_active_time(
     Refresh button can clear a stale figure or one missing a tool that failed.
     """
     _validate_date_params(date_from, date_to)
+    if _dev_fixture_mode() == "dense":
+        from .dev_fixtures import dense_active_time
+
+        return dense_active_time(
+            resolve_period(period, date_from, date_to), seed=_dev_fixture_seed()
+        )
+
     def fetch():
         data = get_active_time_data(
             period,
@@ -1880,6 +1937,10 @@ def get_active_time(
 
 @app.get("/api/session")
 def get_session(tool: str, session_id: str) -> Dict[str, Any]:
+    if _dev_fixture_mode() == "dense":
+        from .dev_fixtures import dense_session_detail
+
+        return dense_session_detail(tool, session_id, seed=_dev_fixture_seed())
     try:
         return get_session_detail(tool, session_id)
     except ValueError as e:
@@ -1959,6 +2020,10 @@ async def serve_service_worker(request: Request):
 
 @app.get("/api/stats")
 def get_stats(year: Optional[int] = None) -> Dict[str, Any]:
+    if _dev_fixture_mode() == "dense":
+        from .dev_fixtures import dense_stats
+
+        return dense_stats(year, seed=_dev_fixture_seed())
     try:
         cache_key = _window_cache_key(
             f"stats_{year}", None, f"{year}-12-31" if year else None
@@ -2029,6 +2094,10 @@ def get_insights(
 
 @app.get("/api/activity-insights")
 def get_activity_insights(refresh: bool = False) -> dict[str, Any]:
+    if _dev_fixture_mode() == "dense":
+        from .dev_fixtures import dense_activity_insights
+
+        return dense_activity_insights(seed=_dev_fixture_seed())
     try:
         return _cached_route(
             "/api/activity-insights",
@@ -2075,6 +2144,15 @@ def _read_install_manifest() -> Dict[str, Any]:
 async def get_version() -> Dict[str, Any]:
     # Local-only version info; async to stay responsive like /health. Provenance
     # fields come from the setup manifest when present (Phase 1+), else None.
+    if _dev_fixture_mode() == "dense":
+        return {
+            "service": "tokdash",
+            "runtime_version": __version__,
+            "install_method": "dev-fixture",
+            "update_check_enabled": False,
+            "usage_db_schema_supported": USAGE_DB_SCHEMA_VERSION,
+            "fixture_seed": _dev_fixture_seed(),
+        }
     manifest = _read_install_manifest()
     return {
         "service": "tokdash",

--- a/src/tokdash/api.py
+++ b/src/tokdash/api.py
@@ -1394,12 +1394,8 @@ def _baseline_version() -> Optional[str]:
     return version if isinstance(version, str) else None
 
 
-def _effective_pricing_db() -> tuple[Dict[str, Any], str]:
-    """The effective pricing DB and its source: the override (authoritative full replacement)
-    when present/valid, else the packaged baseline. Raises 404/500 only on a broken baseline."""
-    override = _read_pricing_override()
-    if override is not None:
-        return override, "override"
+def _baseline_pricing_db() -> tuple[Dict[str, Any], str]:
+    """The packaged baseline pricing DB. Raises 404/500 only on a broken baseline."""
     try:
         base = _validate_pricing_db(json.loads(PRICING_DB_PATH.read_text(encoding="utf-8")))
     except FileNotFoundError:
@@ -1407,6 +1403,15 @@ def _effective_pricing_db() -> tuple[Dict[str, Any], str]:
     except JSONDecodeError as e:
         raise HTTPException(status_code=500, detail=f"pricing_db.json is invalid JSON: {e.msg}")
     return base, "baseline"
+
+
+def _effective_pricing_db() -> tuple[Dict[str, Any], str]:
+    """The effective pricing DB and its source: the override (authoritative full replacement)
+    when present/valid, else the packaged baseline. Raises 404/500 only on a broken baseline."""
+    override = _read_pricing_override()
+    if override is not None:
+        return override, "override"
+    return _baseline_pricing_db()
 
 
 def _clear_pricing_signature_cache() -> None:
@@ -1494,6 +1499,19 @@ def _pricing_cache_key(base: str) -> str:
 
 @app.get("/api/pricing-db")
 def get_pricing_db() -> Dict[str, Any]:
+    if _dev_fixture_mode() == "dense":
+        # The packaged baseline is part of the install, not user data, so the
+        # editor still renders. The override under the data dir is neither read
+        # nor disclosed -- its path alone identifies the real user.
+        baseline, _ = _baseline_pricing_db()
+        return {
+            "path": "<dev-fixture: pricing overrides are not read or written>",
+            "baseline_path": str(PRICING_DB_PATH),
+            "baseline_version": _baseline_version(),
+            "source": "dev-fixture",
+            "data": baseline,
+            "text": _format_pricing_db(baseline),
+        }
     data, source = _effective_pricing_db()
     # `path` is where edits PERSIST (the override under the data dir); baseline is read-only.
     # `baseline_version` is the shipped baseline's version even when an override is in effect,
@@ -1578,6 +1596,11 @@ def get_usage(
 
 @app.get("/api/openclaw")
 def get_openclaw(period: str = "today") -> Dict[str, Any]:
+    if _dev_fixture_mode() == "dense":
+        from .dev_fixtures import dense_openclaw
+
+        return dense_openclaw(resolve_period(period), seed=_dev_fixture_seed())
+
     def fetch():
         data = get_openclaw_data(period)
         data["period"] = period
@@ -1601,6 +1624,11 @@ def get_openclaw(period: str = "today") -> Dict[str, Any]:
 @app.get("/api/tools")
 def get_tools(period: str = "today") -> Dict[str, Any]:
     """Coding tools usage (local parsers)."""
+
+    if _dev_fixture_mode() == "dense":
+        from .dev_fixtures import dense_tools
+
+        return dense_tools(resolve_period(period), seed=_dev_fixture_seed())
 
     try:
         def fetch():
@@ -1803,6 +1831,12 @@ def refresh_quota() -> Dict[str, Any]:
 
 @app.get("/api/codex/sessions")
 def get_codex_sessions(period: str = "today", include_review_sessions: Optional[bool] = None) -> Dict[str, Any]:
+    if _dev_fixture_mode() == "dense":
+        from .dev_fixtures import dense_sessions
+
+        return dense_sessions(
+            "codex", include_review_sessions, seed=_dev_fixture_seed()
+        )
     try:
         cache_key = _window_cache_key(
             f"codex_sessions_{period}_{include_review_sessions}", None, None
@@ -1826,6 +1860,12 @@ def get_codex_sessions(period: str = "today", include_review_sessions: Optional[
 @app.get("/api/codex/session")
 def get_codex_session(session_id: str) -> Dict[str, Any]:
     try:
+        if _dev_fixture_mode() == "dense":
+            from .dev_fixtures import dense_session_detail
+
+            return dense_session_detail(
+                "codex", session_id, seed=_dev_fixture_seed()
+            )
         return get_codex_session_detail(session_id)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
@@ -1842,13 +1882,13 @@ def get_sessions(
     include_review_sessions: Optional[bool] = None,
 ) -> Dict[str, Any]:
     _validate_date_params(date_from, date_to)
-    if _dev_fixture_mode() == "dense":
-        from .dev_fixtures import dense_sessions
-
-        return dense_sessions(
-            tool, include_review_sessions, seed=_dev_fixture_seed()
-        )
     try:
+        if _dev_fixture_mode() == "dense":
+            from .dev_fixtures import dense_sessions
+
+            return dense_sessions(
+                tool, include_review_sessions, seed=_dev_fixture_seed()
+            )
         cache_key = _session_response_cache_key(
             tool,
             period,
@@ -1937,11 +1977,11 @@ def get_active_time(
 
 @app.get("/api/session")
 def get_session(tool: str, session_id: str) -> Dict[str, Any]:
-    if _dev_fixture_mode() == "dense":
-        from .dev_fixtures import dense_session_detail
-
-        return dense_session_detail(tool, session_id, seed=_dev_fixture_seed())
     try:
+        if _dev_fixture_mode() == "dense":
+            from .dev_fixtures import dense_session_detail
+
+            return dense_session_detail(tool, session_id, seed=_dev_fixture_seed())
         return get_session_detail(tool, session_id)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -2060,6 +2100,20 @@ def get_insights(
     year is computed once and every later view is a cache hit.
     """
     _validate_date_params(date_from, date_to)
+    if _dev_fixture_mode() == "dense":
+        # Refused rather than synthesized. This route is for external report
+        # consumers, so silently serving real history would defeat the point of
+        # fixture mode -- but its nine facets are a wide enough contract that a
+        # hand-written stand-in would drift from `compute_insights` unnoticed,
+        # which is the same failure the imported rank keys exist to prevent.
+        # An explicit 409 cannot be mistaken for either one.
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "/api/insights is not synthesized in --dev-fixture mode, and real "
+                "usage history is not read while a fixture is active."
+            ),
+        )
     try:
         cache_key = _window_cache_key(
             f"insights_{period}_{date_from}_{date_to}_{facets}_{include_project_names}",

--- a/src/tokdash/cli.py
+++ b/src/tokdash/cli.py
@@ -117,6 +117,18 @@ def build_parser(prog: str) -> argparse.ArgumentParser:
         action="store_true",
         help="Don't automatically open the browser",
     )
+    parser.add_argument(
+        "--dev-fixture",
+        choices=["dense"],
+        default=None,
+        help="Serve seeded synthetic data for visual development (never reads local history)",
+    )
+    parser.add_argument(
+        "--dev-seed",
+        type=int,
+        default=None,
+        help="Reproduce a development fixture dataset with a specific integer seed",
+    )
 
     # Export options
     parser.add_argument(
@@ -252,14 +264,39 @@ def _open_browser(url: str) -> None:
         pass
 
 
-def serve(host: str, port: int, log_level: str, open_browser: bool = True) -> None:
+def serve(
+    host: str,
+    port: int,
+    log_level: str,
+    open_browser: bool = True,
+    dev_fixture: str | None = None,
+    dev_seed: int | None = None,
+) -> None:
     url_host = "localhost" if host in {"0.0.0.0", "::"} else host
     url = f"http://{url_host}:{port}"
     # Tell the app its effective bind/port so the write-protection gate
     # (api._write_guard) can enforce loopback-only mutations and a Host allowlist.
     app.state.bind = host
     app.state.port = port
+    had_fixture_state = hasattr(app.state, "dev_fixture")
+    previous_fixture = getattr(app.state, "dev_fixture", "")
+    had_fixture_seed_state = hasattr(app.state, "dev_fixture_seed")
+    previous_fixture_seed = getattr(app.state, "dev_fixture_seed", 0)
+    fixture_seed = (
+        dev_seed
+        if dev_fixture and dev_seed is not None
+        else random.SystemRandom().randrange(1, 2**32)
+        if dev_fixture
+        else 0
+    )
+    app.state.dev_fixture = dev_fixture or ""
+    app.state.dev_fixture_seed = fixture_seed
     print(f"🚀 Starting Tokdash on {url}")
+    if dev_fixture:
+        print(
+            f"🧪 Development fixture: {dev_fixture} · seed {fixture_seed} "
+            "(synthetic data; local history, credentials, and provider APIs are not read)"
+        )
     if os.environ.get("TOKDASH_NO_RETENTION_NOTICE", "").strip().lower() not in {"1", "true", "yes"}:
         print(
             "ℹ️  Note: Claude Code & Gemini CLI auto-delete sessions older than ~30 days, "
@@ -274,24 +311,36 @@ def serve(host: str, port: int, log_level: str, open_browser: bool = True) -> No
         timer = threading.Timer(1.0, _open_browser, args=(url,))
         timer.daemon = True
         timer.start()
-    _start_usage_db_sync_daemon()
-    # Materialize the credential_scan grandfather once so upgraded installs keep
-    # their existing polling and the persisted consent state is explicit.
-    from .sources.quota import config as quota_config
-    quota_config.ensure_quota_consent_migrated()
-    _start_quota_poll_daemon()
+    if not dev_fixture:
+        _start_usage_db_sync_daemon()
+        # Materialize the credential_scan grandfather once so upgraded installs keep
+        # their existing polling and the persisted consent state is explicit.
+        from .sources.quota import config as quota_config
+
+        quota_config.ensure_quota_consent_migrated()
+        _start_quota_poll_daemon()
     # Backpressure: cap accepted concurrency and keep-alive lifetime so a load burst
     # returns 503 fast instead of queuing forever and wedging the server. The limit
     # sits above the AnyIO worker pool (~40) so cheap cache hits aren't rejected, but
     # is bounded so the connection backlog can't grow without limit.
-    uvicorn.run(
-        app,
-        host=host,
-        port=port,
-        log_level=log_level,
-        limit_concurrency=_positive_int_env("TOKDASH_LIMIT_CONCURRENCY", 64),
-        timeout_keep_alive=_positive_int_env("TOKDASH_KEEPALIVE", 5),
-    )
+    try:
+        uvicorn.run(
+            app,
+            host=host,
+            port=port,
+            log_level=log_level,
+            limit_concurrency=_positive_int_env("TOKDASH_LIMIT_CONCURRENCY", 64),
+            timeout_keep_alive=_positive_int_env("TOKDASH_KEEPALIVE", 5),
+        )
+    finally:
+        if had_fixture_state:
+            app.state.dev_fixture = previous_fixture
+        else:
+            del app.state.dev_fixture
+        if had_fixture_seed_state:
+            app.state.dev_fixture_seed = previous_fixture_seed
+        else:
+            del app.state.dev_fixture_seed
 
 
 def export(period: str, pretty: bool, output: str | None, include_quota: bool = False) -> None:
@@ -963,8 +1012,17 @@ def cli(argv: list[str] | None = None, prog: str = "tokdash") -> int:
         return run_lifecycle(args)
 
     if args.command == "serve":
+        if args.dev_seed is not None and not args.dev_fixture:
+            parser.error("--dev-seed requires --dev-fixture")
         port = args.port if args.port is not None else _default_port()
-        serve(args.bind, port, args.log_level, open_browser=not args.no_open)
+        serve(
+            args.bind,
+            port,
+            args.log_level,
+            open_browser=not args.no_open,
+            dev_fixture=args.dev_fixture,
+            dev_seed=args.dev_seed,
+        )
         return 0
 
     if args.command == "export":

--- a/src/tokdash/cli.py
+++ b/src/tokdash/cli.py
@@ -282,13 +282,12 @@ def serve(
     previous_fixture = getattr(app.state, "dev_fixture", "")
     had_fixture_seed_state = hasattr(app.state, "dev_fixture_seed")
     previous_fixture_seed = getattr(app.state, "dev_fixture_seed", 0)
-    fixture_seed = (
-        dev_seed
-        if dev_fixture and dev_seed is not None
-        else random.SystemRandom().randrange(1, 2**32)
-        if dev_fixture
-        else 0
-    )
+    if not dev_fixture:
+        fixture_seed = 0
+    elif dev_seed is not None:
+        fixture_seed = dev_seed
+    else:
+        fixture_seed = random.SystemRandom().randrange(1, 2**32)
     app.state.dev_fixture = dev_fixture or ""
     app.state.dev_fixture_seed = fixture_seed
     print(f"🚀 Starting Tokdash on {url}")
@@ -333,6 +332,10 @@ def serve(
             timeout_keep_alive=_positive_int_env("TOKDASH_KEEPALIVE", 5),
         )
     finally:
+        # In production uvicorn.run() only returns at shutdown, so this restore is
+        # effectively process teardown. It exists because the test suite calls
+        # serve() in-process with uvicorn.run monkeypatched, and a leaked
+        # app.state.dev_fixture would make every later test serve fixture data.
         if had_fixture_state:
             app.state.dev_fixture = previous_fixture
         else:
@@ -991,6 +994,18 @@ def cli(argv: list[str] | None = None, prog: str = "tokdash") -> int:
     parser = build_parser(prog=prog)
     args = parser.parse_args(argv)
 
+    # Checked before any command dispatch, not inside the serve branch. These live
+    # on the flat top-level parser, so `tokdash export --dev-fixture dense` parses
+    # cleanly -- and used to export the user's REAL usage while looking like it had
+    # opted into synthetic data. Only serve honors them, so only serve accepts them.
+    if args.command != "serve":
+        if args.dev_fixture:
+            parser.error(f"--dev-fixture is only supported by `serve`, not `{args.command}`")
+        if args.dev_seed is not None:
+            parser.error(f"--dev-seed is only supported by `serve`, not `{args.command}`")
+    elif args.dev_seed is not None and not args.dev_fixture:
+        parser.error("--dev-seed requires --dev-fixture")
+
     if args.command == "version":
         print(f"tokdash {__version__}")
         return 0
@@ -1012,8 +1027,6 @@ def cli(argv: list[str] | None = None, prog: str = "tokdash") -> int:
         return run_lifecycle(args)
 
     if args.command == "serve":
-        if args.dev_seed is not None and not args.dev_fixture:
-            parser.error("--dev-seed requires --dev-fixture")
         port = args.port if args.port is not None else _default_port()
         serve(
             args.bind,

--- a/src/tokdash/dev_fixtures.py
+++ b/src/tokdash/dev_fixtures.py
@@ -1,0 +1,808 @@
+"""Seeded synthetic payloads for visual dashboard development.
+
+These fixtures deliberately live above the persistence layer.  They exercise the
+real dashboard renderers without reading or writing local usage history, credentials,
+pricing overrides, or quota snapshots. A fixture seed adds organic variation between
+server starts while keeping every request stable and reproducible within one run.
+"""
+
+from __future__ import annotations
+
+import calendar
+import hashlib
+import math
+import random
+from collections.abc import Mapping
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+TOOL_SPECS = (
+    ("codex", "Codex", ("openai/gpt-5.6-sol", "openai/gpt-5.5", "openai/o4-mini")),
+    (
+        "claude",
+        "Claude Code",
+        (
+            "anthropic/claude-opus-4.1",
+            "anthropic/claude-sonnet-4",
+            "anthropic/claude-haiku-3.5",
+        ),
+    ),
+    (
+        "cursor",
+        "Cursor",
+        ("cursor/composer-2", "anthropic/claude-sonnet-4", "openai/gpt-5.5"),
+    ),
+    (
+        "gemini_cli",
+        "Gemini CLI",
+        ("google/gemini-3-pro", "google/gemini-3-flash", "google/gemini-2.5-pro"),
+    ),
+    (
+        "opencode",
+        "OpenCode",
+        ("openai/gpt-5.5", "anthropic/claude-sonnet-4", "google/gemini-3-flash"),
+    ),
+    (
+        "kimi",
+        "Kimi CLI",
+        ("moonshot/kimi-k2.6", "moonshot/kimi-k2.5", "moonshot/kimi-code"),
+    ),
+    ("grok", "Grok Build", ("xai/grok-code-fast-1", "xai/grok-4.1", "xai/grok-4-mini")),
+    (
+        "cline",
+        "Cline",
+        ("anthropic/claude-sonnet-4", "openai/gpt-5.5", "google/gemini-3-pro"),
+    ),
+    (
+        "qoder",
+        "Qoder IDE",
+        ("qoder/quest-pro", "qoder/quest-fast", "anthropic/claude-sonnet-4"),
+    ),
+    ("zcode", "ZCode", ("zai/glm-5", "zai/glm-4.7", "zai/glm-4.6")),
+    (
+        "workbuddy",
+        "WorkBuddy",
+        ("alibaba/qwen3-coder", "alibaba/qwen3-max", "openai/gpt-5.5"),
+    ),
+    (
+        "reasonix",
+        "Reasonix",
+        ("minimax/minimax-m3", "deepseek/deepseek-v3.2", "moonshot/kimi-k2.6"),
+    ),
+)
+
+SESSION_LABELS = {
+    "codex": "Codex",
+    "claude": "Claude Code",
+    "opencode": "OpenCode",
+    "pi_agent": "Pi",
+    "omp": "omp",
+    "mimo": "Mimo",
+    "kimi": "Kimi",
+    "dsh": "DeepSeek Harness",
+    "reasonix": "Reasonix",
+    "zcode": "ZCode",
+    "kilocode": "Kilo Code",
+    "grok": "Grok Build",
+    "hermes": "Hermes",
+    "antigravity_cli": "Antigravity CLI",
+    "cline": "Cline",
+    "workbuddy": "WorkBuddy",
+    "qoder": "Qoder IDE",
+}
+
+SESSION_MODELS = (
+    "gpt-5.6-sol",
+    "claude-opus-4.1",
+    "gemini-3-pro",
+    "kimi-k2.6",
+    "glm-5",
+    "qwen3-coder",
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _rng(seed: int, namespace: str) -> random.Random:
+    """Return an order-independent RNG for one fixture surface."""
+    digest = hashlib.blake2b(f"{seed}:{namespace}".encode(), digest_size=8).digest()
+    return random.Random(int.from_bytes(digest, "big"))
+
+
+def _days_in_range(range_info: Mapping[str, Any]) -> int:
+    try:
+        return max(1, int(range_info.get("days", 1)))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _model_row(name: str, tokens: int, seed: int) -> dict[str, Any]:
+    input_tokens = int(tokens * (0.10 + (seed % 4) * 0.008))
+    cache_tokens = int(tokens * (0.68 + (seed % 5) * 0.025))
+    output_tokens = max(1, tokens - input_tokens - cache_tokens)
+    messages = max(1, tokens // (72_000 + (seed % 7) * 9_000))
+    cost = round(
+        input_tokens * 0.0000025
+        + output_tokens * 0.0000105
+        + cache_tokens * 0.00000025,
+        6,
+    )
+    return {
+        "name": name,
+        "tokens": tokens,
+        "tokens_in": input_tokens,
+        "tokens_out": output_tokens,
+        "tokens_cache": cache_tokens,
+        "cost": cost,
+        "messages": messages,
+        "cache_hit_rate": round(cache_tokens / (input_tokens + cache_tokens), 4),
+    }
+
+
+def dense_usage(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, Any]:
+    """Return a crowded but internally consistent Overview payload."""
+    days = _days_in_range(range_info)
+    day_scale = max(1.0, min(days, 366) ** 0.82)
+    usage_rng = _rng(
+        seed, f"usage:{range_info.get('period_resolved', 'custom')}:{days}"
+    )
+    apps: dict[str, dict[str, Any]] = {}
+    coding_models: list[dict[str, Any]] = []
+
+    for tool_index, (tool, _label, model_names) in enumerate(TOOL_SPECS):
+        tool_base = int(
+            (154_000_000 - tool_index * 7_400_000)
+            * day_scale
+            * usage_rng.uniform(0.92, 1.08)
+        )
+        raw_shares = [
+            base * usage_rng.uniform(0.95, 1.05) for base in (0.54, 0.29, 0.17)
+        ]
+        share_total = sum(raw_shares)
+        shares = [share / share_total for share in raw_shares]
+        models = [
+            _model_row(
+                model_name,
+                max(1, int(tool_base * shares[model_index])),
+                tool_index * 5 + model_index,
+            )
+            for model_index, model_name in enumerate(model_names)
+        ]
+        tokens = sum(row["tokens"] for row in models)
+        tokens_in = sum(row["tokens_in"] for row in models)
+        tokens_out = sum(row["tokens_out"] for row in models)
+        tokens_cache = sum(row["tokens_cache"] for row in models)
+        app_row = {
+            "tokens": tokens,
+            "tokens_in": tokens_in,
+            "tokens_out": tokens_out,
+            "tokens_cache": tokens_cache,
+            "cost": round(sum(row["cost"] for row in models), 6),
+            "messages": sum(row["messages"] for row in models),
+            "models": models,
+            "cache_hit_rate": round(tokens_cache / (tokens_in + tokens_cache), 4),
+        }
+        apps[tool] = app_row
+        coding_models.extend({"source": tool, **row} for row in models)
+
+    openclaw_models = [
+        _model_row(
+            "openai/gpt-5.5",
+            int(72_000_000 * day_scale * usage_rng.uniform(0.92, 1.08)),
+            101,
+        ),
+        _model_row(
+            "anthropic/claude-sonnet-4",
+            int(49_000_000 * day_scale * usage_rng.uniform(0.92, 1.08)),
+            102,
+        ),
+        _model_row(
+            "google/gemini-3-flash",
+            int(37_000_000 * day_scale * usage_rng.uniform(0.92, 1.08)),
+            103,
+        ),
+    ]
+
+    combined: dict[str, dict[str, Any]] = {}
+    for row in [*coding_models, *openclaw_models]:
+        name = str(row["name"]).split("/")[-1]
+        target = combined.setdefault(
+            name,
+            {
+                "name": name,
+                "tokens": 0,
+                "tokens_in": 0,
+                "tokens_out": 0,
+                "tokens_cache": 0,
+                "cost": 0.0,
+                "messages": 0,
+            },
+        )
+        for key in ("tokens", "tokens_in", "tokens_out", "tokens_cache", "messages"):
+            target[key] += int(row[key])
+        target["cost"] += float(row["cost"])
+
+    combined_models = []
+    for row in combined.values():
+        row["cost"] = round(row["cost"], 6)
+        row["cache_hit_rate"] = round(
+            row["tokens_cache"] / (row["tokens_in"] + row["tokens_cache"]), 4
+        )
+        combined_models.append(row)
+    combined_models.sort(key=lambda row: (-row["tokens"], -row["cost"], row["name"]))
+
+    by_tool = {
+        tool: {
+            "tokens": row["tokens"],
+            "tokens_in": row["tokens_in"],
+            "tokens_cache": row["tokens_cache"],
+            "cost": row["cost"],
+            "cache_hit_rate": row["cache_hit_rate"],
+        }
+        for tool, row in apps.items()
+    }
+    openclaw_total = sum(row["tokens"] for row in openclaw_models)
+    openclaw_input = sum(row["tokens_in"] for row in openclaw_models)
+    openclaw_cache = sum(row["tokens_cache"] for row in openclaw_models)
+    by_tool["openclaw"] = {
+        "tokens": openclaw_total,
+        "tokens_in": openclaw_input,
+        "tokens_cache": openclaw_cache,
+        "cost": round(sum(row["cost"] for row in openclaw_models), 6),
+        "cache_hit_rate": round(openclaw_cache / (openclaw_input + openclaw_cache), 4),
+    }
+
+    total_tokens = sum(row["tokens"] for row in by_tool.values())
+    total_cost = round(sum(row["cost"] for row in by_tool.values()), 2)
+    total_messages = sum(row["messages"] for row in apps.values()) + sum(
+        row["messages"] for row in openclaw_models
+    )
+    previous_factor = usage_rng.uniform(0.86, 1.06)
+    return {
+        "period": range_info.get("period_resolved", "custom"),
+        "range": dict(range_info),
+        "timestamp": _now_iso(),
+        "total_tokens": total_tokens,
+        "total_cost": total_cost,
+        "total_messages": total_messages,
+        "tokens_in": sum(row["tokens_in"] for row in by_tool.values()),
+        "tokens_cache": sum(row["tokens_cache"] for row in by_tool.values()),
+        "cache_hit_rate": round(
+            sum(row["tokens_cache"] for row in by_tool.values())
+            / sum(row["tokens_in"] + row["tokens_cache"] for row in by_tool.values()),
+            4,
+        ),
+        "apps": apps,
+        "coding_apps": apps,
+        "by_tool": by_tool,
+        "coding_models": coding_models,
+        "openclaw_models": openclaw_models,
+        "combined_models": combined_models,
+        "top_models": combined_models[:5],
+        "top_models_by_cost": sorted(
+            combined_models, key=lambda row: (-row["cost"], -row["tokens"])
+        )[:5],
+        "comparison": {
+            "tokens_prev": int(total_tokens * previous_factor),
+            "cost_prev": round(total_cost * previous_factor, 2),
+            "messages_prev": int(total_messages * previous_factor),
+            "tokens_pct": round((1 / previous_factor - 1) * 100, 1),
+            "cost_pct": round((1 / previous_factor - 1) * 100, 1),
+            "messages_pct": round((1 / previous_factor - 1) * 100, 1),
+        },
+        "response_cache": {
+            "served_from_cache": False,
+            "age_seconds": 0.0,
+            "status": "fixture",
+        },
+        "source_errors": [],
+        "fixture": {"name": "dense", "seed": seed},
+    }
+
+
+def _session_row(tool: str, index: int, seed: int = 0) -> dict[str, Any]:
+    row_rng = _rng(seed, f"session:{tool}:{index}")
+    now = datetime.now(timezone.utc)
+    model = SESSION_MODELS[(index + len(tool)) % len(SESSION_MODELS)]
+    tokens = int(
+        (18_400_000 + (index * 4_719_137) + (len(tool) * 817_000))
+        * row_rng.uniform(0.90, 1.10)
+    )
+    tokens_in = int(
+        tokens * (0.10 + (index % 3) * 0.015 + row_rng.uniform(-0.006, 0.006))
+    )
+    tokens_cache = int(
+        tokens * (0.70 + (index % 4) * 0.03 + row_rng.uniform(-0.01, 0.01))
+    )
+    tokens_out = max(1, tokens - tokens_in - tokens_cache)
+    last_seen = now - timedelta(minutes=index * 17 + len(tool) + row_rng.randint(0, 9))
+    started = last_seen - timedelta(minutes=23 + index * 7 + row_rng.randint(0, 12))
+    return {
+        "tool": tool,
+        "session_id": f"{tool}-dense-{index + 1:02d}",
+        "display_name": (
+            "Investigate cross-provider cache reconciliation and responsive table overflow"
+            if index % 4 == 0
+            else f"Dense fixture session {index + 1}: verify model and token breakdown"
+        ),
+        "project": (
+            "customer-analytics-platform-with-an-intentionally-long-project-name"
+            if index % 5 == 0
+            else ("tokdash-design-lab" if index % 2 else "agent-runtime-integration")
+        ),
+        "is_review_session": tool == "codex" and index % 7 == 0,
+        "model": model,
+        "token_events": 84 + index * 31,
+        "tokens_in": tokens_in,
+        "tokens_cache": tokens_cache,
+        "tokens_out": tokens_out,
+        "tokens_reasoning": int(tokens_out * 0.31),
+        "tokens": tokens,
+        "cache_ratio": round(tokens_cache / tokens, 4),
+        "cache_hit_rate": round(tokens_cache / (tokens_in + tokens_cache), 4),
+        "cost": round(
+            tokens_in * 0.0000025 + tokens_out * 0.0000105 + tokens_cache * 0.00000025,
+            6,
+        ),
+        "started_at": started.isoformat(),
+        "last_seen_at": last_seen.isoformat(),
+        "span_ms": int((last_seen - started).total_seconds() * 1000),
+        "active_ms": (19 + index * 3) * 60_000,
+        "active_ms_sum": (27 + index * 5) * 60_000,
+    }
+
+
+def dense_sessions(
+    tool: str, include_review_sessions: bool | None = None, seed: int = 0
+) -> dict[str, Any]:
+    rows = [_session_row(tool, index, seed) for index in range(18)]
+    if tool == "codex" and include_review_sessions is False:
+        rows = [row for row in rows if not row["is_review_session"]]
+    return {
+        "tool": tool,
+        "tool_label": SESSION_LABELS.get(tool, tool.replace("_", " ").title()),
+        "period": "fixture",
+        "include_review_sessions": bool(include_review_sessions),
+        "latest_session": rows[0] if rows else None,
+        "sessions": rows,
+        "summary": {
+            "session_count": len(rows),
+            "tokens": sum(row["tokens"] for row in rows),
+            "cost": round(sum(row["cost"] for row in rows), 6),
+            "active_ms": sum(row["active_ms"] for row in rows),
+            "active_ms_sum": sum(row["active_ms_sum"] for row in rows),
+            "span_ms": sum(row["span_ms"] for row in rows),
+            "active_gap_cap_ms": 300_000,
+            "active_time_estimated": True,
+            "active_time_method": "capped-inter-event-gap",
+        },
+        "timestamp": _now_iso(),
+    }
+
+
+def dense_session_detail(tool: str, session_id: str, seed: int = 0) -> dict[str, Any]:
+    detail_rng = _rng(seed, f"detail:{tool}:{session_id}")
+    session = _session_row(tool, 0, seed)
+    session["session_id"] = session_id
+    start = datetime.fromisoformat(session["started_at"])
+    turns = []
+    for index in range(48):
+        tokens = int(
+            (84_000 + (index * 37_913) % 710_000) * detail_rng.uniform(0.90, 1.10)
+        )
+        row = _model_row(SESSION_MODELS[index % len(SESSION_MODELS)], tokens, index)
+        model_name = row.pop("name")
+        turns.append(
+            {
+                **row,
+                "model": model_name,
+                "tokens_reasoning": int(row["tokens_out"] * 0.28),
+                "turn_index": index + 1,
+                "timestamp": (
+                    start + timedelta(minutes=index * 3, seconds=index * 7)
+                ).isoformat(),
+            }
+        )
+    return {"session": session, "turns": turns, "timestamp": _now_iso()}
+
+
+def dense_active_time(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, Any]:
+    by_tool: dict[str, dict[str, Any]] = {}
+    for index, (tool, label) in enumerate(SESSION_LABELS.items()):
+        row_rng = _rng(seed, f"active:{tool}")
+        by_tool[tool] = {
+            "tool_label": label,
+            "session_count": 16 + row_rng.randint(0, 5),
+            "active_ms": int((215 + index * 19) * row_rng.uniform(0.92, 1.08)) * 60_000,
+            "active_ms_sum": int((328 + index * 31) * row_rng.uniform(0.92, 1.08))
+            * 60_000,
+        }
+    active_ms = sum(row["active_ms"] for row in by_tool.values())
+    active_ms_sum = sum(row["active_ms_sum"] for row in by_tool.values())
+    return {
+        "period": range_info.get("period_resolved", "custom"),
+        "range": dict(range_info),
+        "active_ms": active_ms,
+        "active_ms_sum": active_ms_sum,
+        "comparison": {
+            "active_ms_prev": int(active_ms * 0.88),
+            "active_ms_sum_prev": int(active_ms_sum * 0.91),
+            "active_ms_pct": 13.6,
+            "active_ms_sum_pct": 9.9,
+        },
+        "by_tool": by_tool,
+        "unavailable_tools": [],
+        "active_gap_cap_ms": 300_000,
+        "active_time_estimated": True,
+        "active_time_method": "capped-inter-event-gap",
+        "include_review_sessions": False,
+        "timestamp": _now_iso(),
+    }
+
+
+def _contribution(day: date, seed: int = 0) -> dict[str, Any]:
+    day_rng = _rng(seed, f"stats:{day.isoformat()}")
+    active = day_rng.random() > 0.16
+    tokens = (
+        0
+        if not active
+        else int(day_rng.triangular(22_000_000, 1_390_000_000, 310_000_000))
+    )
+    if active and day_rng.random() < 0.018:
+        tokens += day_rng.randint(800_000_000, 1_180_000_000)
+    input_tokens = int(tokens * day_rng.uniform(0.105, 0.125))
+    cache_tokens = int(tokens * day_rng.uniform(0.715, 0.755))
+    output_tokens = max(0, tokens - input_tokens - cache_tokens)
+    messages = 0 if not active else day_rng.randint(47, 826)
+    cost = round(
+        input_tokens * 0.0000025
+        + output_tokens * 0.0000105
+        + cache_tokens * 0.00000025,
+        6,
+    )
+    sources = []
+    if active:
+        for source_index in range(5):
+            source_tokens = int(
+                tokens * (0.33 - source_index * 0.045) * day_rng.uniform(0.94, 1.06)
+            )
+            sources.append(
+                {
+                    "source": TOOL_SPECS[
+                        (day.toordinal() + source_index) % len(TOOL_SPECS)
+                    ][0],
+                    "modelId": SESSION_MODELS[
+                        (day.toordinal() + source_index) % len(SESSION_MODELS)
+                    ],
+                    "providerId": ("openai", "anthropic", "google", "moonshot", "zai")[
+                        source_index
+                    ],
+                    "tokens": {
+                        "input": int(source_tokens * 0.12),
+                        "output": int(source_tokens * 0.15),
+                        "cacheRead": int(source_tokens * 0.73),
+                        "cacheWrite": 0,
+                        "reasoning": int(source_tokens * 0.025),
+                    },
+                    "cost": round(cost * (0.31 - source_index * 0.035), 6),
+                    "messages": max(1, int(messages * (0.30 - source_index * 0.03))),
+                }
+            )
+    return {
+        "date": day.isoformat(),
+        "totals": {"tokens": tokens, "cost": cost, "messages": messages},
+        "intensity": 0
+        if not active
+        else min(7, 1 + int(math.log10(max(1, tokens / 10_000_000)) * 2)),
+        "tokenBreakdown": {
+            "input": input_tokens,
+            "output": output_tokens,
+            "cacheRead": cache_tokens,
+            "cacheWrite": 0,
+            "reasoning": int(output_tokens * 0.26),
+        },
+        "sources": sources,
+    }
+
+
+def dense_stats(year: int | None = None, seed: int = 0) -> dict[str, Any]:
+    if year is None:
+        end = datetime.now().astimezone().date()
+        start = end - timedelta(days=419)
+    else:
+        start = date(year, 1, 1)
+        end = date(year, 12, 31)
+    contributions = [
+        _contribution(start + timedelta(days=index), seed)
+        for index in range((end - start).days + 1)
+    ]
+    active = [row for row in contributions if row["totals"]["tokens"] > 0]
+    total_tokens = sum(row["totals"]["tokens"] for row in active)
+    total_cost = round(sum(row["totals"]["cost"] for row in active), 6)
+    messages = sum(row["totals"]["messages"] for row in active)
+    return {
+        "stats": {
+            "favorite_model": "gpt-5.6-sol",
+            "most_used_model": "gpt-5.6-sol",
+            "highest_cost_model": "claude-opus-4.1",
+            "total_tokens": total_tokens,
+            "messages": messages,
+            "sessions": messages,
+            "current_streak": 6,
+            "longest_streak": 37,
+            "active_days": len(active),
+            "total_days": len(contributions),
+        },
+        "summary": {
+            "totalTokens": total_tokens,
+            "totalCost": total_cost,
+            "activeDays": len(active),
+            "totalDays": len(contributions),
+        },
+        "contributions": contributions,
+        "meta": {"source": "dev-fixture", "synthetic": True, "seed": seed},
+        "timestamp": _now_iso(),
+    }
+
+
+def dense_activity_insights(seed: int = 0) -> dict[str, Any]:
+    insights_rng = _rng(seed, "activity-insights")
+    tool_names = (
+        "exec",
+        "exec_command",
+        "node_repl/js",
+        "apply_patch",
+        "browser/search",
+        "browser/open",
+        "write_stdin",
+        "wait_agent",
+        "request_user_input",
+        "send_message",
+        "view_image",
+        "open_in_codex",
+        "automation_update",
+        "read_thread",
+        "list_threads",
+        "create_thread",
+        "web/search_query",
+        "web/open",
+    )
+    base_counts = [
+        48_931,
+        22_481,
+        11_307,
+        7_942,
+        5_319,
+        4_877,
+        3_115,
+        2_487,
+        1_936,
+        1_507,
+        1_103,
+        894,
+        629,
+        474,
+        319,
+        207,
+        188,
+        147,
+    ]
+    counts = [int(value * insights_rng.uniform(0.93, 1.07)) for value in base_counts]
+    total_calls = sum(counts)
+    distribution = [
+        {"name": name, "count": count, "share": round(count / total_calls, 6)}
+        for name, count in zip(tool_names, counts)
+    ]
+    reasoning_counts = {
+        "xhigh": int(5_712 * insights_rng.uniform(0.94, 1.06)),
+        "high": int(3_841 * insights_rng.uniform(0.94, 1.06)),
+        "medium": int(1_936 * insights_rng.uniform(0.94, 1.06)),
+        "low": int(812 * insights_rng.uniform(0.94, 1.06)),
+        "ultra": int(307 * insights_rng.uniform(0.94, 1.06)),
+    }
+    reasoning_total = sum(reasoning_counts.values())
+    reasoning_distribution = [
+        {"effort": effort, "count": count, "share": round(count / reasoning_total, 6)}
+        for effort, count in reasoning_counts.items()
+    ]
+    return {
+        "scope": {
+            "tool": "codex",
+            "local": True,
+            "primary_only": True,
+            "synthetic": True,
+        },
+        "recorded_chats": {
+            "value": int(1_284 * insights_rng.uniform(0.96, 1.04)),
+            "coverage": {
+                "primary_files": 1_516,
+                "files_with_session_id": 1_493,
+                "legacy_unavailable_records": 23,
+            },
+        },
+        "reasoning": {
+            "most_used": reasoning_distribution[0],
+            "distribution": reasoning_distribution,
+            "coverage": {
+                "identified_turns": reasoning_total,
+                "known_effort_turns": reasoning_total,
+                "ambiguous_turns": 0,
+                "excluded_records": 11,
+            },
+        },
+        "tools": {
+            "total_calls": total_calls,
+            "most_used": distribution[0],
+            "distribution": distribution,
+            "coverage": {
+                "named_calls": total_calls,
+                "ambiguous_name_calls": 0,
+                "excluded_records": 37,
+            },
+        },
+        "timestamp": _now_iso(),
+    }
+
+
+def dense_quota(seed: int = 0) -> dict[str, Any]:
+    now = int(datetime.now(timezone.utc).timestamp())
+    provider_specs = (
+        ("codex", "Pro", (("5h", "5-hour window", 78.4), ("7d", "7-day window", 63.7))),
+        (
+            "claude",
+            "Max",
+            (("session", "5-hour session", 91.2), ("weekly", "Weekly", 72.9)),
+        ),
+        (
+            "antigravity",
+            "AI Pro",
+            (("pro", "Pro models", 54.3), ("flash", "Flash models", 26.8)),
+        ),
+        (
+            "minimax",
+            "Coding Plan",
+            (("5h", "5-hour window", 18.6), ("weekly", "Weekly", 44.1)),
+        ),
+        (
+            "kimi",
+            "Allegretto",
+            (("5h", "5-hour window", 37.5), ("plan", "Weekly", 81.3)),
+        ),
+        (
+            "grok",
+            "SuperGrok",
+            (("2h", "2-hour window", 69.7), ("monthly", "Monthly", 33.4)),
+        ),
+        (
+            "zai",
+            "GLM Coding Pro",
+            (("5h", "5-hour window", 47.8), ("monthly", "Monthly", 58.9)),
+        ),
+    )
+    providers = {}
+    for provider_index, (provider, plan, bucket_specs) in enumerate(provider_specs):
+        provider_rng = _rng(seed, f"quota:{provider}")
+        buckets = []
+        for bucket_index, (bucket, label, used) in enumerate(bucket_specs):
+            varied_used = round(
+                min(97.0, max(3.0, used + provider_rng.uniform(-4.8, 4.8))), 1
+            )
+            buckets.append(
+                {
+                    "account": "default",
+                    "bucket": bucket,
+                    "bucket_label": label,
+                    "used_percent": varied_used,
+                    "remaining_percent": round(100 - varied_used, 1),
+                    "resets_at": now
+                    + (bucket_index + 1) * 18_000
+                    + provider_index * 2_100,
+                    "captured_at": now - provider_index * 71,
+                    "source": f"{provider}_api",
+                    "status": "ok",
+                    "unlimited": False,
+                }
+            )
+        providers[provider] = {
+            "provider": provider,
+            "network_enabled": True,
+            "plan": plan,
+            "buckets": buckets,
+            "status": "ok" if provider_index not in {3, 5} else "stale",
+            "status_detail": None
+            if provider_index not in {3, 5}
+            else "Last provider response is older than the configured poll interval.",
+            "status_at": now - provider_index * 71,
+            "updated_at": now - provider_index * 71,
+            "sources": [f"{provider}_api"],
+            "estimated": provider == "codex",
+            "detected": True,
+        }
+    return {
+        "providers": providers,
+        "consent": {
+            "credential_scan": False,
+            **{f"{provider}_api": False for provider in providers},
+        },
+        "enabled": True,
+        "poll": {
+            "enabled": True,
+            "network_enabled": False,
+            "interval": 1800,
+            "interval_source": "dev-fixture",
+            "interval_minutes": 30,
+            "interval_choices": [15, 30, 60, 120],
+            "last_run": now,
+            "kill_switch": True,
+        },
+        "timestamp": now,
+    }
+
+
+def dense_quota_history(granularity: str = "hour", seed: int = 0) -> dict[str, Any]:
+    now = int(datetime.now(timezone.utc).timestamp())
+    step = 3600 if granularity == "hour" else 86_400
+    series = []
+    for provider_index, (provider, _plan, bucket_specs) in enumerate(
+        (
+            ("codex", "Pro", (("5h", "5-hour window", 0), ("7d", "7-day window", 0))),
+            (
+                "claude",
+                "Max",
+                (("session", "5-hour session", 0), ("weekly", "Weekly", 0)),
+            ),
+            (
+                "antigravity",
+                "AI Pro",
+                (("pro", "Pro models", 0), ("flash", "Flash models", 0)),
+            ),
+            ("kimi", "Allegretto", (("5h", "5-hour window", 0), ("plan", "Weekly", 0))),
+        )
+    ):
+        for bucket_index, (bucket, label, _value) in enumerate(bucket_specs):
+            series_rng = _rng(seed, f"quota-history:{granularity}:{provider}:{bucket}")
+            phase = series_rng.uniform(0, 17)
+            slope = series_rng.uniform(3.35, 4.05)
+            points = []
+            consumption = []
+            for point_index in range(72):
+                captured_at = now - (71 - point_index) * step
+                used = round(
+                    (
+                        provider_index * 13
+                        + bucket_index * 19
+                        + phase
+                        + point_index * slope
+                    )
+                    % 96,
+                    1,
+                )
+                points.append({"captured_at": captured_at, "used_percent": used})
+                consumption.append(
+                    {
+                        "period_start": captured_at,
+                        "consumed_percent": round(
+                            1.2 + (point_index * 1.7 + phase / 3) % 11,
+                            1,
+                        ),
+                    }
+                )
+            series.append(
+                {
+                    "provider": provider,
+                    "account": "default",
+                    "bucket": bucket,
+                    "bucket_label": label,
+                    "points": points,
+                    "consumption": consumption,
+                    "estimated": provider == "codex",
+                }
+            )
+    return {"granularity": granularity, "series": series, "any_estimated": True}
+
+
+def fixture_year_days(year: int) -> int:
+    """Small public helper used by tests to pin leap-year fixture coverage."""
+    return 366 if calendar.isleap(year) else 365

--- a/src/tokdash/dev_fixtures.py
+++ b/src/tokdash/dev_fixtures.py
@@ -361,46 +361,126 @@ def dense_openclaw(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, An
             row["name"]: {key: value for key, value in row.items() if key != "name"}
             for row in rows
         },
-        "contributions": _openclaw_contributions(range_info, seed),
+        "contributions": _openclaw_contributions(range_info, seed, rows),
         "period": usage["period"],
         "range": dict(range_info),
         "timestamp": _now_iso(),
     }
 
 
-def _openclaw_contributions(
-    range_info: Mapping[str, Any], seed: int
-) -> list[dict[str, Any]]:
-    """Per-day OpenClaw rows over the requested window, never past today."""
+def _effective_span(range_info: Mapping[str, Any]) -> tuple[date, date]:
+    """The part of the requested window that has actually happened.
+
+    A window can run past today -- a custom range with a future `date_to`, or
+    the calendar month -- and production has no events out there, so nothing
+    scaled by the window may reach into it either.
+    """
     today = datetime.now().astimezone().date()
     try:
         end = min(date.fromisoformat(str(range_info.get("to"))), today)
     except (TypeError, ValueError):
         end = today
-    start = end - timedelta(days=max(0, _days_in_range(range_info) - 1))
+    try:
+        start = date.fromisoformat(str(range_info.get("from")))
+    except (TypeError, ValueError):
+        start = end - timedelta(days=max(0, _days_in_range(range_info) - 1))
+    return min(start, end), end
+
+
+def _split_int(total: int, weights: list[float]) -> list[int]:
+    """Split `total` across `weights`; the parts always add back to `total`."""
+    if not weights:
+        raise ValueError("cannot split a total across no weights")
+    weight_total = sum(weights)
+    if total == 0 or weight_total <= 0:
+        parts = [0] * len(weights)
+        parts[0] = total
+        return parts
+    exact = [total * weight / weight_total for weight in weights]
+    # math.floor, not int(): int() truncates toward zero, which would leak a
+    # negative total away instead of distributing it.
+    parts = [math.floor(value) for value in exact]
+    order = sorted(range(len(weights)), key=lambda i: exact[i] - parts[i], reverse=True)
+    for offset in range(total - sum(parts)):
+        parts[order[offset % len(order)]] += 1
+    return parts
+
+
+def _openclaw_contributions(
+    range_info: Mapping[str, Any], seed: int, rows: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Per-day OpenClaw rows over the requested window, never past today.
+
+    Spread from `rows` -- the same model draw behind the header totals and
+    /api/usage's openclaw slice -- so the grid and the totals above it cannot
+    describe different windows. The real producer gets that for free by folding
+    one window-filtered pass of entries into both, and the store-backed path
+    reads both out of a single snapshot for the same reason; drawing the days
+    from their own RNG stream put a header and a chart 40-60% apart.
+    """
+    start, end = _effective_span(range_info)
+    span = [start + timedelta(days=offset) for offset in range((end - start).days + 1)]
+    active = [
+        day
+        for day in span
+        if _rng(seed, f"openclaw-day:{day.isoformat()}").random() >= 0.12
+    ]
+    # Every token in the header has to land on some day.
+    active = active or span[-1:]
+
+    per_day: dict[date, list[dict[str, Any]]] = {day: [] for day in active}
+    for row in rows:
+        model = str(row["name"])
+        row_rng = _rng(seed, f"openclaw-spread:{model}")
+        weights = [row_rng.triangular(0.2, 1.0, 0.55) for _ in active]
+        shares = {
+            key: _split_int(int(row[key]), weights)
+            for key in ("tokens_in", "tokens_out", "tokens_cache", "messages")
+        }
+        # Cost is split in micro-dollars, so the days add back to the row
+        # instead of drifting by a rounding step each.
+        shares["cost"] = _split_int(round(float(row["cost"]) * 1_000_000), weights)
+        for index, day in enumerate(active):
+            tokens_in = shares["tokens_in"][index]
+            tokens_out = shares["tokens_out"][index]
+            tokens_cache = shares["tokens_cache"][index]
+            messages = shares["messages"][index]
+            cost_micros = shares["cost"][index]
+            if not (tokens_in or tokens_out or tokens_cache or messages or cost_micros):
+                continue
+            per_day[day].append(
+                {
+                    "source": "openclaw",
+                    "modelId": model,
+                    "providerId": model.split("/")[0] if "/" in model else "unknown",
+                    "tokens": {
+                        "input": tokens_in,
+                        "output": tokens_out,
+                        "cacheRead": tokens_cache,
+                        "cacheWrite": 0,
+                        "reasoning": 0,
+                    },
+                    "cost": round(cost_micros / 1_000_000, 6),
+                    "messages": messages,
+                }
+            )
 
     days: list[dict[str, Any]] = []
-    for offset in range((end - start).days + 1):
-        day = start + timedelta(days=offset)
-        day_rng = _rng(seed, f"openclaw-day:{day.isoformat()}")
-        if day_rng.random() < 0.12:
+    for day in active:
+        sources = per_day[day]
+        if not sources:
             continue
-        tokens = int(day_rng.triangular(4_000_000, 180_000_000, 41_000_000))
-        tokens_in = int(tokens * 0.12)
-        tokens_cache = int(tokens * 0.73)
-        tokens_out = max(1, tokens - tokens_in - tokens_cache)
-        messages = day_rng.randint(12, 210)
-        cost = round(
-            tokens_in * 0.0000025
-            + tokens_out * 0.0000105
-            + tokens_cache * 0.00000025,
-            6,
-        )
-        model = SESSION_MODELS[day.toordinal() % len(SESSION_MODELS)]
+        tokens_in = sum(row["tokens"]["input"] for row in sources)
+        tokens_out = sum(row["tokens"]["output"] for row in sources)
+        tokens_cache = sum(row["tokens"]["cacheRead"] for row in sources)
         days.append(
             {
                 "date": day.isoformat(),
-                "totals": {"tokens": tokens, "cost": cost, "messages": messages},
+                "totals": {
+                    "tokens": tokens_in + tokens_out + tokens_cache,
+                    "cost": round(sum(row["cost"] for row in sources), 6),
+                    "messages": sum(row["messages"] for row in sources),
+                },
                 "intensity": 0,
                 "tokenBreakdown": {
                     "input": tokens_in,
@@ -409,22 +489,7 @@ def _openclaw_contributions(
                     "cacheWrite": 0,
                     "reasoning": 0,
                 },
-                "sources": [
-                    {
-                        "source": "openclaw",
-                        "modelId": model,
-                        "providerId": "unknown",
-                        "tokens": {
-                            "input": tokens_in,
-                            "output": tokens_out,
-                            "cacheRead": tokens_cache,
-                            "cacheWrite": 0,
-                            "reasoning": 0,
-                        },
-                        "cost": cost,
-                        "messages": messages,
-                    }
-                ],
+                "sources": sources,
             }
         )
     return days
@@ -566,19 +631,82 @@ def dense_session_detail(tool: str, session_id: str, seed: int = 0) -> dict[str,
     return {"session": session, "turns": turns, "timestamp": _now_iso()}
 
 
-def dense_active_time(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, Any]:
+def _window_ms(range_info: Mapping[str, Any]) -> int:
+    """Wall clock the window covers, never counting time that has not happened.
+
+    Production windows are whole local days, but the intervals inside one come
+    from logged events, so a window reaching today or beyond runs only as far
+    as today has.
+    """
+    start, end = _effective_span(range_info)
+    now_local = datetime.now().astimezone()
+    whole_days = (end - start).days
+    if end < now_local.date():
+        return max(1, (whole_days + 1) * 86_400_000)
+    midnight = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    elapsed_today_ms = int((now_local - midnight).total_seconds() * 1000)
+    return max(1, whole_days * 86_400_000 + elapsed_today_ms)
+
+
+def _active_duty(index: int, days: int, row_rng: random.Random) -> float:
+    """Fraction of the window one tool spent working.
+
+    Falls off with window length because nobody runs an agent two thirds of a
+    year, and rises for the tools the fixture puts at the top of the list.
+    """
+    base = max(0.004, 0.085 - index * 0.0035)
+    return base * days**-0.25 * row_rng.uniform(0.9, 1.1)
+
+
+def dense_active_time(
+    range_info: Mapping[str, Any],
+    include_review_sessions: bool | None = None,
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Cross-tool active time, scaled to the window and bounded by it.
+
+    Every magnitude here is a fraction of the requested window. Production
+    merges intervals that were clipped to `[since_ms, until_ms)`, so `active_ms`
+    can never exceed the span asked for; per-tool constants made this KPI read
+    103h for a one-day range and the same 103h for a year, which is both
+    unreachable and unresponsive -- a range bug in the Overview card would have
+    looked exactly like the fixture working.
+    """
+    include_review = _include_codex_review_sessions(include_review_sessions)
+    days = _days_in_range(range_info)
+    window_ms = _window_ms(range_info)
+
     by_tool: dict[str, dict[str, Any]] = {}
+    duties: list[float] = []
     for index, (tool, label) in enumerate(SESSION_LABELS.items()):
         row_rng = _rng(seed, f"active:{tool}")
+        duty = _active_duty(index, days, row_rng)
+        session_count = 16 + row_rng.randint(0, 5)
+        concurrency = row_rng.uniform(1.35, 1.72)
+        if tool == "codex" and not include_review:
+            # Review sessions are Codex-only, and dropping them drops their
+            # intervals too: the KPI has to move when the toggle does.
+            duty *= 0.82
+            session_count -= 3
+        duties.append(duty)
+        active_ms = int(window_ms * duty)
         by_tool[tool] = {
             "tool_label": label,
-            "session_count": 16 + row_rng.randint(0, 5),
-            "active_ms": int((215 + index * 19) * row_rng.uniform(0.92, 1.08)) * 60_000,
-            "active_ms_sum": int((328 + index * 31) * row_rng.uniform(0.92, 1.08))
-            * 60_000,
+            "session_count": session_count,
+            "active_ms": active_ms,
+            "active_ms_sum": int(active_ms * concurrency),
         }
-    active_ms = sum(row["active_ms"] for row in by_tool.values())
+
+    # The union of the tools' intervals, not their sum: adding them is
+    # `active_ms_sum` arithmetic and overruns the window once enough tools
+    # report. Treating the tools as independent keeps the result between the
+    # busiest single tool and their total, which is where a real union lands.
+    idle = 1.0
+    for duty in duties:
+        idle *= 1.0 - duty
+    active_ms = int(window_ms * (1.0 - idle))
     active_ms_sum = sum(row["active_ms_sum"] for row in by_tool.values())
+
     return {
         "period": range_info.get("period_resolved", "custom"),
         "range": dict(range_info),
@@ -595,7 +723,7 @@ def dense_active_time(range_info: Mapping[str, Any], seed: int = 0) -> dict[str,
         "active_gap_cap_ms": 300_000,
         "active_time_estimated": True,
         "active_time_method": "capped-inter-event-gap",
-        "include_review_sessions": False,
+        "include_review_sessions": include_review,
         "timestamp": _now_iso(),
     }
 

--- a/src/tokdash/dev_fixtures.py
+++ b/src/tokdash/dev_fixtures.py
@@ -16,6 +16,16 @@ from collections.abc import Mapping
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
+from .compute import cache_hit_rate
+from .sessions import SESSION_TOOLS, _include_codex_review_sessions
+from .usage_store import model_cost_rank_key, model_rank_key
+
+# Usage sources (Overview, /api/tools) and session tools (Session Explorer,
+# Active Time) are genuinely different sets in production: `cursor` and
+# `gemini_cli` report token usage but expose no session transcripts, so they
+# appear in TOOL_SPECS and not in SESSION_LABELS. The fixture mirrors that split
+# rather than hiding it -- SESSION_LABELS is pinned to the real
+# `sessions.SESSION_TOOLS` by test_dense_fixture_session_tools_match_production.
 TOOL_SPECS = (
     ("codex", "Codex", ("openai/gpt-5.6-sol", "openai/gpt-5.5", "openai/o4-mini")),
     (
@@ -137,7 +147,7 @@ def _model_row(name: str, tokens: int, seed: int) -> dict[str, Any]:
         "tokens_cache": cache_tokens,
         "cost": cost,
         "messages": messages,
-        "cache_hit_rate": round(cache_tokens / (input_tokens + cache_tokens), 4),
+        "cache_hit_rate": cache_hit_rate(input_tokens, cache_tokens),
     }
 
 
@@ -170,6 +180,7 @@ def dense_usage(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, Any]:
             )
             for model_index, model_name in enumerate(model_names)
         ]
+        models.sort(key=model_rank_key)
         tokens = sum(row["tokens"] for row in models)
         tokens_in = sum(row["tokens_in"] for row in models)
         tokens_out = sum(row["tokens_out"] for row in models)
@@ -182,10 +193,15 @@ def dense_usage(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, Any]:
             "cost": round(sum(row["cost"] for row in models), 6),
             "messages": sum(row["messages"] for row in models),
             "models": models,
-            "cache_hit_rate": round(tokens_cache / (tokens_in + tokens_cache), 4),
+            "cache_hit_rate": cache_hit_rate(tokens_in, tokens_cache),
         }
         apps[tool] = app_row
         coding_models.extend({"source": tool, **row} for row in models)
+
+    # API.md documents coding_models as token-ranked, and the real producer gets
+    # that by filtering an already-sorted all_models. Built per tool, this list
+    # came out grouped by tool instead.
+    coding_models.sort(key=model_rank_key)
 
     openclaw_models = [
         _model_row(
@@ -227,11 +243,11 @@ def dense_usage(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, Any]:
     combined_models = []
     for row in combined.values():
         row["cost"] = round(row["cost"], 6)
-        row["cache_hit_rate"] = round(
-            row["tokens_cache"] / (row["tokens_in"] + row["tokens_cache"]), 4
-        )
+        row["cache_hit_rate"] = cache_hit_rate(row["tokens_in"], row["tokens_cache"])
         combined_models.append(row)
-    combined_models.sort(key=lambda row: (-row["tokens"], -row["cost"], row["name"]))
+    # Imported, not re-derived: a fixture whose ordering can drift from the
+    # server's is the one place the drift would go unnoticed.
+    combined_models.sort(key=model_rank_key)
 
     by_tool = {
         tool: {
@@ -251,7 +267,7 @@ def dense_usage(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, Any]:
         "tokens_in": openclaw_input,
         "tokens_cache": openclaw_cache,
         "cost": round(sum(row["cost"] for row in openclaw_models), 6),
-        "cache_hit_rate": round(openclaw_cache / (openclaw_input + openclaw_cache), 4),
+        "cache_hit_rate": cache_hit_rate(openclaw_input, openclaw_cache),
     }
 
     total_tokens = sum(row["tokens"] for row in by_tool.values())
@@ -269,10 +285,9 @@ def dense_usage(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, Any]:
         "total_messages": total_messages,
         "tokens_in": sum(row["tokens_in"] for row in by_tool.values()),
         "tokens_cache": sum(row["tokens_cache"] for row in by_tool.values()),
-        "cache_hit_rate": round(
-            sum(row["tokens_cache"] for row in by_tool.values())
-            / sum(row["tokens_in"] + row["tokens_cache"] for row in by_tool.values()),
-            4,
+        "cache_hit_rate": cache_hit_rate(
+            sum(row["tokens_in"] for row in by_tool.values()),
+            sum(row["tokens_cache"] for row in by_tool.values()),
         ),
         "apps": apps,
         "coding_apps": apps,
@@ -281,9 +296,7 @@ def dense_usage(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, Any]:
         "openclaw_models": openclaw_models,
         "combined_models": combined_models,
         "top_models": combined_models[:5],
-        "top_models_by_cost": sorted(
-            combined_models, key=lambda row: (-row["cost"], -row["tokens"])
-        )[:5],
+        "top_models_by_cost": sorted(combined_models, key=model_cost_rank_key)[:5],
         "comparison": {
             "tokens_prev": int(total_tokens * previous_factor),
             "cost_prev": round(total_cost * previous_factor, 2),
@@ -300,6 +313,121 @@ def dense_usage(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, Any]:
         "source_errors": [],
         "fixture": {"name": "dense", "seed": seed},
     }
+
+
+def dense_tools(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, Any]:
+    """Coding-tool usage in `parse_entries_json` shape, plus the route's envelope.
+
+    Derived from the same seeded draw as :func:`dense_usage` so Overview and
+    /api/tools never disagree about the same window.
+    """
+    usage = dense_usage(range_info, seed=seed)
+    all_models = usage["coding_models"]
+    return {
+        "total_cost": round(sum(row["cost"] for row in all_models), 6),
+        "total_tokens": sum(row["tokens"] for row in all_models),
+        "total_messages": sum(row["messages"] for row in all_models),
+        "cache_hit_rate": cache_hit_rate(
+            sum(row["tokens_in"] for row in all_models),
+            sum(row["tokens_cache"] for row in all_models),
+        ),
+        "apps": usage["apps"],
+        "all_models": all_models,
+        "source_errors": [],
+        "period": usage["period"],
+        "range": dict(range_info),
+        "timestamp": _now_iso(),
+    }
+
+
+def dense_openclaw(range_info: Mapping[str, Any], seed: int = 0) -> dict[str, Any]:
+    """OpenClaw usage in `sources.openclaw.get_session_usage` shape.
+
+    Note `models` is a mapping keyed by model name with no ``name`` field -- that
+    is the real producer's shape, and it differs from every other model list.
+    """
+    usage = dense_usage(range_info, seed=seed)
+    rows = usage["openclaw_models"]
+    total_in = sum(row["tokens_in"] for row in rows)
+    total_cache = sum(row["tokens_cache"] for row in rows)
+    return {
+        "total_tokens": sum(row["tokens"] for row in rows),
+        "total_cost": round(sum(row["cost"] for row in rows), 6),
+        "total_messages": sum(row["messages"] for row in rows),
+        "total_tokens_in": total_in,
+        "total_tokens_cache": total_cache,
+        "cache_hit_rate": cache_hit_rate(total_in, total_cache),
+        "models": {
+            row["name"]: {key: value for key, value in row.items() if key != "name"}
+            for row in rows
+        },
+        "contributions": _openclaw_contributions(range_info, seed),
+        "period": usage["period"],
+        "range": dict(range_info),
+        "timestamp": _now_iso(),
+    }
+
+
+def _openclaw_contributions(
+    range_info: Mapping[str, Any], seed: int
+) -> list[dict[str, Any]]:
+    """Per-day OpenClaw rows over the requested window, never past today."""
+    today = datetime.now().astimezone().date()
+    try:
+        end = min(date.fromisoformat(str(range_info.get("to"))), today)
+    except (TypeError, ValueError):
+        end = today
+    start = end - timedelta(days=max(0, _days_in_range(range_info) - 1))
+
+    days: list[dict[str, Any]] = []
+    for offset in range((end - start).days + 1):
+        day = start + timedelta(days=offset)
+        day_rng = _rng(seed, f"openclaw-day:{day.isoformat()}")
+        if day_rng.random() < 0.12:
+            continue
+        tokens = int(day_rng.triangular(4_000_000, 180_000_000, 41_000_000))
+        tokens_in = int(tokens * 0.12)
+        tokens_cache = int(tokens * 0.73)
+        tokens_out = max(1, tokens - tokens_in - tokens_cache)
+        messages = day_rng.randint(12, 210)
+        cost = round(
+            tokens_in * 0.0000025
+            + tokens_out * 0.0000105
+            + tokens_cache * 0.00000025,
+            6,
+        )
+        model = SESSION_MODELS[day.toordinal() % len(SESSION_MODELS)]
+        days.append(
+            {
+                "date": day.isoformat(),
+                "totals": {"tokens": tokens, "cost": cost, "messages": messages},
+                "intensity": 0,
+                "tokenBreakdown": {
+                    "input": tokens_in,
+                    "output": tokens_out,
+                    "cacheRead": tokens_cache,
+                    "cacheWrite": 0,
+                    "reasoning": 0,
+                },
+                "sources": [
+                    {
+                        "source": "openclaw",
+                        "modelId": model,
+                        "providerId": "unknown",
+                        "tokens": {
+                            "input": tokens_in,
+                            "output": tokens_out,
+                            "cacheRead": tokens_cache,
+                            "cacheWrite": 0,
+                            "reasoning": 0,
+                        },
+                        "cost": cost,
+                        "messages": messages,
+                    }
+                ],
+            }
+        )
+    return days
 
 
 def _session_row(tool: str, index: int, seed: int = 0) -> dict[str, Any]:
@@ -341,7 +469,7 @@ def _session_row(tool: str, index: int, seed: int = 0) -> dict[str, Any]:
         "tokens_reasoning": int(tokens_out * 0.31),
         "tokens": tokens,
         "cache_ratio": round(tokens_cache / tokens, 4),
-        "cache_hit_rate": round(tokens_cache / (tokens_in + tokens_cache), 4),
+        "cache_hit_rate": cache_hit_rate(tokens_in, tokens_cache),
         "cost": round(
             tokens_in * 0.0000025 + tokens_out * 0.0000105 + tokens_cache * 0.00000025,
             6,
@@ -354,17 +482,30 @@ def _session_row(tool: str, index: int, seed: int = 0) -> dict[str, Any]:
     }
 
 
+SESSION_ROWS_PER_TOOL = 18
+
+
 def dense_sessions(
     tool: str, include_review_sessions: bool | None = None, seed: int = 0
 ) -> dict[str, Any]:
-    rows = [_session_row(tool, index, seed) for index in range(18)]
-    if tool == "codex" and include_review_sessions is False:
+    # Same rejection as `sessions.get_sessions_data`, so an unsupported tool still
+    # renders the dashboard's error state instead of a fabricated session list.
+    key = str(tool or "").strip().lower()
+    if key not in SESSION_TOOLS:
+        raise ValueError(f"Unsupported session tool: {tool}")
+
+    # The real route resolves an unset flag through the configured default rather
+    # than treating None as False -- and the response has to report what was
+    # actually applied, or the payload contradicts the rows it ships.
+    include_review = _include_codex_review_sessions(include_review_sessions)
+    rows = [_session_row(key, index, seed) for index in range(SESSION_ROWS_PER_TOOL)]
+    if key == "codex" and not include_review:
         rows = [row for row in rows if not row["is_review_session"]]
     return {
-        "tool": tool,
-        "tool_label": SESSION_LABELS.get(tool, tool.replace("_", " ").title()),
+        "tool": key,
+        "tool_label": SESSION_LABELS.get(key, key.replace("_", " ").title()),
         "period": "fixture",
-        "include_review_sessions": bool(include_review_sessions),
+        "include_review_sessions": include_review,
         "latest_session": rows[0] if rows else None,
         "sessions": rows,
         "summary": {
@@ -383,9 +524,26 @@ def dense_sessions(
 
 
 def dense_session_detail(tool: str, session_id: str, seed: int = 0) -> dict[str, Any]:
-    detail_rng = _rng(seed, f"detail:{tool}:{session_id}")
-    session = _session_row(tool, 0, seed)
-    session["session_id"] = session_id
+    key = str(tool or "").strip().lower()
+    if key not in SESSION_TOOLS:
+        raise ValueError(f"Unsupported session tool: {tool}")
+
+    # Only ids this fixture actually generates resolve. Fabricating a session for
+    # any string meant /api/session could never 404, so the dashboard's
+    # "session not found" path was unreachable -- one of the states the fixture
+    # exists to exercise.
+    known = {
+        _session_row(key, index, seed)["session_id"]: index
+        for index in range(SESSION_ROWS_PER_TOOL)
+    }
+    index = known.get(str(session_id))
+    if index is None:
+        raise FileNotFoundError(
+            f"{SESSION_LABELS.get(key, key.title())} session not found: {session_id}"
+        )
+
+    detail_rng = _rng(seed, f"detail:{key}:{session_id}")
+    session = _session_row(key, index, seed)
     start = datetime.fromisoformat(session["started_at"])
     turns = []
     for index in range(48):
@@ -508,12 +666,17 @@ def _contribution(day: date, seed: int = 0) -> dict[str, Any]:
 
 
 def dense_stats(year: int | None = None, seed: int = 0) -> dict[str, Any]:
+    today = datetime.now().astimezone().date()
     if year is None:
-        end = datetime.now().astimezone().date()
+        end = today
         start = end - timedelta(days=419)
     else:
         start = date(year, 1, 1)
-        end = date(year, 12, 31)
+        # Never past today: real `compute_stats` builds the contribution list from
+        # dates that actually carry usage, so it cannot emit a future day. Asking
+        # the year selector for the current year used to fill the graph through
+        # December with fabricated activity.
+        end = min(date(year, 12, 31), today)
     contributions = [
         _contribution(start + timedelta(days=index), seed)
         for index in range((end - start).days + 1)

--- a/tests/test_dev_fixture.py
+++ b/tests/test_dev_fixture.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi import HTTPException
 
 from tokdash import api, cli
 from tokdash.compute import parse_entries_json
+from tokdash.compute import resolve_period
 from tokdash.dev_fixtures import (
     SESSION_LABELS,
     TOOL_SPECS,
+    dense_openclaw,
     dense_usage,
     fixture_year_days,
 )
@@ -95,6 +97,97 @@ def test_dense_fixture_sessions_and_details_cover_overflow_states():
     assert len(detail["turns"]) == 48
     assert len(active["by_tool"]) >= 15
     assert all(row["active_ms"] > 0 for row in active["by_tool"].values())
+
+
+def test_dense_fixture_active_time_scales_with_the_window_and_stays_inside_it():
+    with dense_fixture():
+        payloads = {
+            period: api.get_active_time(period=period)
+            for period in ("today", "week", "year")
+        }
+
+    # Read after the calls: an elapsed-time ceiling only ever grows.
+    now_local = datetime.now().astimezone()
+    midnight = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    elapsed_today_ms = int((now_local - midnight).total_seconds() * 1000)
+
+    for period, payload in payloads.items():
+        # Production merges intervals clipped to [since_ms, until_ms), so the
+        # union cannot outrun the window, cannot exceed the additive agent time,
+        # and cannot fall below the busiest single tool.
+        assert payload["active_ms"] <= payload["range"]["days"] * 86_400_000, period
+        assert payload["active_ms"] <= payload["active_ms_sum"], period
+        assert payload["active_ms"] >= max(
+            row["active_ms"] for row in payload["by_tool"].values()
+        ), period
+
+    assert payloads["today"]["active_ms"] <= elapsed_today_ms
+    # One frozen figure for every range would make a range bug in the Overview
+    # card indistinguishable from the fixture working.
+    assert (
+        payloads["today"]["active_ms"]
+        < payloads["week"]["active_ms"]
+        < payloads["year"]["active_ms"]
+    )
+
+
+def test_dense_fixture_active_time_answers_the_review_toggle():
+    with dense_fixture():
+        included = api.get_active_time(period="week", include_review_sessions=True)
+        excluded = api.get_active_time(period="week", include_review_sessions=False)
+
+    # The payload has to describe the request that produced it: the dashboard
+    # sends this flag whenever its toggle is set.
+    assert included["include_review_sessions"] is True
+    assert excluded["include_review_sessions"] is False
+    # Review sessions are Codex-only, and dropping them drops their intervals.
+    codex_on = included["by_tool"]["codex"]
+    codex_off = excluded["by_tool"]["codex"]
+    assert codex_off["active_ms"] < codex_on["active_ms"]
+    assert codex_off["session_count"] < codex_on["session_count"]
+    assert excluded["active_ms"] < included["active_ms"]
+
+
+def test_dense_fixture_active_time_ignores_a_window_that_has_not_happened():
+    today = datetime.now().astimezone().date()
+    with dense_fixture():
+        payload = api.get_active_time(
+            date_from=(today - timedelta(days=1)).isoformat(),
+            date_to=(today + timedelta(days=120)).isoformat(),
+        )
+
+    # 122 nominal days, two of which have happened. Active time is measured from
+    # logged events, and the rest of that window has not produced any.
+    assert payload["range"]["days"] > 100
+    assert payload["active_ms"] <= 2 * 86_400_000
+
+
+@pytest.mark.parametrize(
+    "days_before, days_after",
+    [(29, 0), (1, 120)],  # a closed past window, and one running into the future
+)
+def test_dense_fixture_openclaw_grid_stays_inside_the_requested_window(
+    days_before, days_after
+):
+    today = datetime.now().astimezone().date()
+    # Resolved once and passed in: a today-anchored window moves as the test runs.
+    range_info = resolve_period(
+        "custom",
+        (today - timedelta(days=days_before)).isoformat(),
+        (today + timedelta(days=days_after)).isoformat(),
+    )
+    payload = dense_openclaw(range_info, seed=17)
+    dates = [day["date"] for day in payload["contributions"]]
+
+    assert dates == sorted(dates)
+    assert len(dates) == len(set(dates))
+    # Anchoring the walk-back on today instead of on `from` put the whole grid
+    # months before the window whenever `to` ran past today.
+    assert range_info["from"] <= dates[0]
+    assert dates[-1] <= min(range_info["to"], today.isoformat())
+    assert payload["total_tokens"] == sum(
+        day["totals"]["tokens"] for day in payload["contributions"]
+    )
 
 
 def test_dense_fixture_stats_fill_a_leap_year_and_include_multi_source_days():
@@ -340,6 +433,42 @@ def test_dense_fixture_openclaw_route_matches_the_real_producer_shape():
     assert fixture["total_tokens"] == sum(
         row["tokens"] for row in fixture["models"].values()
     )
+
+
+def test_dense_fixture_openclaw_totals_match_its_own_contributions():
+    with dense_fixture():
+        for period in ("today", "week", "month"):
+            payload = api.get_openclaw(period=period)
+            overview = api.get_usage(period=period)
+            days = payload["contributions"]
+
+            # The header, the day grid and the Overview slice are three views of
+            # one window. The real producer folds a single window-filtered pass
+            # into all of them -- and the store-backed path reads them out of one
+            # snapshot -- so a consumer may take a total from one and a chart
+            # from another.
+            assert payload["total_tokens"] == sum(
+                day["totals"]["tokens"] for day in days
+            ), period
+            assert (
+                payload["total_tokens"] == overview["by_tool"]["openclaw"]["tokens"]
+            ), period
+            assert payload["total_messages"] == sum(
+                day["totals"]["messages"] for day in days
+            ), period
+            assert payload["total_cost"] == pytest.approx(
+                sum(day["totals"]["cost"] for day in days), abs=1e-4
+            ), period
+
+            assert days, period
+            for day in days:
+                breakdown = day["tokenBreakdown"]
+                assert (
+                    breakdown["input"] + breakdown["output"] + breakdown["cacheRead"]
+                    == day["totals"]["tokens"]
+                )
+                day_messages = sum(row["messages"] for row in day["sources"])
+                assert day_messages == day["totals"]["messages"]
 
 
 def test_dense_fixture_pricing_db_never_discloses_the_user_override():

--- a/tests/test_dev_fixture.py
+++ b/tests/test_dev_fixture.py
@@ -2,9 +2,22 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import contextmanager
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
 
 from tokdash import api, cli
-from tokdash.dev_fixtures import dense_usage, fixture_year_days
+from tokdash.compute import parse_entries_json
+from tokdash.dev_fixtures import (
+    SESSION_LABELS,
+    TOOL_SPECS,
+    dense_usage,
+    fixture_year_days,
+)
+from tokdash.sessions import SESSION_TOOLS
+from tokdash.sources.openclaw import get_session_usage
+from tokdash.usage_store import model_cost_rank_key, model_rank_key
 
 
 @contextmanager
@@ -155,3 +168,206 @@ def test_serve_fixture_skips_real_background_daemons(monkeypatch):
     assert calls == ["dense"]
     assert not hasattr(api.app.state, "dev_fixture")
     assert not hasattr(api.app.state, "dev_fixture_seed")
+
+
+# --- Follow-up coverage: the gaps between what the docs promise and what the
+# --- code enforces (PR #63 review).
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["export", "--dev-fixture", "dense"],
+        ["export", "--dev-seed", "5"],
+        ["quota", "--dev-fixture", "dense", "--dev-seed", "5"],
+        ["db", "--dev-fixture", "dense"],
+        ["version", "--dev-fixture", "dense"],
+    ],
+)
+def test_dev_fixture_flags_are_refused_outside_serve(argv, capsys):
+    """Only serve honors these, so only serve may accept them.
+
+    They sit on the flat top-level parser, so every one of these used to parse
+    cleanly and then run against the user's REAL data with no warning.
+    """
+    with pytest.raises(SystemExit):
+        cli.cli(argv)
+
+    assert "only supported by `serve`" in capsys.readouterr().err
+
+
+def test_dev_seed_still_requires_a_fixture_on_serve(capsys):
+    with pytest.raises(SystemExit):
+        cli.cli(["serve", "--dev-seed", "5"])
+
+    assert "--dev-seed requires --dev-fixture" in capsys.readouterr().err
+
+
+def test_dense_fixture_session_tools_match_production():
+    """SESSION_LABELS is the real session-tool set, not an arbitrary subset.
+
+    Active Time covers 17 tools and Overview covers 12 because usage sources and
+    session tools genuinely differ (cursor and gemini_cli report tokens but ship
+    no transcripts). Pinning the session half here keeps that difference
+    deliberate instead of drifting.
+    """
+    assert set(SESSION_LABELS) == set(SESSION_TOOLS)
+    assert {tool for tool, _label, _models in TOOL_SPECS} - set(SESSION_LABELS) == {
+        "cursor",
+        "gemini_cli",
+    }
+
+
+def test_dense_fixture_model_arrays_use_the_shared_rank_keys():
+    """The fixture must not re-implement the #61 ordering contract."""
+    payload = dense_usage(api.resolve_period("year"), seed=17)
+
+    for key in ("combined_models", "coding_models"):
+        rows = payload[key]
+        assert rows == sorted(rows, key=model_rank_key), key
+
+    assert payload["top_models"] == payload["combined_models"][:5]
+    assert (
+        payload["top_models_by_cost"]
+        == sorted(payload["combined_models"], key=model_cost_rank_key)[:5]
+    )
+    for app_row in payload["apps"].values():
+        assert app_row["models"] == sorted(app_row["models"], key=model_rank_key)
+
+
+def test_dense_fixture_surfaces_session_error_states():
+    """404 and 400 are UI states the fixture exists to exercise."""
+    with dense_fixture():
+        with pytest.raises(HTTPException) as unknown_session:
+            api.get_session(tool="codex", session_id="no-such-session")
+        with pytest.raises(HTTPException) as unknown_tool:
+            api.get_sessions(tool="not-a-real-tool", period="week")
+        with pytest.raises(HTTPException) as unknown_detail_tool:
+            api.get_session(tool="not-a-real-tool", session_id="x")
+
+    assert unknown_session.value.status_code == 404
+    assert unknown_tool.value.status_code == 400
+    assert "Unsupported session tool" in str(unknown_tool.value.detail)
+    assert unknown_detail_tool.value.status_code == 400
+
+
+def test_dense_fixture_stats_never_fabricate_future_days():
+    """`compute_stats` builds days from real usage, so it cannot emit the future."""
+    today = datetime.now().astimezone().date()
+
+    with dense_fixture():
+        current_year = api.get_stats(year=today.year)
+        future_year = api.get_stats(year=today.year + 4)
+        rolling = api.get_stats()
+
+    assert current_year["contributions"][-1]["date"] == today.isoformat()
+    assert all(day["date"] <= today.isoformat() for day in current_year["contributions"])
+    assert future_year["contributions"] == []
+    assert all(day["date"] <= today.isoformat() for day in rolling["contributions"])
+
+
+def test_dense_fixture_review_sessions_follow_the_configured_default(monkeypatch):
+    """An unset flag resolves through the real default, and the payload says so."""
+    monkeypatch.delenv("TOKDASH_INCLUDE_CODEX_GUARDIAN", raising=False)
+    with dense_fixture():
+        off = api.get_sessions(tool="codex", period="week")
+
+    assert off["include_review_sessions"] is False
+    assert not any(row["is_review_session"] for row in off["sessions"])
+
+    monkeypatch.setenv("TOKDASH_INCLUDE_CODEX_GUARDIAN", "1")
+    with dense_fixture():
+        on = api.get_sessions(tool="codex", period="week")
+
+    assert on["include_review_sessions"] is True
+    assert any(row["is_review_session"] for row in on["sessions"])
+
+
+def test_dense_fixture_insights_refuses_instead_of_serving_real_history():
+    """/api/insights is the external report endpoint added by #59."""
+    with dense_fixture():
+        with pytest.raises(HTTPException) as refused:
+            api.get_insights(period="year")
+
+    assert refused.value.status_code == 409
+    assert "not synthesized" in str(refused.value.detail)
+
+
+def test_dense_fixture_tools_route_matches_the_real_producer_shape():
+    real = parse_entries_json(
+        {
+            "entries": [
+                {
+                    "source": "codex",
+                    "model": "gpt-5.6-sol",
+                    "provider": "openai",
+                    "input": 10,
+                    "output": 5,
+                    "cacheRead": 3,
+                }
+            ]
+        }
+    )
+
+    with dense_fixture():
+        fixture = api.get_tools(period="week")
+
+    assert set(fixture) == set(real) | {"source_errors", "period", "range", "timestamp"}
+    assert set(fixture["all_models"][0]) == set(real["all_models"][0])
+    assert set(next(iter(fixture["apps"].values()))) == set(
+        next(iter(real["apps"].values()))
+    )
+    assert fixture["total_tokens"] == sum(
+        row["tokens"] for row in fixture["all_models"]
+    )
+
+
+def test_dense_fixture_openclaw_route_matches_the_real_producer_shape():
+    real = get_session_usage(
+        [],
+        since_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        until_date=datetime.now(timezone.utc),
+    )
+
+    with dense_fixture():
+        fixture = api.get_openclaw(period="week")
+
+    assert set(fixture) == set(real) | {"period", "range", "timestamp"}
+    # `models` is a mapping keyed by model name here -- unlike every other model
+    # list in the API -- and a fixture that returned a list would hide that.
+    assert isinstance(fixture["models"], dict)
+    assert all("name" not in row for row in fixture["models"].values())
+    assert fixture["total_tokens"] == sum(
+        row["tokens"] for row in fixture["models"].values()
+    )
+
+
+def test_dense_fixture_pricing_db_never_discloses_the_user_override():
+    with dense_fixture():
+        payload = api.get_pricing_db()
+
+    assert payload["source"] == "dev-fixture"
+    assert str(api._pricing_override_path()) not in payload["path"]
+    # The packaged baseline is part of the install, not user data.
+    assert payload["data"]
+    assert payload["baseline_path"] == str(api.PRICING_DB_PATH)
+
+
+def test_dense_fixture_codex_routes_do_not_read_rollout_files(monkeypatch):
+    """The /api/codex/* pair reads transcripts off disk in the real path."""
+
+    def explode(*_args, **_kwargs):
+        raise AssertionError("fixture mode reached the real Codex reader")
+
+    monkeypatch.setattr(api, "get_codex_sessions_data", explode)
+    monkeypatch.setattr(api, "get_codex_session_detail", explode)
+
+    with dense_fixture():
+        listing = api.get_codex_sessions(period="week", include_review_sessions=True)
+        detail = api.get_codex_session(
+            session_id=listing["sessions"][0]["session_id"]
+        )
+
+    assert listing["tool"] == "codex"
+    assert len(listing["sessions"]) == 18
+    assert detail["turns"]

--- a/tests/test_dev_fixture.py
+++ b/tests/test_dev_fixture.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+
+from tokdash import api, cli
+from tokdash.dev_fixtures import dense_usage, fixture_year_days
+
+
+@contextmanager
+def dense_fixture():
+    had_value = hasattr(api.app.state, "dev_fixture")
+    previous = getattr(api.app.state, "dev_fixture", "")
+    had_seed = hasattr(api.app.state, "dev_fixture_seed")
+    previous_seed = getattr(api.app.state, "dev_fixture_seed", 0)
+    api.app.state.dev_fixture = "dense"
+    api.app.state.dev_fixture_seed = 74_019_130
+    try:
+        yield
+    finally:
+        if had_value:
+            api.app.state.dev_fixture = previous
+        else:
+            del api.app.state.dev_fixture
+        if had_seed:
+            api.app.state.dev_fixture_seed = previous_seed
+        else:
+            del api.app.state.dev_fixture_seed
+
+
+def test_dense_fixture_parser_is_explicit_and_off_by_default():
+    default = cli.build_parser("tokdash").parse_args(["serve"])
+    fixture = cli.build_parser("tokdash").parse_args(
+        ["serve", "--dev-fixture", "dense", "--dev-seed", "17"]
+    )
+
+    assert default.dev_fixture is None
+    assert default.dev_seed is None
+    assert fixture.dev_fixture == "dense"
+    assert fixture.dev_seed == 17
+
+
+def test_dense_fixture_overview_is_crowded_and_consistent():
+    with dense_fixture():
+        payload = api.get_usage(period="week")
+
+    assert len(payload["by_tool"]) >= 10
+    assert len(payload["apps"]) >= 10
+    assert len(payload["combined_models"]) >= 12
+    assert payload["total_tokens"] == sum(
+        row["tokens"] for row in payload["by_tool"].values()
+    )
+    assert payload["range"]["days"] == 7
+    assert payload["response_cache"]["status"] == "fixture"
+    assert payload["fixture"] == {"name": "dense", "seed": 74_019_130}
+
+
+def test_dense_fixture_seed_is_stable_and_changes_the_sample():
+    range_info = api.resolve_period("week")
+
+    first = dense_usage(range_info, seed=17)
+    repeated = dense_usage(range_info, seed=17)
+    different = dense_usage(range_info, seed=18)
+
+    assert first["total_tokens"] == repeated["total_tokens"]
+    assert first["by_tool"] == repeated["by_tool"]
+    assert first["total_tokens"] != different["total_tokens"]
+
+
+def test_dense_fixture_sessions_and_details_cover_overflow_states():
+    with dense_fixture():
+        sessions = api.get_sessions(
+            tool="codex", period="week", include_review_sessions=True
+        )
+        detail = api.get_session(
+            tool="codex", session_id=sessions["sessions"][0]["session_id"]
+        )
+        active = api.get_active_time(period="week")
+
+    assert len(sessions["sessions"]) == 18
+    assert any(len(row["project"]) > 40 for row in sessions["sessions"])
+    assert len(detail["turns"]) == 48
+    assert len(active["by_tool"]) >= 15
+    assert all(row["active_ms"] > 0 for row in active["by_tool"].values())
+
+
+def test_dense_fixture_stats_fill_a_leap_year_and_include_multi_source_days():
+    with dense_fixture():
+        payload = api.get_stats(year=2024)
+
+    assert len(payload["contributions"]) == fixture_year_days(2024)
+    assert len(payload["contributions"]) == 366
+    assert max(len(day["sources"]) for day in payload["contributions"]) == 5
+    assert payload["meta"] == {
+        "source": "dev-fixture",
+        "synthetic": True,
+        "seed": 74_019_130,
+    }
+
+
+def test_dense_fixture_quota_has_multiple_providers_and_chart_series():
+    with dense_fixture():
+        quota = api.get_quota()
+        history = api.get_quota_history(granularity="hour")
+        refreshed = api.refresh_quota()
+
+    assert len(quota["providers"]) == 7
+    assert all(
+        len(provider["buckets"]) == 2 for provider in quota["providers"].values()
+    )
+    assert len(history["series"]) == 8
+    assert all(len(series["points"]) == 72 for series in history["series"])
+    assert refreshed == {
+        "snapshots": 14,
+        "inserted": 0,
+        "fixture": "dense",
+        "seed": 74_019_130,
+    }
+
+
+def test_dense_fixture_rejects_all_mutating_requests():
+    request = type("FixtureRequest", (), {"method": "PUT", "app": api.app})()
+
+    async def unexpected_handler(_request):
+        raise AssertionError("fixture write reached its route handler")
+
+    with dense_fixture():
+        response = asyncio.run(api._write_guard(request, unexpected_handler))
+
+    assert response.status_code == 409
+
+
+def test_serve_fixture_skips_real_background_daemons(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(
+        cli, "_start_usage_db_sync_daemon", lambda: calls.append("usage")
+    )
+    monkeypatch.setattr(cli, "_start_quota_poll_daemon", lambda: calls.append("quota"))
+    monkeypatch.setattr(
+        cli.uvicorn,
+        "run",
+        lambda *args, **kwargs: calls.append(str(api.app.state.dev_fixture)),
+    )
+    monkeypatch.setattr(cli, "_has_display", lambda: False)
+
+    cli.serve(
+        "127.0.0.1",
+        55423,
+        "warning",
+        open_browser=False,
+        dev_fixture="dense",
+        dev_seed=17,
+    )
+
+    assert calls == ["dense"]
+    assert not hasattr(api.app.state, "dev_fixture")
+    assert not hasattr(api.app.state, "dev_fixture_seed")


### PR DESCRIPTION
## Summary

- Add an opt-in `--dev-fixture dense` mode that serves crowded synthetic Overview, Sessions, Stats, Quota, and Activity Insights payloads through the real API and dashboard.
- Add `--dev-seed` for reproducible datasets; omitting it generates and prints a fresh seed for the server run.
- Keep fixture mode isolated from real user data by skipping cache warmers, usage sync, quota polling, local history and credential reads, and by rejecting mutating HTTP requests.
- Document the contributor workflow and cover density, consistency, seed stability, safety, session overflow, leap years, quota series, and daemon isolation.

This PR intentionally contains no dashboard UI or styling changes.

## Production impact

The feature is off by default, fixture payload code is imported only when explicitly enabled, and there are no new dependencies. Normal serving behavior and API responses are unchanged.

## Validation

- `pytest -q tests/test_dev_fixture.py tests/test_cli_serve.py tests/test_api_smoke.py tests/test_api_quota.py tests/test_activity_insights.py tests/test_insights_api.py tests/test_write_protection.py` — 158 passed, 1 skipped
- Full suite — 1,784 passed, 3 skipped, with one pre-existing timezone-sensitive failure in `test_previous_period_range_month_uses_full_previous_calendar_month`
- `ruff check src/tokdash/dev_fixtures.py tests/test_dev_fixture.py`
- `mypy src/tokdash/dev_fixtures.py`
- Manual fixture smoke test: 13 tools, 25 combined models, 18 sessions, writes rejected with HTTP 409; Stats generated in about 13 ms on the test machine.