### PR TITLE
Stop re-parsing a live Codex rollout per thread and per window; add Claude Fable 5.1 pricing

### DIFF
--- a/src/tokdash/compute.py
+++ b/src/tokdash/compute.py
@@ -787,12 +787,25 @@ def get_tools_data(period: str) -> Dict[str, Any]:
     return parse_entries_json(run_tokscale_json(period_args))
 
 
-def get_tools_data_for_range(since: Optional[datetime], until: Optional[datetime]) -> Dict[str, Any]:
+def get_tools_data_for_range(
+    since: Optional[datetime], until: Optional[datetime], *, sync: bool = True
+) -> Dict[str, Any]:
+    """Coding-tool usage for one window.
+
+    ``sync=False`` reads the persistent store as it stands instead of bringing it
+    up to date first. It is for the second window of one request -- the
+    comparison period -- whose sync would only repeat the one the current window
+    just ran, and while a large log is being appended to, would find it changed
+    again and parse it a second time. Never pass it for the first read.
+    """
     if USE_LOCAL_CODING_TOOLS_BACKEND:
         tracker = CodingToolsUsageTracker()
         if persistent_usage_db_enabled():
             try:
-                store, stored_sources = _sync_usage_store(tracker)
+                if sync:
+                    store, stored_sources = _sync_usage_store(tracker)
+                else:
+                    store, stored_sources = UsageEntryStore(), _usage_store_sources(tracker)
                 store_data = store.aggregate_entries(sources=stored_sources, since=since, until=until)
                 live_entries = _collect_live_coding_entries(tracker, since, until, _usage_store_live_sources(tracker))
                 live_data = parse_entries_json({"entries": live_entries})
@@ -1016,7 +1029,13 @@ def previous_period_range(period: str) -> tuple[datetime, datetime]:
     return prev_since, prev_until
 
 
-def _compute_previous_usage(period: str, date_from: Optional[str] = None, date_to: Optional[str] = None) -> Dict[str, Any]:
+def _compute_previous_usage(
+    period: str,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    *,
+    sync: bool = True,
+) -> Dict[str, Any]:
     # If specific dates are provided, calculate previous period based on date range
     if date_from and date_to:
         current_since, current_until = parse_date_range(date_from, date_to)
@@ -1025,11 +1044,11 @@ def _compute_previous_usage(period: str, date_from: Optional[str] = None, date_t
         prev_since = prev_until - duration
 
         openclaw_data = get_session_usage_range(prev_since, prev_until)
-        coding_data = get_tools_data_for_range(prev_since, prev_until)
+        coding_data = get_tools_data_for_range(prev_since, prev_until, sync=sync)
     else:
         since, until = previous_period_range(period)
         openclaw_data = get_session_usage_range(since, until)
-        coding_data = get_tools_data_for_range(since, until)
+        coding_data = get_tools_data_for_range(since, until, sync=sync)
 
     coding_apps = {k: v for k, v in coding_data.get("apps", {}).items() if k.lower() != "openclaw"}
 
@@ -1052,7 +1071,9 @@ def pct_change(current: float, previous: float) -> Optional[float]:
 
 def compute_usage_with_comparison(period: str, date_from: Optional[str] = None, date_to: Optional[str] = None) -> Dict[str, Any]:
     current = compute_usage(period, date_from, date_to)
-    previous = _compute_previous_usage(period, date_from, date_to)
+    # The current window just synced every source; the previous window reads
+    # what that sync stored rather than paying for a second one.
+    previous = _compute_previous_usage(period, date_from, date_to, sync=False)
 
     current["comparison"] = {
         "tokens_prev": previous["total_tokens"],

--- a/src/tokdash/pricing_db.json
+++ b/src/tokdash/pricing_db.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.0.20",
-  "lastUpdated": "2026-08-27T11:22:46Z",
+  "version": "2.0.21",
+  "lastUpdated": "2026-09-02T15:32:40Z",
   "note": "Comprehensive pricing database with all Moonshot, MiniMax, GLM, and OpenAI models from OpenRouter. Cache pricing estimated at 10% of input for cache_read, 100% of input for cache_write.",
   "aliases": {
     "claude-sonnet-5-20260630": "claude-sonnet-5",
@@ -53,7 +53,10 @@
     "longcat2.0": "longcat-2.0",
     "longcat-2-0": "longcat-2.0",
     "meituan/longcat-2.0": "longcat-2.0",
-    "qwen3.8max": "qwen3.8-max"
+    "qwen3.8max": "qwen3.8-max",
+    "fable-5.1": "claude-fable-5.1",
+    "fable-5-1": "claude-fable-5.1",
+    "fable5.1": "claude-fable-5.1"
   },
   "models": {
     "_comment_moonshot": "=== Moonshot AI / Kimi Models ===",
@@ -3098,6 +3101,15 @@
       "cache_write": 0.8,
       "unit": "per_million_tokens",
       "source": "openrouter.ai/amazon/nova-pro-v1"
+    },
+    "claude-fable-5.1": {
+      "provider": "anthropic",
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
+      "cache_write": 12.5,
+      "unit": "per_million_tokens",
+      "source": "openrouter.ai/anthropic/claude-fable-5.1"
     }
   }
 }

--- a/src/tokdash/sessions.py
+++ b/src/tokdash/sessions.py
@@ -5339,6 +5339,36 @@ def _session_records_to_raw_sessions(tool: str, records: Iterable[Dict[str, Any]
     return sessions
 
 
+_store_sync_state = threading.local()
+
+
+class _store_sync_suppressed:
+    """Inside the block, stored-session reads on this thread skip the source sync.
+
+    A request that reads two windows -- the Overview's active time and its
+    comparison period -- synced every stored tool twice, and while a large
+    rollout was being appended to, the second sync found it changed again and
+    parsed it a second time. The second window only needs what the first sync
+    stored. Thread-local rather than a parameter so the fake loaders tests
+    install over ``_raw_sessions_for_tool`` keep their signature.
+    """
+
+    def __enter__(self) -> None:
+        self._previous = getattr(_store_sync_state, "suppressed", False)
+        _store_sync_state.suppressed = True
+
+    def __exit__(self, *_exc: Any) -> None:
+        _store_sync_state.suppressed = self._previous
+
+
+def _store_sync_wanted() -> bool:
+    return not getattr(_store_sync_state, "suppressed", False)
+
+
+def _skip_session_sync(*_args: Any, **_kwargs: Any) -> bool:
+    return False
+
+
 def _stored_sessions_for_tool(
     tool: str,
     *,
@@ -5349,10 +5379,12 @@ def _stored_sessions_for_tool(
     # Before any signature scan: every branch below enumerates that tool's whole
     # session tree, and on a too-new database all of it is wasted.
     store.check_compatible()
+    sync = _store_sync_wanted()
+    sync_files = store.sync_session_files if sync else _skip_session_sync
     if tool == "codex":
-        signatures = _codex_file_signatures()
+        signatures = _codex_file_signatures() if sync else ()
         pricing_sig = _pricing_signature()
-        store.sync_session_files(
+        sync_files(
             "codex",
             signatures,
             parser=_codex_session_parser_signature(),
@@ -5363,11 +5395,13 @@ def _stored_sessions_for_tool(
         )
     elif tool == "claude":
         all_sigs: list[tuple[str, int, int]] = []
-        for projects_dir in clientpaths.claude_project_dirs():
+        # The walk over every project dir is the expensive half of this branch
+        # and only feeds the sync.
+        for projects_dir in clientpaths.claude_project_dirs() if sync else ():
             all_sigs.extend(_iter_file_signatures(projects_dir))
         all_sigs.sort(key=lambda item: item[0])
         pricing_sig = _pricing_signature()
-        store.sync_session_files(
+        sync_files(
             "claude",
             tuple(all_sigs),
             parser=_claude_session_parser_signature(),
@@ -5379,7 +5413,7 @@ def _stored_sessions_for_tool(
     elif tool == "kimi":
         signatures = _kimi_session_signatures()
         pricing_sig = _pricing_signature()
-        store.sync_session_files(
+        sync_files(
             "kimi",
             signatures,
             parser=_kimi_session_parser_signature(),
@@ -5391,7 +5425,7 @@ def _stored_sessions_for_tool(
     elif tool == "dsh":
         signatures = _dsh_session_signatures()
         pricing_sig = _pricing_signature()
-        store.sync_session_files(
+        sync_files(
             "dsh",
             signatures,
             parser=_dsh_session_parser_signature(),
@@ -5403,7 +5437,7 @@ def _stored_sessions_for_tool(
     elif tool == "reasonix":
         signatures = _reasonix_session_signatures()
         pricing_sig = _pricing_signature()
-        store.sync_session_files(
+        sync_files(
             "reasonix",
             signatures,
             parser=_reasonix_session_parser_signature(),
@@ -5600,10 +5634,12 @@ def _active_time_comparison(
     here drops the comparison rather than the runtime the card exists to show.
     """
     try:
-        prev_by_tool, _, prev_intervals = _active_time_window(
-            *_previous_window_bounds(period, date_from, date_to),
-            include_codex_review=include_codex_review,
-        )
+        # The current window already synced every stored tool; read that.
+        with _store_sync_suppressed():
+            prev_by_tool, _, prev_intervals = _active_time_window(
+                *_previous_window_bounds(period, date_from, date_to),
+                include_codex_review=include_codex_review,
+            )
     except Exception as error:  # noqa: BLE001 - the current window is what matters
         logger.warning("active time comparison unavailable: %s", error, exc_info=True)
         return None

--- a/src/tokdash/sources/coding_tools.py
+++ b/src/tokdash/sources/coding_tools.py
@@ -85,6 +85,23 @@ class SourceSyncCapability:
     reason: str = ""
 
 
+def _iter_jsonl_lines(path: Path) -> Iterator[str]:
+    """Yield a JSONL file's lines without holding the whole file in memory.
+
+    ``read_text().splitlines()`` materialises the file twice -- once as one
+    string, once as a list of lines -- which for a live Codex rollout of a few
+    hundred MB was a ~3 GB transient per parse, paid by every request that
+    found the file changed. Streaming keeps it at one line. Lines keep their
+    trailing newline; ``json.loads`` ignores it. One deliberate difference: a
+    decode error now surfaces from the line that carries it rather than before
+    the first, so the caller's per-file ``except`` keeps the entries decoded
+    ahead of the bad byte where it used to drop the whole file. Clients write
+    UTF-8, so this is a corner the two copies were never worth.
+    """
+    with path.open(encoding="utf-8") as handle:
+        yield from handle
+
+
 def _timed_sigs(cache_key: str, scan_fn) -> tuple:
     """Return file signatures from *scan_fn*, reusing a cached value within TTL."""
     now = _time.monotonic()
@@ -1056,7 +1073,7 @@ class CodexParser(BaseParser):
                 # must still be resolved by THIS file's model signal.
                 file_entry_indices: set[int] = set()
 
-                for line_no, line in enumerate(session_file.read_text(encoding="utf-8").splitlines(), start=1):
+                for line_no, line in enumerate(_iter_jsonl_lines(session_file), start=1):
                     try:
                         msg = json.loads(line)
                     except Exception:
@@ -1293,7 +1310,7 @@ class ClaudeParser(BaseParser):
         for path_str, _, _ in self._file_signatures():
             session_file = Path(path_str)
             try:
-                for line in session_file.read_text(encoding="utf-8").splitlines():
+                for line in _iter_jsonl_lines(session_file):
                     try:
                         obj = json.loads(line)
                     except Exception:

--- a/src/tokdash/usage_store.py
+++ b/src/tokdash/usage_store.py
@@ -131,6 +131,50 @@ QUOTA_TORN_READ_MIN_PERCENT = 40.0
 _WRITE_LOCK = threading.RLock()
 _SCHEMA_LOCK = threading.RLock()
 _SCHEMA_READY: set[str] = set()
+
+
+class _SyncFlight:
+    """One source's in-process sync gate: a lock, and how many syncs completed."""
+
+    __slots__ = ("lock", "completed")
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.completed = 0
+
+
+_sync_flights: dict[tuple[str, str], _SyncFlight] = {}
+_sync_flights_guard = threading.Lock()
+
+
+def _single_flight_sync(db_path: Path, kind: str, name: str, run: Callable[[], bool]) -> bool:
+    """Run ``run`` unless an identical sync finished while this caller waited for it.
+
+    Parsing happens outside the store's process lock on purpose, so before this
+    gate every request thread that found a source changed parsed it on its own:
+    a dashboard refresh fans out to several routes, each of which syncs Codex and
+    Claude, and a live multi-hundred-MB rollout was parsed once per thread, at
+    the same moment, for the same rows. Serialising per (database, source) and
+    letting a waiter skip when the holder's sync completed keeps one parse per
+    change. A waiter that arrived while nothing was in flight -- or whose holder
+    raised -- still syncs, so sequential callers see exactly what they did before.
+    The result the skipper serves is at most one sync older than its own would
+    have been, the same window a request already accepts between its scan and
+    its read. Cross-process callers are unaffected; ``usage_db_process_lock``
+    still covers the write.
+    """
+    key = (str(db_path), f"{kind}:{name}")
+    with _sync_flights_guard:
+        flight = _sync_flights.get(key)
+        if flight is None:
+            flight = _sync_flights[key] = _SyncFlight()
+        seen = flight.completed
+    with flight.lock:
+        if flight.completed != seen:
+            return False
+        changed = run()
+        flight.completed += 1
+        return changed
 _CODEX_PERCENT_SCALE_REPAIR_META_KEY = "quota_codex_percent_scale_repair_v2"
 _CODEX_PERCENT_SCALE_REPAIR_DONE = "done"
 _GROK_EMAIL_REPAIR_META_KEY = "quota_grok_email_scrub_v1"
@@ -1455,6 +1499,37 @@ class UsageEntryStore:
         durable: Optional[bool] = None,
         cross_file_stable_keys: bool = False,
     ) -> bool:
+        """:meth:`_sync_files_now`, one in flight per source (see ``_single_flight_sync``)."""
+        return _single_flight_sync(
+            self.path,
+            "files",
+            source,
+            lambda: self._sync_files_now(
+                source,
+                file_signatures,
+                parser=parser,
+                pricing_identity=pricing_identity,
+                parse_file_entries=parse_file_entries,
+                parse_file_tail_entries=parse_file_tail_entries,
+                durable=durable,
+                cross_file_stable_keys=cross_file_stable_keys,
+            ),
+        )
+
+    def _sync_files_now(
+        self,
+        source: str,
+        file_signatures: Iterable[Any],
+        *,
+        parser: Any = None,
+        pricing_identity: Any = None,
+        parse_file_entries: Callable[[tuple[str, int, int]], Iterable[dict[str, Any]]],
+        parse_file_tail_entries: Optional[
+            Callable[[tuple[str, int, int], int], tuple[Iterable[dict[str, Any]], int]]
+        ] = None,
+        durable: Optional[bool] = None,
+        cross_file_stable_keys: bool = False,
+    ) -> bool:
         """Sync a file-backed source by replacing only changed files.
 
         This is the middle tier between agentview-style append ingestion and the
@@ -2138,6 +2213,31 @@ class UsageEntryStore:
         return mapping
 
     def sync_session_files(
+        self,
+        tool: str,
+        file_signatures: Iterable[Any],
+        *,
+        parser: Any = None,
+        parse_file_session: Callable[[tuple[str, int, int]], Any],
+        signature_compatible: Optional[Callable[[str, str], bool]] = None,
+        durable: Optional[bool] = None,
+    ) -> bool:
+        """:meth:`_sync_session_files_now`, one in flight per tool (see ``_single_flight_sync``)."""
+        return _single_flight_sync(
+            self.path,
+            "sessions",
+            tool,
+            lambda: self._sync_session_files_now(
+                tool,
+                file_signatures,
+                parser=parser,
+                parse_file_session=parse_file_session,
+                signature_compatible=signature_compatible,
+                durable=durable,
+            ),
+        )
+
+    def _sync_session_files_now(
         self,
         tool: str,
         file_signatures: Iterable[Any],

--- a/tests/test_sync_single_flight.py
+++ b/tests/test_sync_single_flight.py
@@ -115,8 +115,14 @@ def test_usage_parsers_stream_instead_of_reading_whole_file(monkeypatch, _isolat
     else:
         _write_claude(_isolated_home, "s1")
 
+    original_read_text = Path.read_text
+
     def forbidden(self, *args, **kwargs):
-        raise AssertionError(f"read_text() on {self}")
+        # Only the logs are in question. Other reads stay allowed: on a fresh
+        # process the platform detector reads /proc/version on the way here.
+        if self.suffix == ".jsonl":
+            raise AssertionError(f"read_text() on {self}")
+        return original_read_text(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "read_text", forbidden)
     entries = CodingToolsUsageTracker().parsers[source]._parse_all()

--- a/tests/test_sync_single_flight.py
+++ b/tests/test_sync_single_flight.py
@@ -1,0 +1,344 @@
+"""One parse per change, however many threads and windows ask for it.
+
+A dashboard refresh fans out to several routes, each of which syncs the stored
+sources before reading, and the Overview reads two windows per route (current
+and comparison). While a large rollout was being appended to, that turned into
+the same multi-hundred-MB file being parsed once per thread and twice per
+request, with the whole file held in memory each time. These tests pin the
+three fixes: the parsers stream, concurrent syncs of one source collapse into
+one, and the comparison window reads what the current window just synced.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+import tokdash.compute as compute
+import tokdash.sessions as sessions
+from tokdash.sources import coding_tools
+from tokdash.sources.coding_tools import CodingToolsUsageTracker
+from tokdash.usage_store import UsageEntryStore
+
+TS = "2026-05-19T12:00:00Z"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("TOKDASH_DATA_DIR", str(tmp_path / ".tokdash"))
+    monkeypatch.setenv("TOKDASH_USAGE_DB", "1")
+    for var, relative in (
+        ("DSH_HOME", ".dsh"),
+        ("GROK_HOME", ".grok"),
+        ("REASONIX_HOME", ".reasonix"),
+        ("OPENCLAW_HOME", ".openclaw"),
+        ("ZCODE_HOME", ".zcode"),
+        ("KIMI_SHARE_DIR", ".kimi"),
+        ("KIMI_CODE_HOME", ".kimi-code"),
+        ("PI_CODING_AGENT_DIR", ".pi/agent"),
+    ):
+        monkeypatch.setenv(var, str(tmp_path / relative))
+    coding_tools._sig_cache.clear()
+    coding_tools.BaseParser._entry_cache.clear()
+    yield tmp_path
+
+
+def _write_codex(home: Path, stem: str, turns: int = 2) -> Path:
+    rows = [
+        {"type": "session_meta", "payload": {"id": stem, "cwd": "/w", "timestamp": TS}},
+        {"type": "turn_context", "payload": {"model": "gpt-5"}},
+    ]
+    for index in range(turns):
+        rows.append(
+            {
+                "type": "event_msg",
+                "timestamp": TS,
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": 3_000,
+                            "cached_input_tokens": 2_000,
+                            "output_tokens": 100,
+                            "reasoning_output_tokens": 50,
+                        }
+                    },
+                    "id": f"{stem}-{index}",
+                },
+            }
+        )
+    path = home / ".codex" / "sessions" / "2026" / "05" / "19" / f"{stem}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+    return path
+
+
+def _write_claude(home: Path, stem: str, message_ids: tuple[str, ...] = ("m1", "m2")) -> Path:
+    rows = [
+        {
+            "sessionId": stem,
+            "cwd": "/w",
+            "timestamp": TS,
+            "message": {
+                "role": "assistant",
+                "id": message_id,
+                "model": "claude-sonnet-4-5",
+                "usage": {
+                    "input_tokens": 1_000,
+                    "output_tokens": 100,
+                    "cache_read_input_tokens": 2_000,
+                    "cache_creation_input_tokens": 500,
+                },
+            },
+        }
+        for message_id in message_ids
+    ]
+    path = home / ".claude" / "projects" / "proj" / f"{stem}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+    return path
+
+
+# --- the parsers stream -----------------------------------------------------
+
+
+@pytest.mark.parametrize("source", ["codex", "claude"])
+def test_usage_parsers_stream_instead_of_reading_whole_file(monkeypatch, _isolated_home, source):
+    """Neither parser may materialise a log with read_text() any more."""
+    if source == "codex":
+        _write_codex(_isolated_home, "s1")
+    else:
+        _write_claude(_isolated_home, "s1")
+
+    def forbidden(self, *args, **kwargs):
+        raise AssertionError(f"read_text() on {self}")
+
+    monkeypatch.setattr(Path, "read_text", forbidden)
+    entries = CodingToolsUsageTracker().parsers[source]._parse_all()
+    assert len(entries) == 2
+
+
+def test_streaming_parse_matches_splitlines_semantics(_isolated_home):
+    """CRLF endings, a blank line and a torn final line parse as before."""
+    path = _write_codex(_isolated_home, "s1", turns=2)
+    text = path.read_text(encoding="utf-8").replace("\n", "\r\n")
+    path.write_text(text + "\r\n" + '{"type": "event_msg", "payload": {"type": "token_count"', encoding="utf-8")
+    entries = CodingToolsUsageTracker().parsers["codex"]._parse_all()
+    assert len(entries) == 2
+    assert entries[0]["entry_id"] != entries[1]["entry_id"]
+
+
+# --- concurrent syncs of one source collapse into one -------------------------
+
+
+def _race(first_call, second_call, parse_started: threading.Event, release: threading.Event):
+    """Start one sync; let a second arrive while the first is parsing; release both."""
+    results: dict[str, object] = {}
+
+    def first():
+        results["first"] = first_call()
+
+    def second():
+        results["second"] = second_call()
+
+    t1 = threading.Thread(target=first)
+    t1.start()
+    assert parse_started.wait(5)
+    t2 = threading.Thread(target=second)
+    t2.start()
+    # Give the second caller time to reach the gate while the first still holds
+    # it; nothing observable distinguishes "parked" from "not started yet", so
+    # this is a grace period rather than a wait on a condition.
+    time.sleep(0.2)
+    release.set()
+    t1.join(5)
+    t2.join(5)
+    assert not t1.is_alive() and not t2.is_alive()
+    return results
+
+
+def _grow(path: Path) -> tuple[str, int, int]:
+    """Append to a log, as a live client does between two requests' scans."""
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("\n")
+    stat = path.stat()
+    return (str(path), stat.st_mtime_ns, stat.st_size)
+
+
+def test_concurrent_sync_files_parse_once(_isolated_home):
+    path = _write_codex(_isolated_home, "s1")
+    stat = path.stat()
+    parse_started = threading.Event()
+    release = threading.Event()
+    parses: list[str] = []
+
+    def parse(file_sig):
+        parses.append(file_sig[0])
+        parse_started.set()
+        assert release.wait(5)
+        return [
+            {
+                "source": "codex",
+                "model": "gpt-5",
+                "provider": "openai",
+                "input": 1,
+                "output": 1,
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "reasoning": 0,
+                "cost": 0.0,
+                "timestamp": 1_779_278_400_000,
+                "entry_id": "e1",
+            }
+        ]
+
+    def call_sync(sig):
+        return UsageEntryStore().sync_files(
+            "codex",
+            [sig],
+            parser={"object": "test", "version": 1},
+            parse_file_entries=parse,
+        )
+
+    first_sig = (str(path), stat.st_mtime_ns, stat.st_size)
+    # The second request scanned after the client appended, so its signature is
+    # newer than the one being synced. Without the gate it would parse the whole
+    # file again for a few more bytes.
+    later_sig = _grow(path)
+    results = _race(lambda: call_sync(first_sig), lambda: call_sync(later_sig), parse_started, release)
+    assert parses == [str(path)], "the waiter re-parsed a file the holder had just synced"
+    assert results["first"] is True
+    assert results["second"] is False
+
+    # A later, sequential call with that newer signature still syncs: the gate
+    # only collapses callers that overlapped in time.
+    parses.clear()
+    assert call_sync(later_sig) is True
+    assert parses == [str(path)]
+
+
+def test_concurrent_sync_session_files_parse_once(_isolated_home):
+    path = _write_claude(_isolated_home, "s1")
+    stat = path.stat()
+    parse_started = threading.Event()
+    release = threading.Event()
+    parses: list[str] = []
+
+    def parse(file_sig):
+        parses.append(file_sig[0])
+        parse_started.set()
+        assert release.wait(5)
+        return {"id": "s1", "turns": [], "started_at_ms": 1, "last_seen_at_ms": 2}
+
+    def call_sync(sig):
+        return UsageEntryStore().sync_session_files(
+            "claude",
+            [sig],
+            parser={"object": "test", "version": 1},
+            parse_file_session=parse,
+        )
+
+    first_sig = (str(path), stat.st_mtime_ns, stat.st_size)
+    later_sig = _grow(path)
+    results = _race(lambda: call_sync(first_sig), lambda: call_sync(later_sig), parse_started, release)
+    assert parses == [str(path)]
+    assert results["first"] is True
+    assert results["second"] is False
+    parses.clear()
+    assert call_sync(later_sig) is True
+    assert parses == [str(path)]
+
+
+def test_single_flight_does_not_skip_after_the_holder_failed(_isolated_home):
+    """A waiter whose holder raised must sync itself, or its rows go missing."""
+    path = _write_codex(_isolated_home, "s1")
+    stat = path.stat()
+    parse_started = threading.Event()
+    release = threading.Event()
+    calls: list[str] = []
+
+    def parse(file_sig):
+        calls.append("parse")
+        parse_started.set()
+        assert release.wait(5)
+        if len(calls) == 1:
+            raise RuntimeError("torn read")
+        return []
+
+    def call_sync():
+        try:
+            return UsageEntryStore().sync_files(
+                "codex",
+                [(str(path), stat.st_mtime_ns, stat.st_size)],
+                parser={"object": "test", "version": 1},
+                parse_file_entries=parse,
+            )
+        except RuntimeError:
+            return "raised"
+
+    results = _race(call_sync, call_sync, parse_started, release)
+    assert results["first"] == "raised"
+    assert results["second"] is True
+    assert calls == ["parse", "parse"]
+
+
+# --- the comparison window reads what the current window synced ---------------
+
+
+def test_tools_data_for_range_sync_false_never_syncs(monkeypatch):
+    def explode(tracker):
+        raise AssertionError("sync=False must not sync")
+
+    monkeypatch.setattr(compute, "_sync_usage_store", explode)
+    now = datetime.now(timezone.utc)
+    data = compute.get_tools_data_for_range(now - timedelta(days=1), now, sync=False)
+    assert data["total_tokens"] == 0
+
+
+def test_usage_with_comparison_syncs_once(monkeypatch, _isolated_home):
+    _write_codex(_isolated_home, "s1")
+    original = compute._sync_usage_store
+    calls: list[str] = []
+
+    def counting(tracker):
+        calls.append("sync")
+        return original(tracker)
+
+    monkeypatch.setattr(compute, "_sync_usage_store", counting)
+    payload = compute.compute_usage_with_comparison("7")
+    assert calls == ["sync"], "the previous window synced again"
+    assert "comparison" in payload
+
+
+def test_active_time_syncs_each_stored_tool_once(monkeypatch):
+    synced: list[str] = []
+
+    def counting(self, tool, *args, **kwargs):
+        synced.append(tool)
+        return False
+
+    monkeypatch.setattr(UsageEntryStore, "sync_session_files", counting)
+    sessions.get_active_time_data("today")
+    stored = [tool for tool in synced if tool in {"codex", "claude"}]
+    assert sorted(stored) == ["claude", "codex"], synced
+
+
+def test_suppressed_stored_read_skips_sync_and_scan(monkeypatch):
+    monkeypatch.setattr(
+        UsageEntryStore,
+        "sync_session_files",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("synced")),
+    )
+    monkeypatch.setattr(
+        sessions,
+        "_iter_file_signatures",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("walked the project tree")),
+    )
+    with sessions._store_sync_suppressed():
+        assert sessions._stored_sessions_for_tool("claude") == {}
+    assert sessions._store_sync_wanted() is True


### PR DESCRIPTION
## Why

A forced Refresh while a large Codex session is streaming took 30–60 s and pushed the server past 12 GB RSS. The response cache was not the problem, and neither was the session-record JSON decode. The cost was a live ~450 MB Codex rollout being re-parsed whole on every sync, by every request thread at once, twice per request.

## What

**Parsers stream.** `CodexParser` and `ClaudeParser` read each changed log with `read_text().splitlines()`, holding the whole file plus a list of its lines: a 3.3 GB transient per parse on a 400 MB rollout. Both now stream lines through `_iter_jsonl_lines`. Same file: 1.3 s and 55 MB.

**One sync in flight per source.** `sync_files` and `sync_session_files` go through a per-(database, source) single-flight gate. A caller that waited for an in-flight sync of that source skips its own; sequential callers and callers whose holder raised still sync. Parsing stays outside the process lock.

**The comparison window reads what the current window synced.** `/api/usage` synced once for the current window and again for the previous one; `/api/active-time` did the same for its session stores. While the rollout is being appended to, the second sync found it changed again. `get_tools_data_for_range(sync=False)` on the usage side, and a thread-local `_store_sync_suppressed()` around the active-time comparison so the fake loaders in tests keep their signature.

**Pricing.** Adds `claude-fable-5.1` ($10 / $50 per MTok, cache read $0.25, cache write $12.50) with `fable-5.1`, `fable-5-1` and `fable5.1` aliases, taken from the pricing updater's scrape. The updater also proposed two unrelated additions and 84 price changes; those are left for the regular pricing PR.

## Measured

Against a copy of a production database with a 451 MB live rollout:

| | before | after |
|---|---|---|
| Codex usage parse of the live file | 4.4 s, 3.3 GB transient | 1.3 s, 55 MB |
| usage sync with the live file changed | one parse per request thread, ×2 per request | 2.3 s once |
| serial forced Overview refresh | 30–60 s | ~6 s |

## Tests

`tests/test_sync_single_flight.py`: parsers must not call `read_text`, CRLF/torn-line parity, concurrent syncs of one source parse once (second caller carries a newer signature, so it would otherwise re-parse), a waiter whose holder raised still syncs, `sync=False` never syncs, `compute_usage_with_comparison` syncs once, active time syncs each stored tool once, the suppressed read skips both the sync and the project-tree walk. Each fix was mutation-checked: reverting it makes its test fail. Full per-file sweep of the suite passes.

## Note for later

`_codex_session_parser_signature` hashes the whole of `coding_tools.py`, so this change (like any edit to that file) makes every user re-parse their Codex session files once after upgrading. Hashing the function's own source instead is a one-line follow-up.
