### PR TITLE
Release v2.5.1

### DIFF
--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+## 2.5.1 - 2026-09-02
+
+### Added
+
+- `claude-fable-5.1` is in the pricing database at $10 / $50 per MTok with cache reads at $0.25 and cache writes at $12.50, plus `fable-5.1`, `fable-5-1` and `fable5.1` aliases, so Claude Fable 5.1 usage is priced instead of showing as $0. (#64)
+- `tokdash serve --dev-fixture dense [--dev-seed N]` starts the dashboard against a dense synthetic dataset for UI work. Fixture mode reads no local history, credentials or quota snapshots, skips the background workers and rejects mutating requests; the seed is printed so a dataset can be reproduced. (#63, thanks @674019130)
+
+### Fixed
+
+- A forced Refresh while a large Codex session is streaming no longer takes 30–60 s or pushes the server past 12 GB. Three causes, all on the sync path. The Codex and Claude usage parsers read each changed log with `read_text().splitlines()`, a 3.3 GB transient on a 400 MB rollout; they now stream lines (1.3 s and 55 MB for the same file). Every request thread synced on its own, so a refresh fan-out parsed the same changed file once per route at the same moment; `sync_files` and `sync_session_files` now run one sync per source at a time and a caller that waited for an in-flight sync skips its own. And `/api/usage` and `/api/active-time` synced once for the current window and again for the comparison window, which while a rollout is being appended to found it changed again; the comparison window now reads what the first sync stored. A serial forced Overview refresh with a 450 MB live rollout went from 30–60 s to about 6 s. (#64)
+
+### Changed
+
+- The first request after upgrading re-parses every Codex session file once, because the Codex session-parser signature hashes the whole of `coding_tools.py` and this release edits it. On a large history that is a one-off pause of some tens of seconds. (#64)
+
 ## 2.5.0 - 2026-09-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tokdash"
-version = "2.5.0"
+version = "2.5.1"
 description = "Local token & cost dashboard for AI coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tokdash/__init__.py
+++ b/src/tokdash/__init__.py
@@ -1,3 +1,3 @@
 """Tokdash package."""
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"

--- a/src/tokdash/static/release-notes.json
+++ b/src/tokdash/static/release-notes.json
@@ -1,6 +1,31 @@
 {
-  "current": "2.5.0",
+  "current": "2.5.1",
   "releases": [
+    {
+      "version": "2.5.1",
+      "date": "2026-09-02",
+      "sections": [
+        {
+          "type": "added",
+          "items": [
+            "Claude Fable 5.1 is priced, with fable-5.1 style aliases, instead of showing as $0.",
+            "tokdash serve --dev-fixture dense starts the dashboard against a dense synthetic dataset for UI work, reading none of your real history."
+          ]
+        },
+        {
+          "type": "fixed",
+          "items": [
+            "Refresh while a large Codex session is streaming no longer takes 30-60 s or balloons memory: the Codex and Claude parsers stream their logs, one sync runs per source at a time, and the comparison window reuses the current window's sync."
+          ]
+        },
+        {
+          "type": "changed",
+          "items": [
+            "The first request after upgrading re-parses Codex session files once; on a large history that is a one-off pause of some tens of seconds."
+          ]
+        }
+      ]
+    },
     {
       "version": "2.5.0",
       "date": "2026-09-01",


### PR DESCRIPTION
Patch release: the live-Codex-rollout refresh fix and Claude Fable 5.1 pricing from #64, plus the dev fixture from #63. Bumps the version, adds the changelog section and the in-app What's new entry.


### Added

- `claude-fable-5.1` is in the pricing database at $10 / $50 per MTok with cache reads at $0.25 and cache writes at $12.50, plus `fable-5.1`, `fable-5-1` and `fable5.1` aliases, so Claude Fable 5.1 usage is priced instead of showing as $0. (#64)
- `tokdash serve --dev-fixture dense [--dev-seed N]` starts the dashboard against a dense synthetic dataset for UI work. Fixture mode reads no local history, credentials or quota snapshots, skips the background workers and rejects mutating requests; the seed is printed so a dataset can be reproduced. (#63, thanks @674019130)

### Fixed

- A forced Refresh while a large Codex session is streaming no longer takes 30–60 s or pushes the server past 12 GB. Three causes, all on the sync path. The Codex and Claude usage parsers read each changed log with `read_text().splitlines()`, a 3.3 GB transient on a 400 MB rollout; they now stream lines (1.3 s and 55 MB for the same file). Every request thread synced on its own, so a refresh fan-out parsed the same changed file once per route at the same moment; `sync_files` and `sync_session_files` now run one sync per source at a time and a caller that waited for an in-flight sync skips its own. And `/api/usage` and `/api/active-time` synced once for the current window and again for the comparison window, which while a rollout is being appended to found it changed again; the comparison window now reads what the first sync stored. A serial forced Overview refresh with a 450 MB live rollout went from 30–60 s to about 6 s. (#64)

### Changed

- The first request after upgrading re-parses every Codex session file once, because the Codex session-parser signature hashes the whole of `coding_tools.py` and this release edits it. On a large history that is a one-off pause of some tens of seconds. (#64)

