### PR TITLE
Add pricing entries from the 2026-09-03 model scan

### DIFF
--- a/src/tokdash/pricing_db.json
+++ b/src/tokdash/pricing_db.json
@@ -1,19 +1,27 @@
 {
-  "version": "2.0.21",
-  "lastUpdated": "2026-09-02T15:32:40Z",
+  "version": "2.0.22",
+  "lastUpdated": "2026-09-03T10:17:50Z",
   "note": "Comprehensive pricing database with all Moonshot, MiniMax, GLM, and OpenAI models from OpenRouter. Cache pricing estimated at 10% of input for cache_read, 100% of input for cache_write.",
   "aliases": {
+    "Qwen/Qwen3.8-Flash-Next": "qwen3.8-flash",
+    "ark-code": "seed-2.0-code",
     "claude-sonnet-5-20260630": "claude-sonnet-5",
     "cloudflare/glm-5.2": "glm-5.2",
     "doubao-seed-1.6": "seed-1.6",
     "doubao-seed-1.6-flash": "seed-1.6-flash",
+    "doubao-seed-2.0-code": "seed-2.0-code",
     "doubao-seed-2.0-lite": "seed-2.0-lite",
     "doubao-seed-2.0-mini": "seed-2.0-mini",
     "doubao-seed-2.1-turbo": "seed-2.1-turbo",
+    "doubao-seed-code": "seed-2.0-code",
     "fable": "claude-fable-5",
     "fable-5": "claude-fable-5",
+    "fable-5-1": "claude-fable-5.1",
+    "fable-5.1": "claude-fable-5.1",
     "fable5": "claude-fable-5",
+    "fable5.1": "claude-fable-5.1",
     "gemini-3-flash-a": "antigravity-gemini-3-flash",
+    "gemini-3.7-flash-control": "gemini-3.7-flash",
     "glm-5-1": "glm-5.1",
     "glm-5-2": "glm-5.2",
     "glm-5-3": "glm-5.3",
@@ -29,17 +37,22 @@
     "kimi-ai/kimi-2.5": "kimi-k2.5",
     "kimi-code/k3": "kimi-k3",
     "kimi-code/k3-256k": "kimi-k3-256k",
-    "moonshotai/k3-256k": "kimi-k3-256k",
     "kimi-coding/k2p5": "kimi-k2.5",
     "kimi-k2-6": "kimi-k2.6",
     "kimi-k2p6": "kimi-k2.6",
     "kimi2.5": "kimi-k2.5",
     "kimi2.6": "kimi-k2.6",
+    "longcat-2-0": "longcat-2.0",
+    "longcat2.0": "longcat-2.0",
+    "meituan/longcat-2.0": "longcat-2.0",
     "moonshot-ai/kimi-k2.5": "kimi-k2.5",
     "moonshot-ai/kimi-k2.6": "kimi-k2.6",
+    "moonshotai/k3-256k": "kimi-k3-256k",
     "opus-4.7": "claude-opus-4.7",
     "opus-4.8": "claude-opus-4.8",
     "opus-5": "claude-opus-5",
+    "qwen3.8-flash-next": "qwen3.8-flash",
+    "qwen3.8max": "qwen3.8-max",
     "sonnet-5": "claude-sonnet-5",
     "sonnet5": "claude-sonnet-5",
     "vol-engine/kimi-2.5": "kimi-k2.5",
@@ -49,14 +62,7 @@
     "z-ai/glm-5.3": "glm-5.3",
     "zhipu/glm-5.1": "glm-5.1",
     "zhipu/glm-5.2": "glm-5.2",
-    "zhipu/glm-5.3": "glm-5.3",
-    "longcat2.0": "longcat-2.0",
-    "longcat-2-0": "longcat-2.0",
-    "meituan/longcat-2.0": "longcat-2.0",
-    "qwen3.8max": "qwen3.8-max",
-    "fable-5.1": "claude-fable-5.1",
-    "fable-5-1": "claude-fable-5.1",
-    "fable5.1": "claude-fable-5.1"
+    "zhipu/glm-5.3": "glm-5.3"
   },
   "models": {
     "_comment_moonshot": "=== Moonshot AI / Kimi Models ===",
@@ -2394,6 +2400,15 @@
       "unit": "per_million_tokens",
       "source": "openrouter.ai/tencent/hy-mt2-7b"
     },
+    "hy4-preview": {
+      "provider": "tencent",
+      "input": 0.834,
+      "output": 2.501,
+      "cache_read": 0.042,
+      "cache_write": 0.834,
+      "unit": "per_million_tokens",
+      "source": "openrouter.ai/tencent/hy4-preview"
+    },
     "_comment_xai": "=== xAI Grok Models ===",
     "grok-4.20": {
       "provider": "xai",
@@ -2891,6 +2906,15 @@
       "unit": "per_million_tokens",
       "source": "openrouter.ai/google/gemini-3.1-flash-lite-image"
     },
+    "gemini-3.8-flash": {
+      "provider": "google",
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667,
+      "unit": "per_million_tokens",
+      "source": "openrouter.ai/google/gemini-3.8-flash"
+    },
     "_comment_meta": "=== Meta Models ===",
     "llama-3.1-70b-instruct": {
       "provider": "meta",
@@ -2999,6 +3023,24 @@
       "cache_write": 0.1,
       "unit": "per_million_tokens",
       "source": "openrouter.ai/meta/muse-spark-1.2-contributor"
+    },
+    "muse-spark-1.3": {
+      "provider": "meta",
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15,
+      "cache_write": 1.25,
+      "unit": "per_million_tokens",
+      "source": "openrouter.ai/meta/muse-spark-1.3"
+    },
+    "muse-spark-1.3-contributor": {
+      "provider": "meta",
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002,
+      "cache_write": 0.1,
+      "unit": "per_million_tokens",
+      "source": "openrouter.ai/meta/muse-spark-1.3-contributor"
     },
     "_comment_nvidia": "=== NVIDIA Models ===",
     "nemotron-3-nano-30b-a3b": {


### PR DESCRIPTION
Pricing DB 2.0.21 -> 2.0.22. Data only, no code changes.

Two scans drove this: the companion updater scrape (275 models across 25 tracked OpenRouter slugs plus official Z.ai / MiniMax / DeepSeek pages), and a demand-side scan of every distinct model ID in the local usage DB, which found 17 of 120 resolving to no price.

### Scraped adds (4)

| Model | Provider | In | Out | Cache r/w |
| --- | --- | --- | --- | --- |
| gemini-3.8-flash | google | 0.75 | 3.75 | 0.075 / 0.041667 |
| hy4-preview | tencent | 0.834 | 2.501 | 0.042 / 0.834 |
| muse-spark-1.3 | meta | 1.25 | 4.25 | 0.15 / 1.25 |
| muse-spark-1.3-contributor | meta | 0.1 | 0.2 | 0.002 / 0.1 |

All four sourced from openrouter.ai/<provider>/<model>.

### Alias adds (6)

| Alias | Target | Inherited in/out | Tokens logged |
| --- | --- | --- | --- |
| qwen3.8-flash-next | qwen3.8-flash | 0.15 / 0.47 | 67,097,106 |
| Qwen/Qwen3.8-Flash-Next | qwen3.8-flash | 0.15 / 0.47 | 0 |
| gemini-3.7-flash-control | gemini-3.7-flash | 0.75 / 3.75 | 3,680,374 |
| doubao-seed-2.0-code | seed-2.0-code | 0.5 / 3.0 | 37,539 |
| doubao-seed-code | seed-2.0-code | 0.5 / 3.0 | 18,789 |
| ark-code | seed-2.0-code | 0.5 / 3.0 | 0 |

Qwen/Qwen3.8-Flash-Next is the HuggingFace ID OpenRouter lists for qwen/qwen3.8-flash, so that alias points at the same model rather than a guess. doubao-seed-code and ark-code assume Volcengine generic coding IDs resolve to the Seed 2.0 code line; ark-code has no logged volume yet.

### Deliberately not priced

codex-auto-review (1.52B tokens) and gpt-5.3-codex-spark (1.33B) have no published list price, so both stay unpriced. That is roughly 39 percent of ingested tokens contributing zero cost.

### Reproducibility

The same six aliases live in the companion repo at config/aliases.yaml, so the next pricing_updater render reproduces this file. The rendered DB was verified as a clean superset before copying: 4 added models, 4 added aliases, no deletions, no price changes.

### Tests

- Release-safe trio (pricing_db_contract, model_name_normalization, pricing_normalization): 42 passed
- Broader pricing and API set (pricing_db_editor_api, pricing_override_cache_busting, provider_reported_cost, session_cache_pricing, api_smoke, frontend_normalizer_sync): 117 passed, 1 skipped

The same scan flagged 82 price changes on existing models. Those are NOT in this PR.