### PR TITLE
Add seven style themes from cosyncing and fix cross-theme UI defects

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@
 - **Quota tab** *[new]*: subscription window bars with reset countdowns for Codex, Claude Code, and Antigravity. Codex windows work out of the box from local logs; Codex reset credits, metered features, and all Claude/Antigravity quota need opt-in [live polling](#quota-tracking-optional)
 - **Companion Status Bar App** *[new]*: view spend and subscription quota from the macOS menu bar or Windows notification area — on the [Microsoft Store](https://apps.microsoft.com/detail/9ppnmpdq8b52) for Windows — [screenshots and downloads](#tokdash-companion-status-bar-app)
 - **Multi-server views**: add WSL, macOS, and other Tokdash servers in Settings; combine usage across any selection while keeping quota grouped by machine. See [remote access](docs/guides/REMOTE_ACCESS.md).
-- **Themes and app polish**: 10 style themes, light/dark mode, and PWA install support, UI in six languages (English / 中文 / 日本語 / 한국어 / Español / Português)
+- **Themes and app polish**: 17 style themes, light/dark mode, and PWA install support, UI in six languages (English / 中文 / 日本語 / 한국어 / Español / Português)
 
 ### Client support matrix
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -82,7 +82,7 @@
 - **会话浏览器**：逐会话下钻
 - **Companion 状态栏应用** *[新]*：在 macOS 菜单栏或 Windows 通知区域查看费用与订阅额度，Windows 版已上架 [Microsoft Store](https://apps.microsoft.com/detail/9ppnmpdq8b52) — [截图与下载](#tokdash-companion-状态栏应用)
 - **多服务器视图**：在设置中添加 WSL、macOS 或其他 Tokdash 服务器；可合并任意选择的用量，并按机器分组显示额度。参见[远程访问](docs/guides/REMOTE_ACCESS.md)。
-- **主题与应用体验**：10 款样式主题、明暗模式与 PWA 安装支持、六种界面语言（English / 中文 / 日本語 / 한국어 / Español / Português）
+- **主题与应用体验**：17 款样式主题、明暗模式与 PWA 安装支持、六种界面语言（English / 中文 / 日本語 / 한국어 / Español / Português）
 
 ### 客户端支持矩阵
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -84,7 +84,7 @@
 - **Pestaña Quota** *[nuevo]*: barras de ventana de suscripción con cuenta atrás de reinicio para Codex, Claude Code y Antigravity. Las ventanas de Codex funcionan desde los logs locales; los créditos de reinicio de Codex, las funciones con medidor y todas las cuotas de Claude/Antigravity necesitan [consulta en vivo](#seguimiento-de-cuota-opcional) con opt-in
 - **App de barra de estado Companion** *[nuevo]*: consulta el gasto y la cuota de suscripción desde la barra de menú de macOS o el área de notificaciones de Windows — para Windows en [Microsoft Store](https://apps.microsoft.com/detail/9ppnmpdq8b52) — [capturas y descargas](#tokdash-companion-app-de-barra-de-estado)
 - **Vistas multiseservidor**: añade servidores de Tokdash de WSL, macOS u otros en Ajustes; combina el uso de cualquier selección manteniendo la cuota agrupada por máquina. Ver [acceso remoto](docs/guides/REMOTE_ACCESS.md).
-- **Temas y acabado de la app**: 10 temas de estilo, modo claro/oscuro, soporte de instalación PWA y UI en 6 idiomas (English / 中文 / 日本語 / 한국어 / Español / Português)
+- **Temas y acabado de la app**: 17 temas de estilo, modo claro/oscuro, soporte de instalación PWA y UI en 6 idiomas (English / 中文 / 日本語 / 한국어 / Español / Português)
 
 ### Matriz de soporte de clientes
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -84,7 +84,7 @@
 - **Quota タブ** *[新]*: Codex、Claude Code、Antigravity のサブスクリプションウィンドウバーとリセットカウントダウン。Codex ウィンドウはローカルログからそのまま動作。Codex のリセットクレジット、メーターリング機能、すべての Claude/Antigravity クォータにはオプトインの[ライブポーリング](#クォータ追跡任意)が必要
 - **Companion ステータスバーアプリ** *[新]*: macOS メニューバーまたは Windows 通知領域から支出とサブスクリプションクォータを確認 — Windows 版は[Microsoft Store](https://apps.microsoft.com/detail/9ppnmpdq8b52)に対応 — [スクリーンショットとダウンロード](#tokdash-companion-ステータスバーアプリ)
 - **マルチサーバービュー**: 設定から WSL、macOS、その他の Tokdash サーバーを追加。任意の選択で利用量を統合しつつ、クォータはマシン単位でグループ化。[リモートアクセス](docs/guides/REMOTE_ACCESS.md)を参照。
-- **テーマとアプリの洗練**: 10 種類のスタイルテーマ、ライト/ダークモード、PWA インストール対応、6 ヶ国語の UI（English / 中文 / 日本語 / 한국어 / Español / Português）
+- **テーマとアプリの洗練**: 17 種類のスタイルテーマ、ライト/ダークモード、PWA インストール対応、6 ヶ国語の UI（English / 中文 / 日本語 / 한국어 / Español / Português）
 
 ### クライアント対応マトリックス
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -84,7 +84,7 @@
 - **Quota 탭** *[신규]*: Codex, Claude Code, Antigravity의 구독 윈도우 바와 리셋 카운트다운. Codex 윈도우는 로컬 로그로 바로 동작하며, Codex 리셋 크레딧, 미터링 기능, 모든 Claude/Antigravity 쿼터에는 옵트인 [라이브 폴링](#쿼터-추적-선택사항)이 필요합니다
 - **Companion 상태표 앱** *[신규]*: macOS 메뉴 막대나 Windows 알림 영역에서 지출과 구독 쿼터 확인 — Windows는 [Microsoft Store](https://apps.microsoft.com/detail/9ppnmpdq8b52) 제공 — [스크린샷과 다운로드](#tokdash-companion-상태표-앱)
 - **멀티 서버 뷰**: 설정에서 WSL, macOS, 기타 Tokdash 서버를 추가. 임의의 선택 사용량을 합치고 쿼터는 머신별로 그룹화. [원격 접근](docs/guides/REMOTE_ACCESS.md) 참조.
-- **테마와 앱 마감**: 10가지 스타일 테마, 라이트/다크 모드, PWA 설치 지원, 6개 언어 UI (English / 中文 / 日本語 / 한국어 / Español / Português)
+- **테마와 앱 마감**: 17가지 스타일 테마, 라이트/다크 모드, PWA 설치 지원, 6개 언어 UI (English / 中文 / 日本語 / 한국어 / Español / Português)
 
 ### 클라이언트 지원 매트릭스
 

--- a/README_PT.md
+++ b/README_PT.md
@@ -84,7 +84,7 @@
 - **Aba Quota** *[novo]*: barras de janela de assinatura com contagem regressiva de reset para Codex, Claude Code e Antigravity. As janelas do Codex funcionam direto dos logs locais; créditos de reset do Codex, recursos medidos e todas as cotas do Claude/Antigravity exigem [polling ao vivo](#acompanhamento-de-cota-opcional) opt-in
 - **App de barra de status Companion** *[novo]*: veja gasto e cota de assinatura na barra de menu do macOS ou na área de notificação do Windows — para Windows na [Microsoft Store](https://apps.microsoft.com/detail/9ppnmpdq8b52) — [capturas e downloads](#tokdash-companion-app-de-barra-de-status)
 - **Visões multi-servidor**: adicione servidores Tokdash de WSL, macOS e outros nas Configurações; combine o uso de qualquer seleção mantendo a cota agrupada por máquina. Veja [acesso remoto](docs/guides/REMOTE_ACCESS.md).
-- **Temas e acabamento do app**: 10 temas de estilo, modo claro/escuro, suporte a instalação PWA e UI em 6 idiomas (English / 中文 / 日本語 / 한국어 / Español / Português)
+- **Temas e acabamento do app**: 17 temas de estilo, modo claro/escuro, suporte a instalação PWA e UI em 6 idiomas (English / 中文 / 日本語 / 한국어 / Español / Português)
 
 ### Matriz de suporte de clientes
 

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -15,16 +15,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- Seven style themes adapted from cosyncing's theme set: Teal Obsidian, Graphite, Nordic Warmth, Cyber Amber, Royal Navy, Soft Minimalist, and Flat White. Each ships light and dark tokens with its own heatmap and chart palettes, and the picker label is translated in all six UI languages.
+- Seven style themes adapted from cosyncing's theme set: Teal Obsidian, Graphite, Nordic Warmth, Cyber Amber, Royal Navy, Soft Minimalist, and Flat White. Each ships light and dark tokens with its own heatmap and chart palettes, and the picker label is translated in all six UI languages. (#68)
 
 ### Fixed
 
-- The refresh glyph was hardcoded `stroke="white"` in both the header markup and the re-render template, so it disappeared on themes whose primary button is light (studio and brutalist dark, among others). It now follows the button text color.
-- Overview KPI values in the monospace themes (Terminal, Cyber Amber) wrapped onto two lines; the cards now use trimmed type with the `sm:` step-up preserved at reduced sizes.
-- Theme `.ui-input` rules used the `background:` shorthand, which resets the `background-image` that paints the select caret — the dropdown arrow vanished on eleven themes (paper, liquid, terminal and brutalist had it before this branch). They set `background-color` now, and the per-theme option styling moved from `.style-select option` to `.ui-input option`, so every themed select — including the Language dropdown — follows the theme instead of falling back to slate in dark mode.
-- `--color-label` sat below the WCAG AA 4.5:1 floor in nine theme/mode combinations (seven of them new, plus paper light and studio light); the tokens were darkened or made more opaque until they clear the floor on both page and card backgrounds.
-- Flat White set `--shadow-*: none`, which is only legal as a sole value and invalidated every composed `box-shadow` in the base stylesheet — panels opened with no separation from the page. The tokens now use a transparent zero shadow that composes legally.
-- Cyber Amber dark's `--color-cta` was nearly identical to its primary, so cta-toned stats read as duplicates of their neighbours; it is now a distinct orange. Terminal dark rendered slate-blue table text on phosphor green — the slate utilities now remap to theme greens — and both monospace themes apply their font stack to form controls, which do not inherit the body font by default.
+- The refresh glyph was hardcoded `stroke="white"` in both the header markup and the re-render template, so it disappeared on themes whose primary button is light (studio and brutalist dark, among others). It now follows the button text color. (#68)
+- Overview KPI values in the monospace themes (Terminal, Cyber Amber) wrapped onto two lines; the cards now use trimmed type with the `sm:` step-up preserved at reduced sizes. (#68)
+- Theme `.ui-input` rules used the `background:` shorthand, which resets the `background-image` that paints the select caret — the dropdown arrow vanished on eleven themes (paper, liquid, terminal and brutalist had it before this branch). They set `background-color` now, and the per-theme option styling moved from `.style-select option` to `.ui-input option`, so every themed select — including the Language dropdown — follows the theme instead of falling back to slate in dark mode. (#68)
+- `--color-label` sat below the WCAG AA 4.5:1 floor in nine theme/mode combinations (seven of them new, plus paper light and studio light); the tokens were darkened or made more opaque until they clear the floor on both page and card backgrounds. (#68)
+- Flat White set `--shadow-*: none`, which is only legal as a sole value and invalidated every composed `box-shadow` in the base stylesheet — panels opened with no separation from the page. The tokens now use a transparent zero shadow that composes legally. (#68)
+- Cyber Amber dark's `--color-cta` was nearly identical to its primary, so cta-toned stats read as duplicates of their neighbours; it is now a distinct orange. Terminal dark rendered slate-blue table text on phosphor green — the slate utilities now remap to theme greens — and both monospace themes apply their font stack to form controls, which do not inherit the body font by default. (#68)
 
 ## 2.5.1 - 2026-09-02
 

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -13,6 +13,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Added
+
+- Seven style themes adapted from cosyncing's theme set: Teal Obsidian, Graphite, Nordic Warmth, Cyber Amber, Royal Navy, Soft Minimalist, and Flat White. Each ships light and dark tokens with its own heatmap and chart palettes, and the picker label is translated in all six UI languages.
+
+### Fixed
+
+- The refresh glyph was hardcoded `stroke="white"` in both the header markup and the re-render template, so it disappeared on themes whose primary button is light (studio and brutalist dark, among others). It now follows the button text color.
+- Overview KPI values in the monospace themes (Terminal, Cyber Amber) wrapped onto two lines; the cards now use trimmed type with the `sm:` step-up preserved at reduced sizes.
+- Theme `.ui-input` rules used the `background:` shorthand, which resets the `background-image` that paints the select caret — the dropdown arrow vanished on eleven themes (paper, liquid, terminal and brutalist had it before this branch). They set `background-color` now, and the per-theme option styling moved from `.style-select option` to `.ui-input option`, so every themed select — including the Language dropdown — follows the theme instead of falling back to slate in dark mode.
+- `--color-label` sat below the WCAG AA 4.5:1 floor in nine theme/mode combinations (seven of them new, plus paper light and studio light); the tokens were darkened or made more opaque until they clear the floor on both page and card backgrounds.
+- Flat White set `--shadow-*: none`, which is only legal as a sole value and invalidated every composed `box-shadow` in the base stylesheet — panels opened with no separation from the page. The tokens now use a transparent zero shadow that composes legally.
+- Cyber Amber dark's `--color-cta` was nearly identical to its primary, so cta-toned stats read as duplicates of their neighbours; it is now a distinct orange. Terminal dark rendered slate-blue table text on phosphor green — the slate utilities now remap to theme greens — and both monospace themes apply their font stack to form controls, which do not inherit the body font by default.
+
 ## 2.5.1 - 2026-09-02
 
 ### Added

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -1796,8 +1796,8 @@
             <div class="refresh-control">
               <button id="refreshBtn" class="btn btn-primary" aria-label="Refresh dashboard" aria-controls="refreshReport" aria-expanded="false">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                  <path d="M20 12a8 8 0 1 1-2.343-5.657" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                  <path d="M20 4v6h-6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  <path d="M20 12a8 8 0 1 1-2.343-5.657" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  <path d="M20 4v6h-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
                 <span data-i18n="refresh">Refresh</span>
               </button>
@@ -1903,6 +1903,13 @@
                         <option value="brutalist" data-i18n="styleBrutalist">Brutalist</option>
                         <option value="arcade" data-i18n="styleArcade">Arcade</option>
                         <option value="studio" data-i18n="styleStudio">Studio</option>
+                        <option value="obsidian" data-i18n="styleObsidian">Teal Obsidian</option>
+                        <option value="graphite" data-i18n="styleGraphite">Graphite</option>
+                        <option value="nordic" data-i18n="styleNordic">Nordic Warmth</option>
+                        <option value="amber" data-i18n="styleAmber">Cyber Amber</option>
+                        <option value="navy" data-i18n="styleNavy">Royal Navy</option>
+                        <option value="soft" data-i18n="styleSoft">Soft Minimalist</option>
+                        <option value="flat" data-i18n="styleFlat">Flat White</option>
                       </select>
                     </label>
                     <div class="settings-row">
@@ -1938,7 +1945,7 @@
     <div id="overview-content" class="tab-content active">
 
       <!-- KPI cards -->
-      <section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4 mb-6">
+      <section id="overviewKpiGrid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4 mb-6">
         <div class="surface p-5">
           <div class="text-xs font-semibold uppercase tracking-wider" style="color: var(--color-label);" data-i18n="totalTokens">Total Tokens</div>
           <div id="totalTokensWrap" class="overview-token-value-wrap" data-readable="true">
@@ -4462,6 +4469,13 @@
         styleBrutalist: 'Brutalist',
         styleArcade: 'Arcade',
         styleStudio: 'Studio',
+        styleObsidian: 'Teal Obsidian',
+        styleGraphite: 'Graphite',
+        styleNordic: 'Nordic Warmth',
+        styleAmber: 'Cyber Amber',
+        styleNavy: 'Royal Navy',
+        styleSoft: 'Soft Minimalist',
+        styleFlat: 'Flat White',
         loading: 'Loading…',
         whatsNew: 'What\'s new',
         releaseNotes: 'Release notes',
@@ -4862,6 +4876,13 @@
         styleBrutalist: '粗野主义',
         styleArcade: '街机',
         styleStudio: '工作室',
+        styleObsidian: '青曜石',
+        styleGraphite: '石墨',
+        styleNordic: '北欧暖意',
+        styleAmber: '赛博琥珀',
+        styleNavy: '海军蓝',
+        styleSoft: '柔和极简',
+        styleFlat: '平白',
         loading: '加载中…',
         whatsNew: '更新动态',
         releaseNotes: '更新日志',
@@ -5263,6 +5284,13 @@
         styleBrutalist: 'ブラッタリスト',
         styleArcade: 'アーケード',
         styleStudio: 'スタジオ',
+        styleObsidian: 'ティールオブシディアン',
+        styleGraphite: 'グラファイト',
+        styleNordic: 'ノルディック',
+        styleAmber: 'サイバーアンバー',
+        styleNavy: 'ロイヤルネイビー',
+        styleSoft: 'ソフトミニマル',
+        styleFlat: 'フラットホワイト',
         loading: '読み込み中…',
         whatsNew: '新着情報',
         releaseNotes: 'リリースノート',
@@ -5664,6 +5692,13 @@
         styleBrutalist: '브루탈리스트',
         styleArcade: '아케이드',
         styleStudio: '스튜디오',
+        styleObsidian: '틸 옵시디언',
+        styleGraphite: '그래파이트',
+        styleNordic: '노르딕',
+        styleAmber: '사이버 앰버',
+        styleNavy: '로열 네이비',
+        styleSoft: '소프트 미니멀',
+        styleFlat: '플랫 화이트',
         loading: '로딩 중…',
         whatsNew: '새로운 소식',
         releaseNotes: '릴리스 노트',
@@ -6065,6 +6100,13 @@
         styleBrutalist: 'Brutalista',
         styleArcade: 'Sala de juegos',
         styleStudio: 'Estudio',
+        styleObsidian: 'Obsidiana verde',
+        styleGraphite: 'Grafito',
+        styleNordic: 'Calidez nórdica',
+        styleAmber: 'Ámbar cibernético',
+        styleNavy: 'Azul marino',
+        styleSoft: 'Minimalista suave',
+        styleFlat: 'Blanco plano',
         loading: 'Cargando…',
         whatsNew: 'Novedades',
         releaseNotes: 'Notas de versión',
@@ -6466,6 +6508,13 @@
         styleBrutalist: 'Brutalista',
         styleArcade: 'Arcade',
         styleStudio: 'Estúdio',
+        styleObsidian: 'Obsidiana verde',
+        styleGraphite: 'Grafite',
+        styleNordic: 'Calor nórdico',
+        styleAmber: 'Âmbar cibernético',
+        styleNavy: 'Azul-marinho',
+        styleSoft: 'Minimalista suave',
+        styleFlat: 'Branco plano',
         loading: 'Carregando…',
         whatsNew: 'Novidades',
         releaseNotes: 'Notas de versão',
@@ -7308,8 +7357,8 @@
       const iconClass = spinning ? ' class="refresh-icon-spin"' : '';
       refreshBtn.innerHTML = `
         <svg${iconClass} width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <path d="M20 12a8 8 0 1 1-2.343-5.657" stroke="white" stroke-width="2" stroke-linecap="round"/>
-          <path d="M20 4v6h-6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M20 12a8 8 0 1 1-2.343-5.657" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          <path d="M20 4v6h-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
         <span>${label}</span>
       `;

--- a/src/tokdash/static/theme-config.js
+++ b/src/tokdash/static/theme-config.js
@@ -11,6 +11,13 @@
       "brutalist",
       "arcade",
       "studio",
+      "obsidian",
+      "graphite",
+      "nordic",
+      "amber",
+      "navy",
+      "soft",
+      "flat",
     ],
     heatColorsMap: {
       elevated: {
@@ -52,6 +59,34 @@
       studio: {
         light: ["#F5F5F4", "#E7E5E4", "#D6D3D1", "#A8A29E", "#78716C", "#57534E", "#334155", "#111827"],
         dark: ["#101215", "#181C20", "#252B31", "#334155", "#475569", "#64748B", "#CBD5E1", "#F8FAFC"],
+      },
+      obsidian: {
+        light: ["#F0F6F5", "#DCEDEB", "#C4E2DE", "#9FD2CC", "#6FBEB5", "#3FA89C", "#0F766E", "#0B5A54"],
+        dark: ["#0C1216", "#10262A", "#0E3E3E", "#0F5A55", "#0F766E", "#14B8A6", "#2DD4BF", "#99F6E4"],
+      },
+      graphite: {
+        light: ["#F8FAFC", "#EEF2F6", "#E2E8F0", "#CBD5E1", "#94A3B8", "#64748B", "#334155", "#0F172A"],
+        dark: ["#0B0F19", "#141B29", "#1E293B", "#334155", "#475569", "#64748B", "#CBD5E1", "#F8FAFC"],
+      },
+      nordic: {
+        light: ["#F7F6F3", "#EFEDE7", "#E2E0F4", "#C9C5EC", "#A5A1E2", "#818CF8", "#6366F1", "#4F46E5"],
+        dark: ["#1A1815", "#262219", "#2E2B45", "#3F3C74", "#4F46E5", "#6366F1", "#818CF8", "#C7D2FE"],
+      },
+      amber: {
+        light: ["#FAF6EE", "#F4EBD9", "#EBD9B4", "#E0C188", "#D2A24E", "#C2871B", "#9E6600", "#7A4E00"],
+        dark: ["#100D08", "#1D1608", "#332408", "#4A3400", "#6B4A00", "#8A5E00", "#D48F00", "#FFC000"],
+      },
+      navy: {
+        light: ["#F0F4FA", "#E1EBF5", "#CBDCF0", "#A8C4E6", "#7FA6D9", "#5485C9", "#1D4ED8", "#1E3A8A"],
+        dark: ["#0A0E1A", "#101A30", "#16264A", "#1D3560", "#2547A0", "#2B5CE6", "#3B82F6", "#93C5FD"],
+      },
+      soft: {
+        light: ["#F4F4F6", "#E9E9F0", "#DBDBEA", "#C5C5E0", "#A9A9D8", "#8B8BD0", "#6366F1", "#4F46E5"],
+        dark: ["#0F0F12", "#17171D", "#23233A", "#34345C", "#4F46E5", "#6366F1", "#818CF8", "#C7D2FE"],
+      },
+      flat: {
+        light: ["#FCFCFC", "#F5F5F5", "#EAEAEA", "#D4D4D4", "#A3A3A3", "#737373", "#404040", "#000000"],
+        dark: ["#0A0A0A", "#141414", "#1F1F1F", "#2E2E2E", "#525252", "#8C8C8C", "#D4D4D4", "#FFFFFF"],
       },
     },
     chartPaletteMap: {
@@ -95,6 +130,34 @@
         light: ["#111827", "#475569", "#2563EB", "#0F766E", "#DC2626", "#A8A29E"],
         dark: ["#F8FAFC", "#CBD5E1", "#60A5FA", "#34D399", "#FB7185", "#78716C"],
       },
+      obsidian: {
+        light: ["#0F766E", "#0369A1", "#B45309", "#6D28D9", "#BE185D", "#5F7370"],
+        dark: ["#2DD4BF", "#38BDF8", "#F59E0B", "#A78BFA", "#F472B6", "#94A3B8"],
+      },
+      graphite: {
+        light: ["#0F172A", "#2563EB", "#10B981", "#C2410C", "#8B5CF6", "#64748B"],
+        dark: ["#F8FAFC", "#3B82F6", "#34D399", "#F97316", "#A78BFA", "#94A3B8"],
+      },
+      nordic: {
+        light: ["#4F46E5", "#0E7490", "#047857", "#B45309", "#BE185D", "#70655B"],
+        dark: ["#818CF8", "#22D3EE", "#34D399", "#FBBF24", "#F472B6", "#A89F95"],
+      },
+      amber: {
+        light: ["#9E6600", "#0369A1", "#047857", "#A3341B", "#BE185D", "#6E5D4F"],
+        dark: ["#FFC000", "#00E5FF", "#4EDBA4", "#FF9E64", "#F472B6", "#A08B72"],
+      },
+      navy: {
+        light: ["#1D4ED8", "#0369A1", "#047857", "#B45309", "#BE185D", "#3B5580"],
+        dark: ["#3B82F6", "#52C7FA", "#10B981", "#F59E0B", "#F472B6", "#A3C2FA"],
+      },
+      soft: {
+        light: ["#4F46E5", "#096F9C", "#047857", "#9E5704", "#BE185D", "#626270"],
+        dark: ["#818CF8", "#38BDF8", "#34D399", "#FBBF24", "#F472B6", "#A0A0B0"],
+      },
+      flat: {
+        light: ["#000000", "#2563EB", "#059669", "#B44409", "#DB2777", "#737373"],
+        dark: ["#FFFFFF", "#3B82F6", "#34D399", "#F97316", "#F472B6", "#A3A3A3"],
+      },
     },
     themeMetaColors: {
       elevated: { light: "#1E40AF", dark: "#0F172A" },
@@ -107,6 +170,13 @@
       brutalist: { light: "#F7F3E9", dark: "#101010" },
       arcade: { light: "#F6EFFF", dark: "#12061F" },
       studio: { light: "#F5F5F4", dark: "#131417" },
+      obsidian: { light: "#F2F5F4", dark: "#0B0E14" },
+      graphite: { light: "#F8FAFC", dark: "#0B0F19" },
+      nordic: { light: "#FBFBFA", dark: "#181614" },
+      amber: { light: "#FAF6EE", dark: "#0F0D0A" },
+      navy: { light: "#F0F4FA", dark: "#0A0E1A" },
+      soft: { light: "#F4F4F6", dark: "#0F0F12" },
+      flat: { light: "#FCFCFC", dark: "#0A0A0A" },
     },
   });
 

--- a/src/tokdash/static/themes.css
+++ b/src/tokdash/static/themes.css
@@ -126,7 +126,7 @@ html[data-ui-theme="paper"] {
   --color-messages: #B36A3A;
   --color-bg: #F7F2E8;
   --color-border: #DDD0BC;
-  --color-label: rgba(107, 92, 72, 0.88);
+  --color-label: rgba(107, 92, 72, 0.92);
   --color-surface-glass: rgba(255, 250, 241, 0.95);
 }
 
@@ -155,7 +155,7 @@ html[data-ui-theme="paper"] .surface:hover {
 }
 
 html[data-ui-theme="paper"] .ui-input {
-  background: rgba(255, 251, 245, 0.96);
+  background-color: rgba(255, 251, 245, 0.96);
   border-color: rgba(170, 145, 110, 0.22);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.78);
 }
@@ -220,7 +220,7 @@ html[data-ui-theme="paper"] .tab-btn[aria-selected="true"]::after {
   display: none;
 }
 
-html[data-ui-theme="paper"] .style-select option {
+html[data-ui-theme="paper"] .ui-input option {
   background: #FBF7F0;
   color: #2E2A25;
 }
@@ -261,7 +261,7 @@ html.dark[data-ui-theme="paper"] .surface:hover {
 }
 
 html.dark[data-ui-theme="paper"] .ui-input {
-  background: rgba(30, 24, 18, 0.96);
+  background-color: rgba(30, 24, 18, 0.96);
   border-color: rgba(198,168,120,0.20);
 }
 
@@ -323,7 +323,7 @@ html.dark[data-ui-theme="paper"] .tab-btn[aria-selected="true"]::after {
   display: none;
 }
 
-html.dark[data-ui-theme="paper"] .style-select option {
+html.dark[data-ui-theme="paper"] .ui-input option {
   background: #261E16;
   color: #F2E8D8;
 }
@@ -507,7 +507,7 @@ html[data-ui-theme="liquid"] .surface:hover {
 }
 
 html[data-ui-theme="liquid"] .ui-input {
-  background: rgba(255,255,255,0.52);
+  background-color: rgba(255,255,255,0.52);
   border-color: rgba(255,255,255,0.72);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.78);
   backdrop-filter: blur(18px) saturate(170%);
@@ -516,7 +516,7 @@ html[data-ui-theme="liquid"] .ui-input {
 
 html[data-ui-theme="liquid"] .ui-input:hover {
   border-color: rgba(79,124,255,0.28);
-  background: rgba(255,255,255,0.62);
+  background-color: rgba(255,255,255,0.62);
 }
 
 html[data-ui-theme="liquid"] .ui-input:focus {
@@ -582,7 +582,7 @@ html[data-ui-theme="liquid"] .tab-btn[aria-selected="true"]::after {
   display: none;
 }
 
-html[data-ui-theme="liquid"] .style-select option {
+html[data-ui-theme="liquid"] .ui-input option {
   background: #F4F8FF;
   color: #0F172A;
 }
@@ -617,7 +617,7 @@ html.dark[data-ui-theme="liquid"] .surface:hover {
 }
 
 html.dark[data-ui-theme="liquid"] .ui-input {
-  background: rgba(15,23,42,0.44);
+  background-color: rgba(15,23,42,0.44);
   border-color: rgba(148,163,184,0.22);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.06);
   backdrop-filter: blur(18px) saturate(170%);
@@ -626,7 +626,7 @@ html.dark[data-ui-theme="liquid"] .ui-input {
 
 html.dark[data-ui-theme="liquid"] .ui-input:hover {
   border-color: rgba(143,181,255,0.32);
-  background: rgba(15,23,42,0.52);
+  background-color: rgba(15,23,42,0.52);
 }
 
 html.dark[data-ui-theme="liquid"] .ui-input:focus {
@@ -690,7 +690,7 @@ html.dark[data-ui-theme="liquid"] .tab-btn[aria-selected="true"]::after {
   display: none;
 }
 
-html.dark[data-ui-theme="liquid"] .style-select option {
+html.dark[data-ui-theme="liquid"] .ui-input option {
   background: #14213B;
   color: #E2E8F0;
 }
@@ -843,7 +843,7 @@ html[data-ui-theme="terminal"] .surface:hover {
 }
 
 html[data-ui-theme="terminal"] .ui-input {
-  background: rgba(249, 253, 248, 0.96);
+  background-color: rgba(249, 253, 248, 0.96);
   border-color: rgba(20,122,67,0.20);
 }
 
@@ -907,7 +907,7 @@ html[data-ui-theme="terminal"] .tab-btn[aria-selected="true"]::after {
   display: none;
 }
 
-html[data-ui-theme="terminal"] .style-select option {
+html[data-ui-theme="terminal"] .ui-input option {
   background: #F3FAF1;
   color: #133118;
 }
@@ -945,7 +945,7 @@ html.dark[data-ui-theme="terminal"] .surface:hover {
 }
 
 html.dark[data-ui-theme="terminal"] .ui-input {
-  background: rgba(4, 16, 9, 0.98);
+  background-color: rgba(4, 16, 9, 0.98);
   border-color: rgba(82,247,143,0.18);
   color: #B8FFD0;
 }
@@ -1011,10 +1011,15 @@ html.dark[data-ui-theme="terminal"] .tab-btn[aria-selected="true"]::after {
   display: none;
 }
 
-html.dark[data-ui-theme="terminal"] .style-select option {
+html.dark[data-ui-theme="terminal"] .ui-input option {
   background: #08150D;
   color: #D9FFE6;
 }
+
+html.dark[data-ui-theme="terminal"] .text-slate-800 { color: #93FFBA; }
+html.dark[data-ui-theme="terminal"] .text-slate-700 { color: #52F78F; }
+html.dark[data-ui-theme="terminal"] .text-slate-600 { color: #3E9E63; }
+html.dark[data-ui-theme="terminal"] .text-slate-500 { color: #3E9E63; }
 
 /* Brutalist */
 html[data-ui-theme="brutalist"] {
@@ -1077,7 +1082,7 @@ html[data-ui-theme="brutalist"] .tab-btn {
 }
 
 html[data-ui-theme="brutalist"] .ui-input {
-  background: #FFFDF8;
+  background-color: #FFFDF8;
   border: 2px solid #111827;
   box-shadow: none;
 }
@@ -1141,7 +1146,7 @@ html[data-ui-theme="brutalist"] .tab-btn[aria-selected="true"]::after {
   display: none;
 }
 
-html[data-ui-theme="brutalist"] .style-select option {
+html[data-ui-theme="brutalist"] .ui-input option {
   background: #FFFDF8;
   color: #111827;
 }
@@ -1205,7 +1210,7 @@ html.dark[data-ui-theme="brutalist"] .tab-btn {
 }
 
 html.dark[data-ui-theme="brutalist"] .ui-input {
-  background: #0F0F0F;
+  background-color: #0F0F0F;
   border: 2px solid #F5F5F4;
   color: #F8FAFC;
 }
@@ -1269,7 +1274,7 @@ html.dark[data-ui-theme="brutalist"] .tab-btn[aria-selected="true"]::after {
   display: none;
 }
 
-html.dark[data-ui-theme="brutalist"] .style-select option {
+html.dark[data-ui-theme="brutalist"] .ui-input option {
   background: #111111;
   color: #F8FAFC;
 }
@@ -1354,7 +1359,7 @@ html[data-ui-theme="arcade"] .tab-btn[aria-selected="true"]::after {
   display: none;
 }
 
-html[data-ui-theme="arcade"] .style-select option {
+html[data-ui-theme="arcade"] .ui-input option {
   background: #FBF3FF;
   color: #2E1065;
 }
@@ -1438,7 +1443,7 @@ html.dark[data-ui-theme="arcade"] .tab-btn[aria-selected="true"]::after {
   display: none;
 }
 
-html.dark[data-ui-theme="arcade"] .style-select option {
+html.dark[data-ui-theme="arcade"] .ui-input option {
   background: #18082D;
   color: #F5D0FE;
 }
@@ -1452,7 +1457,7 @@ html[data-ui-theme="studio"] {
   --color-messages: #DC2626;
   --color-bg: #F5F5F4;
   --color-border: #D6D3D1;
-  --color-label: rgba(87, 83, 78, 0.78);
+  --color-label: rgba(87, 83, 78, 0.90);
   --color-surface-glass: rgba(255,255,255,0.96);
 }
 
@@ -1522,7 +1527,7 @@ html[data-ui-theme="studio"] .tab-btn[aria-selected="true"]::after {
   display: none;
 }
 
-html[data-ui-theme="studio"] .style-select option {
+html[data-ui-theme="studio"] .ui-input option {
   background: #FFFFFF;
   color: #111827;
 }
@@ -1606,9 +1611,1536 @@ html.dark[data-ui-theme="studio"] .tab-btn[aria-selected="true"]::after {
   display: none;
 }
 
-html.dark[data-ui-theme="studio"] .style-select option {
+html.dark[data-ui-theme="studio"] .ui-input option {
   background: #15171B;
   color: #F8FAFC;
+}
+
+/* Obsidian — adapted from cosyncing's Teal Obsidian */
+html[data-ui-theme="obsidian"] {
+  --color-primary: #0F766E;
+  --color-secondary: #0369A1;
+  --color-cta: #B45309;
+  --color-cost: #047857;
+  --color-messages: #6D28D9;
+  --color-bg: #F2F5F4;
+  --color-text: #1E2927;
+  --color-muted: #5F7370;
+  --color-border: #DBE3E1;
+  --color-label: rgba(74, 90, 87, 0.88);
+  --color-surface-glass: rgba(255, 255, 255, 0.94);
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --datepickr-radius: 10px;
+  --datepickr-day-radius: 6px;
+}
+
+html[data-ui-theme="obsidian"] body {
+  background:
+    radial-gradient(900px 480px at 12% -8%, rgba(15,118,110,0.07), transparent 58%),
+    linear-gradient(180deg, #F7FAF9 0%, #ECF2F0 100%);
+}
+
+html[data-ui-theme="obsidian"] .surface {
+  background: rgba(255, 255, 255, 0.96);
+  border-color: rgba(219, 227, 225, 0.95);
+  box-shadow: 0 8px 20px rgba(30, 41, 39, 0.06);
+}
+
+html[data-ui-theme="obsidian"] .surface:hover {
+  transform: none;
+  box-shadow: 0 10px 24px rgba(30, 41, 39, 0.08);
+}
+
+html[data-ui-theme="obsidian"] .ui-input {
+  background-color: rgba(255, 255, 255, 0.96);
+  border-color: rgba(219, 227, 225, 0.95);
+  border-radius: 8px;
+}
+
+html[data-ui-theme="obsidian"] .ui-input:hover {
+  border-color: rgba(15,118,110,0.30);
+}
+
+html[data-ui-theme="obsidian"] .ui-input:focus {
+  border-color: rgba(15,118,110,0.42);
+  box-shadow: 0 0 0 4px rgba(15,118,110,0.10), 0 1px 3px rgba(30,41,39,0.10);
+}
+
+html[data-ui-theme="obsidian"] .btn::before {
+  display: none;
+}
+
+html[data-ui-theme="obsidian"] .btn-primary {
+  background: #0F766E;
+  box-shadow: 0 10px 22px rgba(15,118,110,0.20);
+}
+
+html[data-ui-theme="obsidian"] .btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15,118,110,0.24);
+}
+
+html[data-ui-theme="obsidian"] .btn-ghost {
+  background: rgba(255, 255, 255, 0.84);
+  border-color: rgba(219,227,225,0.95);
+}
+
+html[data-ui-theme="obsidian"] .btn-ghost:hover {
+  background: rgba(240, 246, 245, 0.98);
+  border-color: rgba(15,118,110,0.26);
+  transform: translateY(-1px);
+}
+
+html[data-ui-theme="obsidian"] .tab-btn {
+  border-radius: 8px;
+  padding: 10px 16px;
+  font-weight: 700;
+  border: 1px solid rgba(219,227,225,0.95);
+  background: rgba(255, 255, 255, 0.84);
+}
+
+html[data-ui-theme="obsidian"] .tab-btn:hover {
+  background: rgba(240,246,245,0.98);
+  border-color: rgba(15,118,110,0.24);
+  transform: translateY(-1px);
+}
+
+html[data-ui-theme="obsidian"] .tab-btn[aria-selected="true"] {
+  color: #0F766E;
+  border-color: rgba(15,118,110,0.30);
+  background: rgba(15,118,110,0.08);
+  box-shadow: none;
+}
+
+html[data-ui-theme="obsidian"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html[data-ui-theme="obsidian"] .ui-input option {
+  background: #FFFFFF;
+  color: #1E2927;
+}
+
+html.dark[data-ui-theme="obsidian"] {
+  --color-primary: #2DD4BF;
+  --color-secondary: #38BDF8;
+  --color-cta: #F59E0B;
+  --color-cost: #14B8A6;
+  --color-messages: #A78BFA;
+  --color-bg: #0B0E14;
+  --color-text: #E2E8F0;
+  --color-muted: #94A3B8;
+  --color-border: #232F42;
+  --color-label: rgba(148, 163, 184, 0.78);
+  --color-surface-glass: rgba(18, 23, 34, 0.94);
+}
+
+html.dark[data-ui-theme="obsidian"] body {
+  background:
+    radial-gradient(900px 480px at 12% -8%, rgba(45,212,191,0.06), transparent 58%),
+    linear-gradient(180deg, #0B0E14 0%, #0D1220 100%);
+}
+
+html.dark[data-ui-theme="obsidian"] .surface {
+  background: rgba(18, 23, 34, 0.94);
+  border-color: rgba(35, 47, 66, 0.95);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.28);
+}
+
+html.dark[data-ui-theme="obsidian"] .surface:hover {
+  transform: none;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.34);
+}
+
+html.dark[data-ui-theme="obsidian"] .ui-input {
+  background-color: rgba(11, 14, 20, 0.96);
+  border-color: rgba(35,47,66,0.95);
+  border-radius: 8px;
+  color: #E2E8F0;
+}
+
+html.dark[data-ui-theme="obsidian"] .ui-input:hover {
+  border-color: rgba(45,212,191,0.30);
+}
+
+html.dark[data-ui-theme="obsidian"] .ui-input:focus {
+  border-color: rgba(45,212,191,0.44);
+  box-shadow: 0 0 0 4px rgba(45,212,191,0.10), 0 1px 3px rgba(0,0,0,0.30);
+}
+
+html.dark[data-ui-theme="obsidian"] .btn::before {
+  display: none;
+}
+
+html.dark[data-ui-theme="obsidian"] .btn-primary {
+  background: #2DD4BF;
+  color: #0B0E14;
+  box-shadow: 0 10px 22px rgba(45,212,191,0.16);
+}
+
+html.dark[data-ui-theme="obsidian"] .btn-primary:hover {
+  box-shadow: 0 12px 24px rgba(45,212,191,0.22);
+}
+
+html.dark[data-ui-theme="obsidian"] .btn-ghost {
+  background: rgba(18, 23, 34, 0.92);
+  border-color: rgba(35,47,66,0.95);
+}
+
+html.dark[data-ui-theme="obsidian"] .btn-ghost:hover {
+  background: rgba(27, 35, 50, 0.98);
+  border-color: rgba(45,212,191,0.26);
+}
+
+html.dark[data-ui-theme="obsidian"] .tab-btn {
+  border-radius: 8px;
+  padding: 10px 16px;
+  font-weight: 700;
+  border: 1px solid rgba(35,47,66,0.95);
+  background: rgba(18, 23, 34, 0.92);
+  color: #CBD5E1;
+}
+
+html.dark[data-ui-theme="obsidian"] .tab-btn:hover {
+  background: rgba(27,35,50,0.98);
+  border-color: rgba(45,212,191,0.24);
+  transform: translateY(-1px);
+}
+
+html.dark[data-ui-theme="obsidian"] .tab-btn[aria-selected="true"] {
+  color: #2DD4BF;
+  border-color: rgba(45,212,191,0.32);
+  background: rgba(45,212,191,0.10);
+  box-shadow: none;
+}
+
+html.dark[data-ui-theme="obsidian"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html.dark[data-ui-theme="obsidian"] .ui-input option {
+  background: #121722;
+  color: #E2E8F0;
+}
+
+/* Graphite — adapted from cosyncing's Graphite Minimalist */
+html[data-ui-theme="graphite"] {
+  --color-primary: #0F172A;
+  --color-secondary: #2563EB;
+  --color-cta: #C2410C;
+  --color-cost: #10B981;
+  --color-messages: #8B5CF6;
+  --color-bg: #F8FAFC;
+  --color-text: #0F172A;
+  --color-muted: #475569;
+  --color-border: #E2E8F0;
+  --color-label: rgba(71, 85, 105, 0.85);
+  --color-surface-glass: rgba(255, 255, 255, 0.97);
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --shadow-sm: 0 1px 2px rgba(15,23,42,0.05);
+  --shadow-md: 0 4px 12px rgba(15,23,42,0.06);
+  --shadow-lg: 0 10px 28px rgba(15,23,42,0.08);
+  --datepickr-radius: 8px;
+  --datepickr-day-radius: 4px;
+}
+
+html[data-ui-theme="graphite"] body {
+  background: linear-gradient(180deg, #FAFBFC 0%, #F1F5F9 100%);
+}
+
+html[data-ui-theme="graphite"] .surface {
+  background: rgba(255, 255, 255, 0.97);
+  border-color: #E2E8F0;
+  box-shadow: var(--shadow-md);
+}
+
+html[data-ui-theme="graphite"] .surface:hover {
+  transform: none;
+  box-shadow: var(--shadow-md);
+}
+
+html[data-ui-theme="graphite"] .ui-input {
+  background-color: #FFFFFF;
+  border-color: #E2E8F0;
+  border-radius: 6px;
+}
+
+html[data-ui-theme="graphite"] .ui-input:hover {
+  border-color: #CBD5E1;
+}
+
+html[data-ui-theme="graphite"] .ui-input:focus {
+  border-color: rgba(15,23,42,0.40);
+  box-shadow: 0 0 0 4px rgba(15,23,42,0.08);
+}
+
+html[data-ui-theme="graphite"] .btn::before {
+  display: none;
+}
+
+html[data-ui-theme="graphite"] .btn-primary {
+  background: #0F172A;
+  box-shadow: 0 8px 18px rgba(15,23,42,0.18);
+}
+
+html[data-ui-theme="graphite"] .btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(15,23,42,0.20);
+}
+
+html[data-ui-theme="graphite"] .btn-ghost {
+  background: #FFFFFF;
+  border-color: #E2E8F0;
+}
+
+html[data-ui-theme="graphite"] .btn-ghost:hover {
+  background: #F8FAFC;
+  border-color: #CBD5E1;
+  transform: translateY(-1px);
+}
+
+html[data-ui-theme="graphite"] .tab-btn {
+  border-radius: 6px;
+  padding: 10px 16px;
+  font-weight: 700;
+  border: 1px solid #E2E8F0;
+  background: #FFFFFF;
+}
+
+html[data-ui-theme="graphite"] .tab-btn:hover {
+  background: #F8FAFC;
+  border-color: #CBD5E1;
+  transform: translateY(-1px);
+}
+
+html[data-ui-theme="graphite"] .tab-btn[aria-selected="true"] {
+  color: #FFFFFF;
+  border-color: #0F172A;
+  background: #0F172A;
+  box-shadow: none;
+}
+
+html[data-ui-theme="graphite"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html[data-ui-theme="graphite"] .ui-input option {
+  background: #FFFFFF;
+  color: #0F172A;
+}
+
+html.dark[data-ui-theme="graphite"] {
+  --color-primary: #F8FAFC;
+  --color-secondary: #3B82F6;
+  --color-cta: #F97316;
+  --color-cost: #34D399;
+  --color-messages: #A78BFA;
+  --color-bg: #0B0F19;
+  --color-text: #F8FAFC;
+  --color-muted: #94A3B8;
+  --color-border: #334155;
+  --color-label: rgba(148, 163, 184, 0.80);
+  --color-surface-glass: rgba(18, 24, 38, 0.97);
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.40);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.36);
+  --shadow-lg: 0 10px 28px rgba(0,0,0,0.44);
+}
+
+html.dark[data-ui-theme="graphite"] body {
+  background: linear-gradient(180deg, #0B0F19 0%, #0D1320 100%);
+}
+
+html.dark[data-ui-theme="graphite"] .surface {
+  background: rgba(18, 24, 38, 0.97);
+  border-color: #334155;
+  box-shadow: var(--shadow-md);
+}
+
+html.dark[data-ui-theme="graphite"] .surface:hover {
+  transform: none;
+  box-shadow: var(--shadow-md);
+}
+
+html.dark[data-ui-theme="graphite"] .ui-input {
+  background-color: #0B0F19;
+  border-color: #334155;
+  border-radius: 6px;
+  color: #F8FAFC;
+}
+
+html.dark[data-ui-theme="graphite"] .ui-input:hover {
+  border-color: #475569;
+}
+
+html.dark[data-ui-theme="graphite"] .ui-input:focus {
+  border-color: rgba(248,250,252,0.42);
+  box-shadow: 0 0 0 4px rgba(248,250,252,0.08);
+}
+
+html.dark[data-ui-theme="graphite"] .btn::before {
+  display: none;
+}
+
+html.dark[data-ui-theme="graphite"] .btn-primary {
+  background: #F8FAFC;
+  color: #0F172A;
+  box-shadow: 0 8px 18px rgba(248,250,252,0.10);
+}
+
+html.dark[data-ui-theme="graphite"] .btn-primary:hover {
+  box-shadow: 0 10px 20px rgba(248,250,252,0.14);
+}
+
+html.dark[data-ui-theme="graphite"] .btn-ghost {
+  background: rgba(18,24,38,0.97);
+  border-color: #334155;
+}
+
+html.dark[data-ui-theme="graphite"] .btn-ghost:hover {
+  background: rgba(30,41,59,0.98);
+  border-color: #475569;
+}
+
+html.dark[data-ui-theme="graphite"] .tab-btn {
+  border-radius: 6px;
+  padding: 10px 16px;
+  font-weight: 700;
+  border: 1px solid #334155;
+  background: rgba(18,24,38,0.97);
+  color: #E2E8F0;
+}
+
+html.dark[data-ui-theme="graphite"] .tab-btn:hover {
+  background: rgba(30,41,59,0.98);
+  border-color: #475569;
+  transform: translateY(-1px);
+}
+
+html.dark[data-ui-theme="graphite"] .tab-btn[aria-selected="true"] {
+  color: #0F172A;
+  border-color: #F8FAFC;
+  background: #F8FAFC;
+  box-shadow: none;
+}
+
+html.dark[data-ui-theme="graphite"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html.dark[data-ui-theme="graphite"] .ui-input option {
+  background: #121826;
+  color: #F8FAFC;
+}
+
+/* Nordic — adapted from cosyncing's Nordic Warmth */
+html[data-ui-theme="nordic"] {
+  --color-primary: #4F46E5;
+  --color-secondary: #0E7490;
+  --color-cta: #B45309;
+  --color-cost: #047857;
+  --color-messages: #BE185D;
+  --color-bg: #FBFBFA;
+  --color-text: #2E251E;
+  --color-muted: #70655B;
+  --color-border: #EBE8E2;
+  --color-label: rgba(112, 101, 91, 0.95);
+  --color-surface-glass: rgba(255, 255, 255, 0.94);
+}
+
+html[data-ui-theme="nordic"] body {
+  background:
+    radial-gradient(900px 480px at 10% -6%, rgba(180,83,9,0.05), transparent 58%),
+    linear-gradient(180deg, #FCFCFB 0%, #F4F2ED 100%);
+}
+
+html[data-ui-theme="nordic"] .surface {
+  background: rgba(255, 255, 255, 0.96);
+  border-color: #EBE8E2;
+  box-shadow: 0 8px 22px rgba(46, 37, 30, 0.06);
+}
+
+html[data-ui-theme="nordic"] .surface:hover {
+  transform: none;
+  box-shadow: 0 12px 26px rgba(46, 37, 30, 0.08);
+}
+
+html[data-ui-theme="nordic"] .ui-input {
+  background-color: rgba(255, 255, 255, 0.97);
+  border-color: #EBE8E2;
+}
+
+html[data-ui-theme="nordic"] .ui-input:hover {
+  border-color: rgba(79,70,229,0.26);
+}
+
+html[data-ui-theme="nordic"] .ui-input:focus {
+  border-color: rgba(79,70,229,0.40);
+  box-shadow: 0 0 0 4px rgba(79,70,229,0.08), 0 1px 3px rgba(46,37,30,0.10);
+}
+
+html[data-ui-theme="nordic"] .btn::before {
+  display: none;
+}
+
+html[data-ui-theme="nordic"] .btn-primary {
+  background: #4F46E5;
+  box-shadow: 0 10px 22px rgba(79,70,229,0.20);
+}
+
+html[data-ui-theme="nordic"] .btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(79,70,229,0.24);
+}
+
+html[data-ui-theme="nordic"] .btn-ghost {
+  background: rgba(255, 255, 255, 0.86);
+  border-color: #EBE8E2;
+}
+
+html[data-ui-theme="nordic"] .btn-ghost:hover {
+  background: rgba(244, 243, 240, 0.98);
+  border-color: rgba(79,70,229,0.22);
+  transform: translateY(-1px);
+}
+
+html[data-ui-theme="nordic"] .tab-btn {
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-weight: 700;
+  border: 1px solid #EBE8E2;
+  background: rgba(255, 255, 255, 0.86);
+}
+
+html[data-ui-theme="nordic"] .tab-btn:hover {
+  background: rgba(244,243,240,0.98);
+  border-color: rgba(79,70,229,0.20);
+  transform: translateY(-1px);
+}
+
+html[data-ui-theme="nordic"] .tab-btn[aria-selected="true"] {
+  color: #4F46E5;
+  border-color: rgba(79,70,229,0.28);
+  background: rgba(79,70,229,0.08);
+  box-shadow: none;
+}
+
+html[data-ui-theme="nordic"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html[data-ui-theme="nordic"] .ui-input option {
+  background: #FFFFFF;
+  color: #2E251E;
+}
+
+html.dark[data-ui-theme="nordic"] {
+  --color-primary: #818CF8;
+  --color-secondary: #22D3EE;
+  --color-cta: #FBBF24;
+  --color-cost: #34D399;
+  --color-messages: #F472B6;
+  --color-bg: #181614;
+  --color-text: #F5F2EB;
+  --color-muted: #A89F95;
+  --color-border: #3C3631;
+  --color-label: rgba(168, 159, 149, 0.82);
+  --color-surface-glass: rgba(34, 30, 27, 0.94);
+}
+
+html.dark[data-ui-theme="nordic"] body {
+  background:
+    radial-gradient(900px 480px at 10% -6%, rgba(129,140,248,0.05), transparent 58%),
+    linear-gradient(180deg, #181614 0%, #1D1917 100%);
+}
+
+html.dark[data-ui-theme="nordic"] .surface {
+  background: rgba(34, 30, 27, 0.94);
+  border-color: #3C3631;
+  box-shadow: 0 8px 22px rgba(0,0,0,0.28);
+}
+
+html.dark[data-ui-theme="nordic"] .surface:hover {
+  transform: none;
+  box-shadow: 0 12px 26px rgba(0,0,0,0.34);
+}
+
+html.dark[data-ui-theme="nordic"] .ui-input {
+  background-color: rgba(24, 22, 20, 0.97);
+  border-color: #3C3631;
+  color: #F5F2EB;
+}
+
+html.dark[data-ui-theme="nordic"] .ui-input:hover {
+  border-color: rgba(129,140,248,0.28);
+}
+
+html.dark[data-ui-theme="nordic"] .ui-input:focus {
+  border-color: rgba(129,140,248,0.42);
+  box-shadow: 0 0 0 4px rgba(129,140,248,0.10), 0 1px 3px rgba(0,0,0,0.30);
+}
+
+html.dark[data-ui-theme="nordic"] .btn::before {
+  display: none;
+}
+
+html.dark[data-ui-theme="nordic"] .btn-primary {
+  background: #818CF8;
+  color: #181614;
+  box-shadow: 0 10px 22px rgba(129,140,248,0.18);
+}
+
+html.dark[data-ui-theme="nordic"] .btn-primary:hover {
+  box-shadow: 0 12px 24px rgba(129,140,248,0.24);
+}
+
+html.dark[data-ui-theme="nordic"] .btn-ghost {
+  background: rgba(34, 30, 27, 0.90);
+  border-color: #3C3631;
+}
+
+html.dark[data-ui-theme="nordic"] .btn-ghost:hover {
+  background: rgba(46, 41, 37, 0.98);
+  border-color: rgba(129,140,248,0.24);
+}
+
+html.dark[data-ui-theme="nordic"] .tab-btn {
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-weight: 700;
+  border: 1px solid #3C3631;
+  background: rgba(34, 30, 27, 0.90);
+  color: #E7E0D6;
+}
+
+html.dark[data-ui-theme="nordic"] .tab-btn:hover {
+  background: rgba(46,41,37,0.98);
+  border-color: rgba(129,140,248,0.22);
+  transform: translateY(-1px);
+}
+
+html.dark[data-ui-theme="nordic"] .tab-btn[aria-selected="true"] {
+  color: #A5B0FC;
+  border-color: rgba(129,140,248,0.30);
+  background: rgba(129,140,248,0.12);
+  box-shadow: none;
+}
+
+html.dark[data-ui-theme="nordic"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html.dark[data-ui-theme="nordic"] .ui-input option {
+  background: #221E1B;
+  color: #F5F2EB;
+}
+
+/* Amber — adapted from cosyncing's Cyber Amber */
+html[data-ui-theme="amber"] {
+  --color-primary: #9E6600;
+  --color-secondary: #0369A1;
+  --color-cta: #A3341B;
+  --color-cost: #047857;
+  --color-messages: #BE185D;
+  --color-bg: #FAF6EE;
+  --color-text: #29211A;
+  --color-muted: #6E5D4F;
+  --color-border: #E3DAC9;
+  --color-label: rgba(110, 93, 79, 0.90);
+  --color-surface-glass: rgba(255, 255, 255, 0.95);
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --datepickr-radius: 6px;
+  --datepickr-day-radius: 4px;
+}
+
+html[data-ui-theme="amber"] body {
+  font-family: "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background:
+    radial-gradient(900px 480px at 12% -8%, rgba(158,102,0,0.06), transparent 58%),
+    linear-gradient(180deg, #FBF7EF 0%, #F4ECDC 100%);
+}
+
+html[data-ui-theme="amber"] .surface {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: #E3DAC9;
+  box-shadow: 0 10px 22px rgba(41, 33, 26, 0.07), inset 0 1px 0 rgba(255,255,255,0.72);
+}
+
+html[data-ui-theme="amber"] .surface:hover {
+  transform: none;
+  box-shadow: 0 12px 26px rgba(41, 33, 26, 0.09), inset 0 1px 0 rgba(255,255,255,0.76);
+}
+
+html[data-ui-theme="amber"] .ui-input {
+  background-color: rgba(255, 253, 248, 0.97);
+  border-color: #E3DAC9;
+  border-radius: 6px;
+}
+
+html[data-ui-theme="amber"] .ui-input:hover {
+  border-color: rgba(158,102,0,0.30);
+}
+
+html[data-ui-theme="amber"] .ui-input:focus {
+  border-color: rgba(158,102,0,0.44);
+  box-shadow: 0 0 0 4px rgba(158,102,0,0.10), 0 1px 3px rgba(41,33,26,0.10);
+}
+
+html[data-ui-theme="amber"] .btn::before {
+  display: none;
+}
+
+html[data-ui-theme="amber"] .btn-primary {
+  background: #9E6600;
+  box-shadow: 0 10px 22px rgba(158,102,0,0.22);
+}
+
+html[data-ui-theme="amber"] .btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(158,102,0,0.26);
+}
+
+html[data-ui-theme="amber"] .btn-ghost {
+  background: rgba(255, 252, 246, 0.88);
+  border-color: #E3DAC9;
+}
+
+html[data-ui-theme="amber"] .btn-ghost:hover {
+  background: rgba(250, 246, 238, 0.98);
+  border-color: rgba(158,102,0,0.28);
+  transform: translateY(-1px);
+}
+
+html[data-ui-theme="amber"] .tab-btn {
+  border-radius: 6px;
+  padding: 10px 14px;
+  font-weight: 700;
+  border: 1px solid #E3DAC9;
+  background: rgba(255, 252, 246, 0.88);
+}
+
+html[data-ui-theme="amber"] .tab-btn:hover {
+  background: rgba(250,246,238,0.98);
+  border-color: rgba(158,102,0,0.26);
+  transform: translateY(-1px);
+}
+
+html[data-ui-theme="amber"] .tab-btn[aria-selected="true"] {
+  color: #9E6600;
+  border-color: rgba(158,102,0,0.34);
+  background: rgba(158,102,0,0.10);
+  box-shadow: none;
+}
+
+html[data-ui-theme="amber"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html[data-ui-theme="amber"] .ui-input option {
+  background: #FFFFFF;
+  color: #29211A;
+}
+
+html.dark[data-ui-theme="amber"] {
+  --color-primary: #FFC000;
+  --color-secondary: #00E5FF;
+  --color-cta: #FF9E64;
+  --color-cost: #4EDBA4;
+  --color-messages: #F472B6;
+  --color-bg: #0F0D0A;
+  --color-text: #FFB000;
+  --color-muted: #D48F00;
+  --color-border: #3B3026;
+  --color-label: rgba(212, 143, 0, 0.82);
+  --color-surface-glass: rgba(26, 22, 18, 0.94);
+}
+
+html.dark[data-ui-theme="amber"] body {
+  font-family: "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background:
+    linear-gradient(180deg, rgba(255,192,0,0.03), rgba(255,192,0,0.03)),
+    repeating-linear-gradient(180deg, rgba(255,192,0,0.04) 0, rgba(255,192,0,0.04) 1px, transparent 1px, transparent 3px),
+    radial-gradient(900px 480px at 50% -10%, rgba(255,192,0,0.08), transparent 55%),
+    linear-gradient(180deg, #0F0D0A 0%, #14100A 100%);
+}
+
+html.dark[data-ui-theme="amber"] .surface {
+  background: rgba(26, 22, 18, 0.94);
+  border-color: rgba(255,192,0,0.16);
+  box-shadow: 0 0 0 1px rgba(255,192,0,0.03), 0 16px 34px rgba(0,0,0,0.42), 0 0 24px rgba(255,192,0,0.05);
+}
+
+html.dark[data-ui-theme="amber"] .surface:hover {
+  transform: none;
+  box-shadow: 0 0 0 1px rgba(255,192,0,0.05), 0 18px 38px rgba(0,0,0,0.48), 0 0 28px rgba(255,192,0,0.07);
+}
+
+html.dark[data-ui-theme="amber"] .ui-input {
+  background-color: rgba(15, 13, 10, 0.98);
+  border-color: rgba(255,192,0,0.18);
+  border-radius: 6px;
+  color: #FFD24D;
+}
+
+html.dark[data-ui-theme="amber"] .ui-input:hover {
+  border-color: rgba(255,192,0,0.28);
+}
+
+html.dark[data-ui-theme="amber"] .ui-input:focus {
+  border-color: rgba(255,192,0,0.38);
+  box-shadow: 0 0 0 4px rgba(255,192,0,0.08), 0 0 20px rgba(255,192,0,0.08);
+}
+
+html.dark[data-ui-theme="amber"] .btn::before {
+  display: none;
+}
+
+html.dark[data-ui-theme="amber"] .btn-primary {
+  background: #FFC000;
+  color: #0F0D0A;
+  box-shadow: 0 14px 30px rgba(0,0,0,0.42), 0 0 20px rgba(255,192,0,0.14);
+}
+
+html.dark[data-ui-theme="amber"] .btn-primary:hover {
+  box-shadow: 0 16px 34px rgba(0,0,0,0.48), 0 0 26px rgba(255,192,0,0.20);
+}
+
+html.dark[data-ui-theme="amber"] .btn-ghost {
+  background: rgba(15, 13, 10, 0.90);
+  border-color: rgba(255,192,0,0.16);
+  color: #FFD24D;
+}
+
+html.dark[data-ui-theme="amber"] .btn-ghost:hover {
+  background: rgba(38, 32, 26, 0.98);
+  border-color: rgba(255,192,0,0.28);
+}
+
+html.dark[data-ui-theme="amber"] .tab-btn {
+  border-radius: 6px;
+  padding: 10px 14px;
+  font-weight: 700;
+  border: 1px solid rgba(255,192,0,0.16);
+  background: rgba(15, 13, 10, 0.90);
+  color: #FFD24D;
+}
+
+html.dark[data-ui-theme="amber"] .tab-btn:hover {
+  background: rgba(38,32,26,0.98);
+  border-color: rgba(255,192,0,0.26);
+  transform: translateY(-1px);
+}
+
+html.dark[data-ui-theme="amber"] .tab-btn[aria-selected="true"] {
+  color: #0F0D0A;
+  border-color: #FFC000;
+  background: #FFC000;
+  box-shadow: 0 0 18px rgba(255,192,0,0.24);
+}
+
+html.dark[data-ui-theme="amber"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html.dark[data-ui-theme="amber"] .ui-input option {
+  background: #1A1612;
+  color: #FFD24D;
+}
+
+/* The amber phosphor palette extends to the slate-typed table cells. */
+html.dark[data-ui-theme="amber"] .text-slate-800 { color: #FFC42E; }
+html.dark[data-ui-theme="amber"] .text-slate-700 { color: #E09F00; }
+html.dark[data-ui-theme="amber"] .text-slate-600 { color: #B07E0A; }
+html.dark[data-ui-theme="amber"] .text-slate-500 { color: #B07E0A; }
+html.dark[data-ui-theme="amber"] .update-enable-link { color: var(--color-muted); }
+
+/* Navy — adapted from cosyncing's Royal Navy */
+html[data-ui-theme="navy"] {
+  --color-primary: #1D4ED8;
+  --color-secondary: #0369A1;
+  --color-cta: #B45309;
+  --color-cost: #047857;
+  --color-messages: #BE185D;
+  --color-bg: #F0F4FA;
+  --color-text: #0D1E3D;
+  --color-muted: #3B5580;
+  --color-border: #C9D8E6;
+  --color-label: rgba(59, 85, 128, 0.86);
+  --color-surface-glass: rgba(255, 255, 255, 0.95);
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --datepickr-radius: 10px;
+  --datepickr-day-radius: 6px;
+}
+
+html[data-ui-theme="navy"] body {
+  background:
+    radial-gradient(980px 520px at 14% -8%, rgba(29,78,216,0.07), transparent 60%),
+    radial-gradient(880px 500px at 88% 4%, rgba(3,105,161,0.05), transparent 56%),
+    linear-gradient(180deg, #F3F7FC 0%, #E7EFF8 100%);
+}
+
+html[data-ui-theme="navy"] .surface {
+  background: rgba(255, 255, 255, 0.96);
+  border-color: #C9D8E6;
+  box-shadow: 0 10px 24px rgba(13, 30, 61, 0.07);
+}
+
+html[data-ui-theme="navy"] .surface:hover {
+  transform: none;
+  box-shadow: 0 12px 28px rgba(13, 30, 61, 0.09);
+}
+
+html[data-ui-theme="navy"] .ui-input {
+  background-color: rgba(255, 255, 255, 0.97);
+  border-color: #C9D8E6;
+  border-radius: 8px;
+}
+
+html[data-ui-theme="navy"] .ui-input:hover {
+  border-color: rgba(29,78,216,0.30);
+}
+
+html[data-ui-theme="navy"] .ui-input:focus {
+  border-color: rgba(29,78,216,0.44);
+  box-shadow: 0 0 0 4px rgba(29,78,216,0.10), 0 1px 3px rgba(13,30,61,0.10);
+}
+
+html[data-ui-theme="navy"] .btn::before {
+  display: none;
+}
+
+html[data-ui-theme="navy"] .btn-primary {
+  background: linear-gradient(180deg, #2563EB 0%, #1D4ED8 100%);
+  box-shadow: 0 10px 24px rgba(29,78,216,0.24), inset 0 1px 0 rgba(255,255,255,0.18);
+}
+
+html[data-ui-theme="navy"] .btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(29,78,216,0.28), inset 0 1px 0 rgba(255,255,255,0.20);
+}
+
+html[data-ui-theme="navy"] .btn-ghost {
+  background: rgba(255, 255, 255, 0.86);
+  border-color: #C9D8E6;
+}
+
+html[data-ui-theme="navy"] .btn-ghost:hover {
+  background: rgba(240, 244, 250, 0.98);
+  border-color: rgba(29,78,216,0.26);
+  transform: translateY(-1px);
+}
+
+html[data-ui-theme="navy"] .tab-btn {
+  border-radius: 8px;
+  padding: 10px 16px;
+  font-weight: 700;
+  border: 1px solid #C9D8E6;
+  background: rgba(255, 255, 255, 0.86);
+}
+
+html[data-ui-theme="navy"] .tab-btn:hover {
+  background: rgba(240,244,250,0.98);
+  border-color: rgba(29,78,216,0.24);
+  transform: translateY(-1px);
+}
+
+html[data-ui-theme="navy"] .tab-btn[aria-selected="true"] {
+  color: #1D4ED8;
+  border-color: rgba(29,78,216,0.30);
+  background: rgba(29,78,216,0.08);
+  box-shadow: none;
+}
+
+html[data-ui-theme="navy"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html[data-ui-theme="navy"] .ui-input option {
+  background: #FFFFFF;
+  color: #0D1E3D;
+}
+
+html.dark[data-ui-theme="navy"] {
+  --color-primary: #3B82F6;
+  --color-secondary: #52C7FA;
+  --color-cta: #F59E0B;
+  --color-cost: #10B981;
+  --color-messages: #F472B6;
+  --color-bg: #0A0E1A;
+  --color-text: #E6F0FF;
+  --color-muted: #A3C2FA;
+  --color-border: #2B3B66;
+  --color-label: rgba(163, 194, 250, 0.68);
+  --color-surface-glass: rgba(18, 26, 48, 0.94);
+}
+
+html.dark[data-ui-theme="navy"] body {
+  background:
+    radial-gradient(980px 520px at 14% -8%, rgba(59,130,246,0.10), transparent 60%),
+    radial-gradient(880px 500px at 88% 4%, rgba(82,199,250,0.06), transparent 56%),
+    linear-gradient(180deg, #0A0E1A 0%, #0D1526 100%);
+}
+
+html.dark[data-ui-theme="navy"] .surface {
+  background: rgba(18, 26, 48, 0.94);
+  border-color: #2B3B66;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.34), inset 0 1px 0 rgba(230,240,255,0.04);
+}
+
+html.dark[data-ui-theme="navy"] .surface:hover {
+  transform: none;
+  box-shadow: 0 12px 28px rgba(0,0,0,0.40), inset 0 1px 0 rgba(230,240,255,0.05);
+}
+
+html.dark[data-ui-theme="navy"] .ui-input {
+  background-color: rgba(10, 14, 26, 0.97);
+  border-color: #2B3B66;
+  border-radius: 8px;
+  color: #E6F0FF;
+}
+
+html.dark[data-ui-theme="navy"] .ui-input:hover {
+  border-color: rgba(59,130,246,0.34);
+}
+
+html.dark[data-ui-theme="navy"] .ui-input:focus {
+  border-color: rgba(59,130,246,0.48);
+  box-shadow: 0 0 0 4px rgba(59,130,246,0.12), 0 1px 3px rgba(0,0,0,0.30);
+}
+
+html.dark[data-ui-theme="navy"] .btn::before {
+  display: none;
+}
+
+html.dark[data-ui-theme="navy"] .btn-primary {
+  background: linear-gradient(180deg, #3B82F6 0%, #2563EB 100%);
+  box-shadow: 0 10px 24px rgba(37,99,235,0.32), inset 0 1px 0 rgba(255,255,255,0.16);
+}
+
+html.dark[data-ui-theme="navy"] .btn-primary:hover {
+  box-shadow: 0 12px 26px rgba(37,99,235,0.38), inset 0 1px 0 rgba(255,255,255,0.18);
+}
+
+html.dark[data-ui-theme="navy"] .btn-ghost {
+  background: rgba(18, 26, 48, 0.90);
+  border-color: #2B3B66;
+}
+
+html.dark[data-ui-theme="navy"] .btn-ghost:hover {
+  background: rgba(28, 41, 74, 0.98);
+  border-color: rgba(59,130,246,0.30);
+}
+
+html.dark[data-ui-theme="navy"] .tab-btn {
+  border-radius: 8px;
+  padding: 10px 16px;
+  font-weight: 700;
+  border: 1px solid #2B3B66;
+  background: rgba(18, 26, 48, 0.90);
+  color: #C7DAFB;
+}
+
+html.dark[data-ui-theme="navy"] .tab-btn:hover {
+  background: rgba(28,41,74,0.98);
+  border-color: rgba(59,130,246,0.28);
+  transform: translateY(-1px);
+}
+
+html.dark[data-ui-theme="navy"] .tab-btn[aria-selected="true"] {
+  color: #93C5FD;
+  border-color: rgba(59,130,246,0.36);
+  background: rgba(59,130,246,0.14);
+  box-shadow: none;
+}
+
+html.dark[data-ui-theme="navy"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html.dark[data-ui-theme="navy"] .ui-input option {
+  background: #121A30;
+  color: #E6F0FF;
+}
+
+/* Soft — adapted from cosyncing's Soft Minimalist */
+html[data-ui-theme="soft"] {
+  --color-primary: #4F46E5;
+  --color-secondary: #096F9C;
+  --color-cta: #9E5704;
+  --color-cost: #047857;
+  --color-messages: #BE185D;
+  --color-bg: #F4F4F6;
+  --color-text: #1E1E24;
+  --color-muted: #626270;
+  --color-border: #E2E2E8;
+  --color-label: rgba(98, 98, 112, 0.92);
+  --color-surface-glass: rgba(255, 255, 255, 0.92);
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  --shadow-sm: 0 1px 2px rgba(30,27,75,0.04);
+  --shadow-md: 0 14px 34px rgba(30,27,75,0.07);
+  --shadow-lg: 0 24px 54px rgba(30,27,75,0.10);
+  --datepickr-radius: 16px;
+  --datepickr-day-radius: 10px;
+}
+
+html[data-ui-theme="soft"] body {
+  background: linear-gradient(180deg, #F6F6F8 0%, #F0F0F4 100%);
+}
+
+html[data-ui-theme="soft"] .surface {
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(226, 226, 232, 0.72);
+  box-shadow: var(--shadow-md);
+}
+
+html[data-ui-theme="soft"] .surface:hover {
+  transform: none;
+  box-shadow: var(--shadow-lg);
+}
+
+html[data-ui-theme="soft"] .ui-input {
+  background-color: rgba(255, 255, 255, 0.94);
+  border-color: rgba(226,226,232,0.85);
+  border-radius: 14px;
+}
+
+html[data-ui-theme="soft"] .ui-input:hover {
+  border-color: rgba(79,70,229,0.24);
+}
+
+html[data-ui-theme="soft"] .ui-input:focus {
+  border-color: rgba(79,70,229,0.38);
+  box-shadow: 0 0 0 4px rgba(79,70,229,0.08), 0 1px 3px rgba(30,27,75,0.08);
+}
+
+html[data-ui-theme="soft"] .btn::before {
+  display: none;
+}
+
+html[data-ui-theme="soft"] .btn-primary {
+  background: #4F46E5;
+  box-shadow: 0 12px 26px rgba(79,70,229,0.20);
+}
+
+html[data-ui-theme="soft"] .btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(79,70,229,0.24);
+}
+
+html[data-ui-theme="soft"] .btn-ghost {
+  background: rgba(255, 255, 255, 0.78);
+  border-color: rgba(226,226,232,0.85);
+}
+
+html[data-ui-theme="soft"] .btn-ghost:hover {
+  background: rgba(255, 255, 255, 0.96);
+  border-color: rgba(79,70,229,0.20);
+  transform: translateY(-1px);
+}
+
+html[data-ui-theme="soft"] .tab-btn {
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-weight: 700;
+  border: 1px solid rgba(226,226,232,0.85);
+  background: rgba(255, 255, 255, 0.78);
+}
+
+html[data-ui-theme="soft"] .tab-btn:hover {
+  background: rgba(255,255,255,0.96);
+  border-color: rgba(79,70,229,0.18);
+  transform: translateY(-1px);
+}
+
+html[data-ui-theme="soft"] .tab-btn[aria-selected="true"] {
+  color: #4F46E5;
+  border-color: rgba(79,70,229,0.24);
+  background: rgba(79,70,229,0.08);
+  box-shadow: none;
+}
+
+html[data-ui-theme="soft"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html[data-ui-theme="soft"] .ui-input option {
+  background: #FFFFFF;
+  color: #1E1E24;
+}
+
+html.dark[data-ui-theme="soft"] {
+  --color-primary: #818CF8;
+  --color-secondary: #38BDF8;
+  --color-cta: #FBBF24;
+  --color-cost: #34D399;
+  --color-messages: #F472B6;
+  --color-bg: #0F0F12;
+  --color-text: #F1F1F5;
+  --color-muted: #A0A0B0;
+  --color-border: #2A2A35;
+  --color-label: rgba(160, 160, 176, 0.80);
+  --color-surface-glass: rgba(22, 22, 27, 0.92);
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.34);
+  --shadow-md: 0 14px 34px rgba(0,0,0,0.38);
+  --shadow-lg: 0 24px 54px rgba(0,0,0,0.46);
+}
+
+html.dark[data-ui-theme="soft"] body {
+  background: linear-gradient(180deg, #0F0F12 0%, #131318 100%);
+}
+
+html.dark[data-ui-theme="soft"] .surface {
+  background: rgba(22, 22, 27, 0.92);
+  border-color: rgba(42, 42, 53, 0.72);
+  box-shadow: var(--shadow-md);
+}
+
+html.dark[data-ui-theme="soft"] .surface:hover {
+  transform: none;
+  box-shadow: var(--shadow-lg);
+}
+
+html.dark[data-ui-theme="soft"] .ui-input {
+  background-color: rgba(15, 15, 18, 0.94);
+  border-color: rgba(42,42,53,0.85);
+  border-radius: 14px;
+  color: #F1F1F5;
+}
+
+html.dark[data-ui-theme="soft"] .ui-input:hover {
+  border-color: rgba(129,140,248,0.26);
+}
+
+html.dark[data-ui-theme="soft"] .ui-input:focus {
+  border-color: rgba(129,140,248,0.40);
+  box-shadow: 0 0 0 4px rgba(129,140,248,0.10), 0 1px 3px rgba(0,0,0,0.30);
+}
+
+html.dark[data-ui-theme="soft"] .btn::before {
+  display: none;
+}
+
+html.dark[data-ui-theme="soft"] .btn-primary {
+  background: #818CF8;
+  color: #0F0F12;
+  box-shadow: 0 12px 26px rgba(129,140,248,0.20);
+}
+
+html.dark[data-ui-theme="soft"] .btn-primary:hover {
+  box-shadow: 0 14px 30px rgba(129,140,248,0.26);
+}
+
+html.dark[data-ui-theme="soft"] .btn-ghost {
+  background: rgba(22, 22, 27, 0.86);
+  border-color: rgba(42,42,53,0.85);
+}
+
+html.dark[data-ui-theme="soft"] .btn-ghost:hover {
+  background: rgba(32, 32, 40, 0.96);
+  border-color: rgba(129,140,248,0.22);
+}
+
+html.dark[data-ui-theme="soft"] .tab-btn {
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-weight: 700;
+  border: 1px solid rgba(42,42,53,0.85);
+  background: rgba(22, 22, 27, 0.86);
+  color: #D4D4DE;
+}
+
+html.dark[data-ui-theme="soft"] .tab-btn:hover {
+  background: rgba(32,32,40,0.96);
+  border-color: rgba(129,140,248,0.20);
+  transform: translateY(-1px);
+}
+
+html.dark[data-ui-theme="soft"] .tab-btn[aria-selected="true"] {
+  color: #A5B0FC;
+  border-color: rgba(129,140,248,0.28);
+  background: rgba(129,140,248,0.12);
+  box-shadow: none;
+}
+
+html.dark[data-ui-theme="soft"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html.dark[data-ui-theme="soft"] .ui-input option {
+  background: #16161B;
+  color: #F1F1F5;
+}
+
+/* Flat — adapted from cosyncing's Flat White Minimalist */
+html[data-ui-theme="flat"] {
+  --color-primary: #000000;
+  --color-secondary: #2563EB;
+  --color-cta: #B44409;
+  --color-cost: #059669;
+  --color-messages: #DB2777;
+  --color-bg: #FCFCFC;
+  --color-text: #000000;
+  --color-muted: #666666;
+  --color-border: #EAEAEA;
+  --color-label: rgba(102, 102, 102, 0.92);
+  --color-surface-glass: #FFFFFF;
+  --radius-md: 0px;
+  --radius-lg: 0px;
+  --shadow-sm: 0 0 #0000;
+  --shadow-md: 0 0 #0000;
+  --shadow-lg: 0 0 #0000;
+  --datepickr-radius: 0px;
+  --datepickr-day-radius: 0px;
+}
+
+html[data-ui-theme="flat"] body {
+  background: #FCFCFC;
+}
+
+html[data-ui-theme="flat"] .surface {
+  background: #FFFFFF;
+  border-color: #EAEAEA;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+html[data-ui-theme="flat"] .surface:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+html[data-ui-theme="flat"] .ui-input {
+  background-color: #FFFFFF;
+  border: 1px solid #EAEAEA;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+html[data-ui-theme="flat"] .ui-input:hover {
+  border-color: #8C8C8C;
+}
+
+html[data-ui-theme="flat"] .ui-input:focus {
+  border-color: #000000;
+  box-shadow: none;
+}
+
+html[data-ui-theme="flat"] .btn::before {
+  display: none;
+}
+
+html[data-ui-theme="flat"] .btn,
+html[data-ui-theme="flat"] .tab-btn {
+  border-radius: 0;
+}
+
+html[data-ui-theme="flat"] .btn-primary {
+  background: #000000;
+  box-shadow: none;
+}
+
+html[data-ui-theme="flat"] .btn-primary:hover {
+  transform: none;
+  background: #262626;
+  box-shadow: none;
+}
+
+html[data-ui-theme="flat"] .btn-ghost {
+  background: #FFFFFF;
+  border-color: #EAEAEA;
+}
+
+html[data-ui-theme="flat"] .btn-ghost:hover {
+  background: #F5F5F5;
+  border-color: #8C8C8C;
+  transform: none;
+}
+
+html[data-ui-theme="flat"] .tab-btn {
+  padding: 10px 16px;
+  font-weight: 700;
+  border: 1px solid #EAEAEA;
+  background: #FFFFFF;
+}
+
+html[data-ui-theme="flat"] .tab-btn:hover {
+  background: #F5F5F5;
+  border-color: #8C8C8C;
+  transform: none;
+}
+
+html[data-ui-theme="flat"] .tab-btn[aria-selected="true"] {
+  color: #FFFFFF;
+  border-color: #000000;
+  background: #000000;
+  box-shadow: none;
+}
+
+html[data-ui-theme="flat"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html[data-ui-theme="flat"] .ui-input option {
+  background: #FFFFFF;
+  color: #000000;
+}
+
+html.dark[data-ui-theme="flat"] {
+  --color-primary: #FFFFFF;
+  --color-secondary: #3B82F6;
+  --color-cta: #F97316;
+  --color-cost: #34D399;
+  --color-messages: #F472B6;
+  --color-bg: #0A0A0A;
+  --color-text: #FFFFFF;
+  --color-muted: #A3A3A3;
+  --color-border: #262626;
+  --color-label: rgba(163, 163, 163, 0.76);
+  --color-surface-glass: #101010;
+  --shadow-sm: 0 0 #0000;
+  --shadow-md: 0 0 #0000;
+  --shadow-lg: 0 0 #0000;
+}
+
+html.dark[data-ui-theme="flat"] body {
+  background: #0A0A0A;
+}
+
+html.dark[data-ui-theme="flat"] .surface {
+  background: #101010;
+  border-color: #262626;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+html.dark[data-ui-theme="flat"] .surface:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+html.dark[data-ui-theme="flat"] .ui-input {
+  background-color: #0A0A0A;
+  border: 1px solid #262626;
+  border-radius: 0;
+  box-shadow: none;
+  color: #FFFFFF;
+}
+
+html.dark[data-ui-theme="flat"] .ui-input:hover {
+  border-color: #676767;
+}
+
+html.dark[data-ui-theme="flat"] .ui-input:focus {
+  border-color: #FFFFFF;
+  box-shadow: none;
+}
+
+html.dark[data-ui-theme="flat"] .btn::before {
+  display: none;
+}
+
+html.dark[data-ui-theme="flat"] .btn,
+html.dark[data-ui-theme="flat"] .tab-btn {
+  border-radius: 0;
+}
+
+html.dark[data-ui-theme="flat"] .btn-primary {
+  background: #FFFFFF;
+  color: #0A0A0A;
+  box-shadow: none;
+}
+
+html.dark[data-ui-theme="flat"] .btn-primary:hover {
+  transform: none;
+  background: #D4D4D4;
+  box-shadow: none;
+}
+
+html.dark[data-ui-theme="flat"] .btn-ghost {
+  background: #101010;
+  border-color: #262626;
+  color: #FFFFFF;
+}
+
+html.dark[data-ui-theme="flat"] .btn-ghost:hover {
+  background: #1A1A1A;
+  border-color: #676767;
+  transform: none;
+}
+
+html.dark[data-ui-theme="flat"] .tab-btn {
+  padding: 10px 16px;
+  font-weight: 700;
+  border: 1px solid #262626;
+  background: #101010;
+  color: #FFFFFF;
+}
+
+html.dark[data-ui-theme="flat"] .tab-btn:hover {
+  background: #1A1A1A;
+  border-color: #676767;
+  transform: none;
+}
+
+html.dark[data-ui-theme="flat"] .tab-btn[aria-selected="true"] {
+  color: #0A0A0A;
+  border-color: #FFFFFF;
+  background: #FFFFFF;
+  box-shadow: none;
+}
+
+html.dark[data-ui-theme="flat"] .tab-btn[aria-selected="true"]::after {
+  display: none;
+}
+
+html.dark[data-ui-theme="flat"] .ui-input option {
+  background: #101010;
+  color: #FFFFFF;
+}
+
+/* Monospace body themes set wider glyphs; trim overview KPI type so cards do not
+   wrap. The sm: step-up is preserved at reduced sizes — the stock 2.25rem step
+   (text-4xl) is what overflows a six-card row in a mono stack. */
+
+/* Form controls do not inherit the body font by default; keep the mono stack. */
+html[data-ui-theme="terminal"] button,
+html[data-ui-theme="terminal"] input,
+html[data-ui-theme="terminal"] select,
+html[data-ui-theme="terminal"] textarea,
+html[data-ui-theme="amber"] button,
+html[data-ui-theme="amber"] input,
+html[data-ui-theme="amber"] select,
+html[data-ui-theme="amber"] textarea {
+  font-family: inherit;
+}
+
+html[data-ui-theme="terminal"] #overviewKpiGrid .surface,
+html[data-ui-theme="amber"] #overviewKpiGrid .surface {
+  padding: 14px;
+}
+
+html[data-ui-theme="terminal"] #overviewKpiGrid .text-3xl,
+html[data-ui-theme="amber"] #overviewKpiGrid .text-3xl {
+  font-size: 1.5rem;
+  line-height: 1.9rem;
+}
+
+@media (min-width: 640px) {
+  html[data-ui-theme="terminal"] #overviewKpiGrid .text-3xl,
+  html[data-ui-theme="amber"] #overviewKpiGrid .text-3xl {
+    font-size: 1.65rem;
+    line-height: 2rem;
+  }
+}
+
+html[data-ui-theme="terminal"] #overviewKpiGrid .text-xs,
+html[data-ui-theme="amber"] #overviewKpiGrid .text-xs {
+  font-size: 11px;
+  letter-spacing: 0.03em;
 }
 
 /* Gradient themes should paint one continuous canvas across the full document.

--- a/tests/test_style_themes_frontend.py
+++ b/tests/test_style_themes_frontend.py
@@ -1,0 +1,333 @@
+"""Contract tests for the dashboard style themes.
+
+Adding a theme means touching five places at once: the `validStyleThemes`
+list in static/theme-config.js, the three per-theme maps in the same file
+(`heatColorsMap`, `chartPaletteMap`, `themeMetaColors`), a theme section in
+static/themes.css, an `<option>` in the settings picker, and a `styleXxx`
+label in all six i18n dictionaries. The runtime falls back to `elevated` for
+missing map entries, so a forgotten map fails silently — these tests make the
+whole checklist fail loudly instead.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import tokdash  # type: ignore[import-untyped]
+
+STATIC = Path(tokdash.__file__).parent / "static"
+THEME_CONFIG_JS = STATIC / "theme-config.js"
+THEMES_CSS = STATIC / "themes.css"
+INDEX_HTML = STATIC / "index.html"
+
+EXPECTED_LANGUAGES = ("en", "zh", "ja", "ko", "es", "pt")
+
+
+def _valid_style_themes() -> list[str]:
+    source = THEME_CONFIG_JS.read_text(encoding="utf-8")
+    block = re.search(r"validStyleThemes: \[(.*?)\]", source, re.S)
+    assert block, "validStyleThemes not found in theme-config.js"
+    themes = re.findall(r'"([^"]+)"', block.group(1))
+    assert themes, "validStyleThemes is empty"
+    return themes
+
+
+VALID_STYLE_THEMES = _valid_style_themes()
+
+# Elevated is the base stylesheet: the unselected `html` rules already are the
+# elevated look, so themes.css carries no `data-ui-theme="elevated"` override
+# section for it. Every other theme needs one.
+BASE_STYLESHEET_THEMES = ("elevated",)
+
+
+def _config_map_span(source: str, name: str, next_marker: str | None) -> str:
+    start = source.find(f"    {name}: {{")
+    assert start != -1, f"{name} not found in theme-config.js"
+    end = source.find(next_marker, start) if next_marker else source.find("\n  });", start)
+    assert end != -1, f"unterminated {name} in theme-config.js"
+    return source[start:end]
+
+
+@pytest.mark.parametrize("theme", VALID_STYLE_THEMES)
+def test_theme_has_css_section(theme: str) -> None:
+    if theme in BASE_STYLESHEET_THEMES:
+        pytest.skip(f"{theme!r} is the base stylesheet, no override section by design")
+    source = THEMES_CSS.read_text(encoding="utf-8")
+    assert f'html[data-ui-theme="{theme}"]' in source, (
+        f"themes.css has no section for {theme!r}"
+    )
+
+
+@pytest.mark.parametrize("theme", VALID_STYLE_THEMES)
+def test_theme_has_heat_colors(theme: str) -> None:
+    source = THEME_CONFIG_JS.read_text(encoding="utf-8")
+    span = _config_map_span(source, "heatColorsMap", "    chartPaletteMap: {")
+    entry = re.search(
+        rf'{re.escape(theme)}: \{{\s*light: \[(.*?)\],\s*dark: \[(.*?)\],?\s*\}}', span
+    )
+    assert entry, f"heatColorsMap is missing {theme!r}"
+    for mode in (1, 2):
+        colors = re.findall(r'"#[0-9A-Fa-f]{6}"', entry.group(mode))
+        assert len(colors) == 8, (
+            f"heatColorsMap[{theme}] must have 8 colors per mode, "
+            f"found {len(colors)} in group {mode}"
+        )
+
+
+@pytest.mark.parametrize("theme", VALID_STYLE_THEMES)
+def test_theme_has_chart_palette(theme: str) -> None:
+    source = THEME_CONFIG_JS.read_text(encoding="utf-8")
+    span = _config_map_span(source, "chartPaletteMap", "    themeMetaColors: {")
+    entry = re.search(
+        rf'{re.escape(theme)}: \{{\s*light: \[(.*?)\],\s*dark: \[(.*?)\],?\s*\}}', span
+    )
+    assert entry, f"chartPaletteMap is missing {theme!r}"
+    for mode in (1, 2):
+        colors = re.findall(r'"#[0-9A-Fa-f]{6}"', entry.group(mode))
+        assert len(colors) == 6, (
+            f"chartPaletteMap[{theme}] must have 6 colors per mode, "
+            f"found {len(colors)} in group {mode}"
+        )
+
+
+@pytest.mark.parametrize("theme", VALID_STYLE_THEMES)
+def test_theme_has_meta_colors(theme: str) -> None:
+    source = THEME_CONFIG_JS.read_text(encoding="utf-8")
+    span = _config_map_span(source, "themeMetaColors", None)
+    entry = re.search(
+        rf'{re.escape(theme)}: \{{\s*light: "#[0-9A-Fa-f]{{6}}",\s*dark: "#[0-9A-Fa-f]{{6}}"\s*\}}',
+        span,
+    )
+    assert entry, f"themeMetaColors is missing a light/dark pair for {theme!r}"
+
+
+def _picker_options(source: str) -> list[tuple[str, str]]:
+    select_start = source.index('<select id="styleThemeSelect"')
+    select_end = source.index("</select>", select_start)
+    select = source[select_start:select_end]
+    return re.findall(r'<option value="([^"]+)" data-i18n="([^"]+)"', select)
+
+
+def test_picker_lists_every_theme_in_order() -> None:
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    options = _picker_options(source)
+    assert [value for value, _ in options] == VALID_STYLE_THEMES, (
+        "styleThemeSelect options drifted from validStyleThemes"
+    )
+    for value, i18n_key in options:
+        expected_key = "style" + value[:1].upper() + value[1:]
+        assert i18n_key == expected_key, (
+            f"picker option {value!r} uses {i18n_key!r}, expected {expected_key!r}"
+        )
+
+
+@pytest.mark.parametrize("theme", VALID_STYLE_THEMES)
+def test_theme_label_in_every_language(theme: str) -> None:
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    key = "style" + theme[:1].upper() + theme[1:]
+    start = source.find("const I18N = {")
+    assert start != -1, "const I18N = { not found in index.html"
+    end = source.find("\n    };", start)
+    assert end != -1, "unterminated I18N object in index.html"
+    literal = source[start : end + 6]
+    blocks = dict(
+        re.findall(r"^      ([a-z]+): \{\n(.*?)^      \},?$", literal, re.M | re.S)
+    )
+    assert tuple(blocks) == EXPECTED_LANGUAGES
+    for lang, block in blocks.items():
+        assert re.search(rf"^        {key}: ", block, re.M), (
+            f"i18n dictionary {lang!r} is missing {key!r}"
+        )
+
+
+# --- README theme-count parity ------------------------------------------------
+#
+# Each README's feature list quotes the theme count in its own words, and no
+# other test reads those lines — the count once shipped stale in five of the
+# six READMEs after a theme batch bumped only the English one. The phrases are
+# per-language on purpose: a reworded README stops matching and fails loudly
+# instead of passing unchecked.
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+README_THEME_COUNT_PHRASE = {
+    "README.md": "style themes",
+    "README_CN.md": "款样式主题",
+    "README_JA.md": "種類のスタイルテーマ",
+    "README_KO.md": "가지 스타일 테마",
+    "README_ES.md": "temas de estilo",
+    "README_PT.md": "temas de estilo",
+}
+
+
+@pytest.mark.parametrize("readme", sorted(README_THEME_COUNT_PHRASE))
+def test_readme_theme_count_matches_config(readme: str) -> None:
+    source = (REPO_ROOT / readme).read_text(encoding="utf-8")
+    phrase = README_THEME_COUNT_PHRASE[readme]
+    match = re.search(rf"(\d+)\s*{re.escape(phrase)}", source)
+    assert match, f"{readme} theme-count line not found (expected '<N> {phrase}')"
+    assert int(match.group(1)) == len(VALID_STYLE_THEMES), (
+        f"{readme} says {match.group(1)} themes, "
+        f"validStyleThemes has {len(VALID_STYLE_THEMES)}"
+    )
+
+
+# --- Rendering invariant guards -----------------------------------------------
+#
+# The checks below exist because each new theme used to be authored by copying
+# the previous theme's block, so a single authoring mistake replicated across
+# every new theme: flat's `--shadow-*: none` broke every composed box-shadow,
+# the `.ui-input { background: ... }` shorthand erased the select caret in
+# eleven themes, and seven new `--color-label` tokens failed WCAG AA. All three
+# are mechanically checkable, so they are checked here.
+
+
+@pytest.mark.parametrize("theme", VALID_STYLE_THEMES)
+def test_theme_has_dark_section(theme: str) -> None:
+    if theme in BASE_STYLESHEET_THEMES:
+        pytest.skip(f"{theme!r} is the base stylesheet, no override section by design")
+    source = THEMES_CSS.read_text(encoding="utf-8")
+    assert f'html.dark[data-ui-theme="{theme}"]' in source, (
+        f"themes.css has no dark-mode section for {theme!r}"
+    )
+
+
+def test_shadow_tokens_are_composable() -> None:
+    # Base rules compose `box-shadow: var(--shadow-md), <second layer>`. A bare
+    # `none` token is only legal as the sole value, so it invalidates the whole
+    # declaration (second layer included) at computed-value time. Use `0 0 #0000`.
+    source = THEMES_CSS.read_text(encoding="utf-8")
+    offenders = re.findall(r"--shadow-(?:sm|md|lg):\s*none\s*;", source)
+    assert not offenders, (
+        f"--shadow-* tokens set to none break composed box-shadows: {offenders}"
+    )
+
+
+def test_theme_inputs_keep_background_shorthand_out() -> None:
+    # `.style-select` paints the dropdown caret with background-image at lower
+    # specificity. A theme rule on the control itself (`.ui-input`, optionally
+    # with :hover/:focus) using the `background:` shorthand resets
+    # background-image to none and the caret vanishes. Descendant rules such as
+    # `.ui-input option` are unaffected — options carry no caret image.
+    source = THEMES_CSS.read_text(encoding="utf-8")
+    offenders = []
+    for match in re.finditer(
+        r"(html(?:\.dark)?\[data-ui-theme=\"[^\"]+\"\] \.ui-input(?::\w+)?)\s*\{(.*?)\}",
+        source,
+        re.S,
+    ):
+        selector, body = match.group(1), match.group(2)
+        if re.search(r"(?<![\w-])background:\s", body):
+            offenders.append(selector)
+    assert not offenders, (
+        f".ui-input rules using the background: shorthand hide the select caret: "
+        f"{offenders}"
+    )
+
+
+def _hex_rgb(value: str) -> tuple[float, float, float]:
+    value = value.lstrip("#")
+    return (
+        int(value[0:2], 16) / 255,
+        int(value[2:4], 16) / 255,
+        int(value[4:6], 16) / 255,
+    )
+
+
+def _parse_rgba(value: str) -> tuple[tuple[float, float, float], float]:
+    match = re.match(r"rgba\(\s*(\d+),\s*(\d+),\s*(\d+),\s*([\d.]+)\s*\)", value)
+    assert match, f"not an rgba() color: {value!r}"
+    rgb = tuple(int(match.group(i)) / 255 for i in (1, 2, 3))
+    return rgb, float(match.group(4))
+
+
+def _composite(fg: tuple[float, float, float], alpha: float, bg: tuple[float, float, float]):
+    return tuple(f * alpha + b * (1 - alpha) for f, b in zip(fg, bg))
+
+
+def _relative_luminance(rgb) -> float:
+    def channel(c: float) -> float:
+        return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+    r, g, b = (channel(c) for c in rgb)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast(fg, bg) -> float:
+    lighter, darker = sorted(
+        (_relative_luminance(fg), _relative_luminance(bg)), reverse=True
+    )
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _theme_token(body: str, name: str) -> str | None:
+    match = re.search(rf"--{name}:\s*([^;]+);", body)
+    return match.group(1).strip() if match else None
+
+
+def _global_tokens(dark: bool) -> dict[str, str]:
+    """The :root / html.dark base tokens in index.html that theme sections
+    inherit from when they do not declare an override."""
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    selector = r"html\.dark" if dark else r":root"
+    block = re.search(rf"{selector} \{{(.*?)\}}", source, re.S)
+    assert block, f"base {selector} block not found in index.html"
+    return {
+        name: _theme_token(block.group(1), name)
+        for name in ("color-label", "color-bg", "color-surface-glass")
+    }
+
+
+@pytest.mark.parametrize("theme", VALID_STYLE_THEMES)
+@pytest.mark.parametrize("dark", [False, True])
+def test_theme_label_color_meets_wcag_aa(theme: str, dark: bool) -> None:
+    # Tokens resolve through the same cascade as the browser: theme section
+    # first, then the global :root / html.dark default. A theme that declares
+    # its own background but no --color-label is still checked — skipping on a
+    # missing token would let a future theme fall back silently onto a
+    # combination nobody measured.
+    source = THEMES_CSS.read_text(encoding="utf-8")
+    prefix = "html.dark" if dark else "html"
+    section = re.search(
+        rf'{prefix}\[data-ui-theme="{re.escape(theme)}"\] \{{(.*?)\n\}}', source, re.S
+    )
+    section_body = section.group(1) if section else ""
+    globals_ = _global_tokens(dark)
+
+    def resolve(name: str) -> str:
+        value = _theme_token(section_body, name) or globals_.get(name)
+        assert value, f"no {name} in {theme!r} section or the global defaults"
+        return value
+
+    label = resolve("color-label")
+    bg = resolve("color-bg")
+    surface_glass = resolve("color-surface-glass")
+
+    bg_rgb = _hex_rgb(bg)
+    if surface_glass.startswith("#"):
+        surface_rgb = _hex_rgb(surface_glass)
+    else:
+        s_rgb, s_alpha = _parse_rgba(surface_glass)
+        surface_rgb = _composite(s_rgb, s_alpha, bg_rgb)
+
+    l_rgb, l_alpha = _parse_rgba(label)
+    mode = "dark" if dark else "light"
+    for surface_name, surface in (("bg", bg_rgb), ("surface", surface_rgb)):
+        ratio = _contrast(_composite(l_rgb, l_alpha, surface), surface)
+        assert ratio >= 4.5, (
+            f"--color-label in {theme} {mode} is {ratio:.2f}:1 over {surface_name}, "
+            f"below the WCAG AA 4.5:1 floor for small text"
+        )
+
+
+def test_refresh_icon_stroke_follows_button_color() -> None:
+    # The refresh glyph ships twice (static markup and the renderRefreshButton
+    # JS template); a hardcoded stroke="white" is invisible on light-background
+    # primary buttons. Both copies must inherit the button text color.
+    source = INDEX_HTML.read_text(encoding="utf-8")
+    assert 'stroke="white"' not in source, (
+        'an SVG icon hardcodes stroke="white"; use stroke="currentColor"'
+    )


### PR DESCRIPTION
## What

Adds 7 style themes adapted from cosyncing's theme set — Teal Obsidian, Graphite, Nordic Warmth, Cyber Amber (monospace, scanline dark mode), Royal Navy, Soft Minimalist, Flat White — bringing the picker to 17. Each ships light and dark tokens, 8-step heatmap scales, 6-color chart palettes, meta colors, and picker labels in all six UI languages. All six READMEs updated to match.

## Fixes included

- Refresh glyph hardcoded `stroke="white"` in both the header markup and the re-render template — invisible on light-button themes (studio/brutalist dark). Now `currentColor`.
- Overview KPI values wrapped in monospace themes (Terminal, Cyber Amber); cards now use trimmed type with the `sm:` step-up preserved at reduced sizes (verified 24px → 26.4px at the breakpoint).
- Theme `.ui-input` rules used the `background:` shorthand, resetting the `background-image` that paints the select caret — the dropdown arrow vanished on 11 themes (paper, liquid, terminal, brutalist predated this branch). All 24 declarations now set `background-color`.
- Per-theme option styling moved from `.style-select option` to `.ui-input option`, so every themed select (Language dropdown included) follows the theme instead of falling back to slate in dark mode.
- `--color-label` was below WCAG AA 4.5:1 in 9 theme/mode combos (7 new + paper light + studio light); tokens darkened or made more opaque until they clear the floor on both page and card backgrounds (floor is now 4.75).
- Flat White's `--shadow-*: none` invalidated every composed `box-shadow` in the base stylesheet (4 rules) — panels opened with zero separation. Tokens now use `0 0 #0000`.
- Cyber Amber dark `--color-cta` was 1.16:1 from primary; now a distinct orange (#FF9E64), reconciling the token with its chart palette slot.
- Terminal dark rendered slate-blue table text on phosphor green; slate utilities remap to theme greens. Monospace themes apply their font stack to form controls.

## Tests

New `tests/test_style_themes_frontend.py` (154 tests): walks `validStyleThemes` and asserts, per theme — CSS light/dark sections, heatmap/chart/meta map entries (with counts), picker option presence and order, i18n label keys in all 6 dictionaries, README theme-count parity in all 6 READMEs, shadow-token composability, the caret-safe shorthand rule, and WCAG AA label contrast resolved through the same cascade the browser uses (theme section → :root/html.dark), against both page and composited card backgrounds.

Full suite: **1960 passed, 6 skipped** (the 6 skips are the two elevated base-stylesheet exemptions plus 4 pre-existing).

Changelog entries are in `## Unreleased`; PR refs get appended here before merge per RELEASING.md.