### PR TITLE
Speed up the Report tab

### DIFF
--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Unreleased
+
+### Changed
+
+- The Report tab is much faster to reopen. Merged sessions are now cached per session, keyed on the files behind each one rather than on the window, so the week, month and year views share one assembly instead of rebuilding it three times and an appended log invalidates only the session it belongs to. On a year window over a 986MB database the tab's three requests fall from 14.92s to 7.07s, of which `/api/active-time` is 10.50s to 2.28s; the first read after a restart is unchanged, since the tab's own windows are warmed at startup. (#74)
+- Session reads merge a session's files in one pass on every harness, not just the store-backed ones. Pi, OMP, Kilo Code and WorkBuddy still folded their files pairwise, which rebuilds the whole accumulated session on every file and grows quadratically with the number of files one session spans -- the shape subagent fan-out produces. (#74)
+- OpenCode, MiMo and Kilo Code no longer key their session cache on the requested window, where three periods took three of the eight slots and a single pricing edit took all of them. They read unwindowed and the window is applied where every other tool applies it. (#74)
+- `TOKDASH_SESSION_CACHE_TURNS` bounds what the new session cache retains, in turns rather than sessions, since one long-running session can outweigh a thousand short ones. The default is 500,000 turns; `0` disables the cache. (#74)
+
 ## 2.5.3 - 2026-09-05
 
 ### Added

--- a/src/tokdash/api.py
+++ b/src/tokdash/api.py
@@ -322,14 +322,62 @@ def _active_time_cache_key(
     )
 
 
+def _active_time_payload(
+    period: str,
+    date_from: Optional[str],
+    date_to: Optional[str],
+    include_review_sessions: Optional[bool],
+) -> Any:
+    """What /api/active-time stores under its key — warmer and route alike.
+
+    The route used to add ``range`` inside a closure no warmer could reach, so a
+    warmed key held a payload one field short of the one a request builds. No
+    caller reads that field on this endpoint today, which is precisely why the
+    divergence would have sat there until one did.
+    """
+    data = get_active_time_data(
+        period, date_from, date_to, include_review_sessions=include_review_sessions
+    )
+    if isinstance(data, dict):
+        data["range"] = resolve_period(period, date_from, date_to)
+    return data
+
+
+def _usage_cache_key(period: str, date_from: Optional[str], date_to: Optional[str]) -> str:
+    return _window_cache_key(f"usage_{period}_{date_from}_{date_to}", date_from, date_to)
+
+
+def _insights_cache_key(
+    period: str,
+    date_from: Optional[str],
+    date_to: Optional[str],
+    facets: Optional[str],
+    include_project_names: bool,
+) -> str:
+    return _window_cache_key(
+        f"insights_{period}_{date_from}_{date_to}_{facets}_{include_project_names}",
+        date_from,
+        date_to,
+    )
+
+
 def _warm_caches() -> None:
     """Best-effort background warm so the first user request hits hot caches.
 
     Populates the parser caches (coding_tools._entry_cache, openclaw._ENTRY_CACHE)
     and the API response cache for the dashboard's initial loads — the exact Overview
-    date range, Stats, and each Sessions tool panel. The period-only Today usage key
-    is intentionally not warmed: the dashboard never requests it, and computing both
-    forms used to duplicate the largest startup aggregation.
+    date range, Stats, each Sessions tool panel, and the Report tab's three windows.
+    The period-only Today usage key is intentionally not warmed: the dashboard never
+    requests it, and computing both forms used to duplicate the largest startup
+    aggregation.
+
+    The Report tab's share is the expensive half and goes last. Measured on one
+    machine with a year of history: ~5s for the week, ~5s for the month and ~15s
+    for the year, so roughly 25s on top of a ~22s base warm. The year window is
+    most of it, and it scales with history rather than with the window. That is
+    background CPU, but it is not free — it holds the interpreter lock in slices,
+    so foreground requests during the warm are slower than they would otherwise
+    be. TOKDASH_WARM_ON_START=0 turns the whole warm off.
 
     A foreground request for the key currently being warmed may join that one fill;
     see ``get_cached_or_fetch``. This keeps the browser's first load from racing the
@@ -337,7 +385,10 @@ def _warm_caches() -> None:
     Disable with TOKDASH_WARM_ON_START=0.
     Failures are swallowed; warming must never crash `serve`.
     """
-    today = _local_today().isoformat()
+    # One clock for the whole list: read twice, a warm straddling local midnight
+    # would build the Report keys for a different day than the Overview keys.
+    day = _local_today()
+    today = day.isoformat()
     # Composed by name, not by slicing _day_warm_targets(): the warm order is the order
     # the dashboard needs these in, and stats belongs second, immediately behind the
     # Overview usage key. Reordering the per-day targets must not silently demote it.
@@ -346,6 +397,8 @@ def _warm_caches() -> None:
         (_window_cache_key("stats_None", None, None), lambda: compute_stats(None)),
         *_session_warm_targets(today),
         (_day_scoped_key(ACTIVITY_INSIGHTS_CACHE_KEY), get_codex_activity_insights),
+        # Last: the heaviest warm, and the Overview is the tab that opens first.
+        *_report_warm_targets(day),
     ]
     _run_warmers(warmers)
 
@@ -363,7 +416,7 @@ def _usage_warm_target(day: str):
     is what stops the warmer and the browser from drifting apart.
     """
     return (
-        _window_cache_key(f"usage_today_{day}_{day}", day, day),
+        _usage_cache_key("today", day, day),
         lambda: compute_usage_with_comparison("today", day, day),
     )
 
@@ -383,9 +436,80 @@ def _session_warm_targets(day: str) -> list:
     targets.append(
         (
             _active_time_cache_key("today", day, day, None),
-            lambda: get_active_time_data("today", day, day, include_review_sessions=None),
+            lambda: _active_time_payload("today", day, day, None),
         )
     )
+    return targets
+
+
+# The Report tab's facet request, verbatim (USAGE_REPORT_FACETS in index.html).
+# The facet string is part of the cache key, so a set listed in a different order
+# is a different key: the warm would fill one nobody asks for and the tab would
+# still pay the cold scan.
+REPORT_FACETS = "daily,streaks,firsts,hourly,weekday,tools,models,projects"
+
+
+def _report_windows(day: date) -> list[tuple[str, str]]:
+    """The Report tab's three calendar-aligned windows, all ending on ``day``.
+
+    Mirrors ``usageReportWindows()`` in index.html, Monday week start included.
+    Cheapest first, so the light windows are ready while the year is still going.
+
+    ``day`` is the *server's* local date, because that is what the cache key is
+    stamped with. A reader whose browser sits in a different timezone can ask for
+    a window a day either side of these and miss the warm entirely. That is
+    correct rather than unfortunate — their window really is a different window —
+    and it costs them one cold load, not a wrong number.
+    """
+    return [
+        ((day - timedelta(days=day.weekday())).isoformat(), day.isoformat()),
+        (day.replace(day=1).isoformat(), day.isoformat()),
+        (day.replace(month=1, day=1).isoformat(), day.isoformat()),
+    ]
+
+
+def _report_warm_targets(day: date, *, skip_single_day: bool = False) -> list:
+    """The three requests the Report tab issues, for each of its three windows.
+
+    All three periods, because the tab restores the reader's last one from
+    localStorage and the server cannot know which that was.
+
+    ``skip_single_day`` drops any window that has collapsed to ``day`` alone —
+    the week on a Monday, the month on the 1st. Only the midnight warm passes it;
+    see ``_warm_report_windows`` for why the hour is what makes the difference.
+
+    The tab sends no ``period`` parameter, so each key carries the *route's*
+    default — "today" for usage and active time, "year" for insights — rather
+    than the period the reader picked. Building them through the same helpers
+    the routes use is what keeps that subtlety from silently un-warming this.
+    Active time is also pinned to include_review_sessions=true here, which is a
+    different key from the Overview's, and is why browsing the Overview never
+    warmed this tab.
+    """
+    targets: list = []
+    for date_from, date_to in _report_windows(day):
+        if skip_single_day and date_from == date_to:
+            continue
+        targets.append(
+            (
+                _usage_cache_key("today", date_from, date_to),
+                lambda f=date_from, t=date_to: compute_usage_with_comparison("today", f, t),
+            )
+        )
+        targets.append(
+            (
+                _insights_cache_key("year", date_from, date_to, REPORT_FACETS, True),
+                lambda f=date_from, t=date_to: compute_insights(
+                    "year", f, t, facets=REPORT_FACETS, include_project_names=True
+                ),
+            )
+        )
+        targets.append(
+            (
+                _active_time_cache_key("today", date_from, date_to, True),
+                lambda f=date_from, t=date_to: _active_time_payload("today", f, t, True),
+            )
+        )
     return targets
 
 
@@ -420,6 +544,33 @@ def _warm_previous_day() -> None:
     _run_warmers(_day_warm_targets(yesterday), join_seconds=DAILY_WARM_JOIN_SECONDS)
 
 
+def _warm_report_windows() -> None:
+    """Warm the Report tab's windows for the day that just started.
+
+    A partial exception to the rule above. These windows end today, so they are
+    open and go cold at midnight like every other open key — but a week, month or
+    year at 00:05 is *usually* almost entirely days that have already closed, so
+    the snapshot is worth having rather than near-empty.
+
+    Usually, not always. On a Monday the week window is today alone, on the 1st
+    the month window is, and on 1 January all three are. There the rule above
+    applies unchanged: warming it would put the near-empty snapshot the Overview
+    refuses to cache in front of the morning's first request, and this tab has no
+    auto-refresh, so stale-while-revalidate would show an empty week until the
+    reader loaded it a second time. A single-day window is also cheap to compute
+    cold (a second or two), so skipping it costs the reader nothing.
+
+    The startup warm keeps them: it runs when someone started the server, not at
+    a fixed hour, so there is no near-empty window to protect against.
+
+    Kept separate from ``_warm_previous_day`` rather than folded into it: that
+    one warms a closed day and this one warms open windows, and the two docstrings
+    would otherwise have to argue with each other.
+    """
+    targets = _report_warm_targets(_local_today(), skip_single_day=True)
+    _run_warmers(targets, join_seconds=DAILY_WARM_JOIN_SECONDS)
+
+
 def _daily_warm_minute() -> int:
     """Minutes past local midnight for the daily warm, default 5.
 
@@ -448,6 +599,10 @@ def _daily_warm_loop() -> None:
             _warm_previous_day()
         except Exception:  # pragma: no cover - a warm failure must never kill the loop
             logger.debug("tokdash daily warm failed", exc_info=True)
+        try:
+            _warm_report_windows()
+        except Exception:  # pragma: no cover - and neither half may kill the other
+            logger.debug("tokdash daily report warm failed", exc_info=True)
 
 
 @asynccontextmanager
@@ -1575,7 +1730,7 @@ def get_usage(
             resolve_period(period, date_from, date_to), seed=_dev_fixture_seed()
         )
     try:
-        cache_key = _window_cache_key(f"usage_{period}_{date_from}_{date_to}", date_from, date_to)
+        cache_key = _usage_cache_key(period, date_from, date_to)
         return _cached_route(
             "/api/usage",
             cache_key,
@@ -1945,24 +2100,17 @@ def get_active_time(
             seed=_dev_fixture_seed(),
         )
 
-    def fetch():
-        data = get_active_time_data(
-            period,
-            date_from,
-            date_to,
-            include_review_sessions=include_review_sessions,
-        )
-        if isinstance(data, dict):
-            data["range"] = resolve_period(period, date_from, date_to)
-        return data
-
     try:
         cache_key = _active_time_cache_key(period, date_from, date_to, include_review_sessions)
         return _cached_route(
             "/api/active-time",
             cache_key,
-            fetch,
+            lambda: _active_time_payload(period, date_from, date_to, include_review_sessions),
             force_refresh=refresh,
+            # The Report tab decides whether to re-read from these. Without it the
+            # decision rode on /api/usage alone — the one of the three that is
+            # reliably fast, and so the one least likely to still be stale.
+            include_cache_metadata=True,
         )
     except UsageDatabaseSchemaTooNewError as e:
         # 500, not 503: 503 is the dashboard retry signal, and a database
@@ -2116,10 +2264,8 @@ def get_insights(
             seed=_dev_fixture_seed(),
         )
     try:
-        cache_key = _window_cache_key(
-            f"insights_{period}_{date_from}_{date_to}_{facets}_{include_project_names}",
-            date_from,
-            date_to,
+        cache_key = _insights_cache_key(
+            period, date_from, date_to, facets, include_project_names
         )
         return _cached_route(
             "/api/insights",
@@ -2132,6 +2278,9 @@ def get_insights(
                 include_project_names=include_project_names,
             ),
             force_refresh=refresh,
+            # See /api/active-time: this is the other slow half of the Report tab,
+            # and it carries most of the page.
+            include_cache_metadata=True,
         )
     except UnknownFacetError as e:
         # Refused rather than ignored: a dropped facet renders as a blank

--- a/src/tokdash/sessions.py
+++ b/src/tokdash/sessions.py
@@ -9,6 +9,7 @@ import os
 import re
 import sqlite3
 import threading
+from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache, wraps
 from pathlib import Path
@@ -413,6 +414,9 @@ def reload_pricing_db() -> None:
     _load_cline_sessions.cache_clear()
     _parse_workbuddy_session_file.cache_clear()
     _load_workbuddy_sessions.cache_clear()
+    # New rates change every token in the assembly token, so the entries were
+    # already unreachable; dropping them frees the budget they were holding.
+    _SESSION_ASSEMBLY.clear()
 
 
 def _truthy_env(name: str) -> bool:
@@ -1069,7 +1073,14 @@ def _drop_codex_subagent_replay_turns(
     earliest sibling (by first turn timestamp, then session id) keeps it; later
     siblings drop turns whose event key an earlier sibling already retained —
     the same single-survivor rule Overview's global event-key index applies.
+
+    Neither ``sessions`` nor the session dicts inside it are modified: a trimmed
+    session is a shallow copy in the returned mapping. Callers hand this the
+    output of a merge they own today, but the sessions a merge produces are
+    cacheable, and trimming one in place would strip turns from every later read
+    of a different window.
     """
+    result = dict(sessions)
     keys_by_session = {
         session_id: {
             str(turn.get("_event_key"))
@@ -1089,19 +1100,20 @@ def _drop_codex_subagent_replay_turns(
         if not parent_keys:
             orphan_children.append((parent_id, session_id, session))
             continue
+        turns = session.get("turns", [])
         kept = [
             turn
-            for turn in session.get("turns", [])
+            for turn in turns
             if not turn.get("_event_key") or str(turn.get("_event_key")) not in parent_keys
         ]
-        if kept:
-            session["turns"] = kept
+        if not kept:
+            result.pop(session_id, None)
+            keys_by_session.pop(session_id, None)
+        elif len(kept) != len(turns):
+            result[session_id] = {**session, "turns": kept}
             keys_by_session[session_id] = {
                 str(turn.get("_event_key")) for turn in kept if turn.get("_event_key")
             }
-        else:
-            del sessions[session_id]
-            keys_by_session.pop(session_id, None)
 
     orphans_by_parent: Dict[str, list] = {}
     for parent_id, session_id, session in orphan_children:
@@ -1117,33 +1129,41 @@ def _drop_codex_subagent_replay_turns(
         )
         retained_keys: set = set()
         for session_id, session in siblings:
+            turns = session.get("turns", [])
             kept = []
-            for turn in session.get("turns", []):
+            for turn in turns:
                 event_key = str(turn.get("_event_key") or "")
                 if event_key and event_key in retained_keys:
                     continue
                 kept.append(turn)
                 if event_key:
                     retained_keys.add(event_key)
-            if kept:
-                session["turns"] = kept
-            else:
-                del sessions[session_id]
+            if not kept:
+                result.pop(session_id, None)
                 keys_by_session.pop(session_id, None)
-    return sessions
+            elif len(kept) != len(turns):
+                result[session_id] = {**session, "turns": kept}
+    return result
 
 
 def _codex_unwindowed_parent_keys(
-    store: "UsageEntryStore", sessions: Dict[str, Dict[str, Any]]
+    store: "UsageEntryStore",
+    sessions: Dict[str, Dict[str, Any]],
+    tokens: Optional[Dict[str, tuple]] = None,
 ) -> Dict[str, set]:
     """Event keys of fork-parent sessions that a windowed read excluded.
 
-    ``query_session_records(whole_sessions=True)`` only loads sessions touching the
-    window. A forked subagent file keeps its own session id while its replayed
-    prefix turns are restamped into the window, so the parent session can be absent
-    from the result while present in the store. Fetch those parents unbounded by
-    time so the replay dedup is window-independent. A parent with no stored rows
-    yields no keys and the child keeps the prefix (counted once, never dropped).
+    A windowed read only loads sessions touching the window. A forked subagent
+    file keeps its own session id while its replayed prefix turns are restamped
+    into the window, so the parent session can be absent from the result while
+    present in the store. Fetch those parents unbounded by time so the replay
+    dedup is window-independent. A parent with no stored rows yields no keys and
+    the child keeps the prefix (counted once, never dropped).
+
+    ``tokens`` lets the parents come from the same assembly cache the windowed
+    sessions use. Without it this was a second uncached deserialization of the
+    same rows on every request; with it a parent is assembled once and is then
+    already in hand for any later window that does include it.
     """
     missing = {
         str(session["_subagent_parent_id"])
@@ -1152,15 +1172,35 @@ def _codex_unwindowed_parent_keys(
     } - set(sessions)
     if not missing:
         return {}
-    parent_keys: Dict[str, set] = {}
-    for record in store.query_session_records_by_ids("codex", missing):
-        session_id = str(record.get("session_id") or "")
-        keys = parent_keys.setdefault(session_id, set())
-        for turn in record.get("turns") or []:
-            event_key = turn.get("_event_key")
-            if event_key:
-                keys.add(str(event_key))
-    return parent_keys
+    tokens = tokens or {}
+    parents: Dict[str, Dict[str, Any]] = {}
+    stale: list[str] = []
+    for session_id in sorted(missing):
+        token = tokens.get(session_id)
+        cached = _SESSION_ASSEMBLY.get("codex", session_id, token) if token else None
+        if cached is None:
+            stale.append(session_id)
+        else:
+            parents[session_id] = cached
+    if stale:
+        rebuilt = _raw_sessions_from_records(
+            "codex", store.query_session_records_by_ids("codex", stale)
+        )
+        admit: list[tuple[str, Any, Dict[str, Any]]] = []
+        for session_id, session in rebuilt.items():
+            token = tokens.get(session_id)
+            if token:
+                admit.append((session_id, token, session))
+            parents[session_id] = session
+        _SESSION_ASSEMBLY.putall("codex", admit)
+    return {
+        session_id: {
+            str(turn["_event_key"])
+            for turn in session.get("turns", [])
+            if turn.get("_event_key")
+        }
+        for session_id, session in parents.items()
+    }
 def _merge_raw_session_sequence(raws: list[Dict[str, Any]]) -> Dict[str, Any]:
     """Left-fold ``raws`` exactly as repeated :func:`_merge_raw_session` would.
 
@@ -1231,6 +1271,167 @@ def _merge_raw_session_sequence(raws: list[Dict[str, Any]]) -> Dict[str, Any]:
     if not meta["display_name"]:
         meta["display_name"] = _fallback_display_name(meta["session_id"], meta["project"])
     return meta
+
+
+def _merge_grouped_raw_sessions(
+    grouped: Dict[str, list[Dict[str, Any]]]
+) -> Dict[str, Dict[str, Any]]:
+    """Collapse per-session raw lists into one merged session each.
+
+    Loaders accumulate raws per session id and merge here rather than folding as
+    they go: the pairwise fold rebuilds the whole accumulated session on every
+    file, so a session split across K files costs O(K^2). That is the shape
+    subagent fan-out produces on every tool that can attribute several transcripts
+    to one session id, not just the ones large enough to have hit it yet.
+    """
+    return {
+        session_id: _merge_raw_session_sequence(raws)
+        for session_id, raws in grouped.items()
+    }
+
+
+SESSION_CACHE_TURNS_DEFAULT = 500_000
+
+
+@lru_cache(maxsize=4)
+def _parse_turn_budget(raw: str) -> int:
+    if not raw:
+        return SESSION_CACHE_TURNS_DEFAULT
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return SESSION_CACHE_TURNS_DEFAULT
+
+
+def _session_cache_turn_budget() -> int:
+    """Turns the assembly cache may hold; override with ``TOKDASH_SESSION_CACHE_TURNS``.
+
+    Turns rather than sessions because that is what varies by orders of magnitude
+    between installs: one long-running session can outweigh a thousand short ones,
+    and it is bytes the budget exists to bound. Zero empties the cache and keeps
+    it empty.
+
+    Read once per store, not once per session: a cold read of a large tool calls
+    this a thousand times, and the parse behind it never changes between them.
+    """
+    return _parse_turn_budget(os.environ.get("TOKDASH_SESSION_CACHE_TURNS", "").strip())
+
+
+class _SessionAssemblyCache:
+    """Merged sessions kept between requests, keyed by the files behind each one.
+
+    The expensive half of a session read is assembly — deserializing each of a
+    session's rows and merging them — and it repeats in full on every request
+    because nothing above it is keyed on content. The obvious memo, one keyed on
+    the window, does not help: the windows a reader opens end today, so a stored
+    entry is only ever reused inside one route's response-cache TTL, which
+    already absorbs those repeats. A key with no dates in it does help, and is
+    reusable across every window and every period at once.
+
+    Entries are invalidated by token, not by time: the token is the set of files
+    behind the session plus the pricing signature, so an appended log invalidates
+    exactly the one session it belongs to instead of the whole tool.
+
+    Cached sessions are handed out by reference and read by several requests at
+    once, so nothing downstream may modify one. That is already true of the live
+    loaders, whose own memo shares its result the same way.
+    """
+
+    def __init__(self) -> None:
+        self._entries: "OrderedDict[tuple[str, str], tuple[Any, Any, int]]" = OrderedDict()
+        self._turns = 0
+        self._lock = threading.Lock()
+
+    def get(self, tool: str, session_id: str, token: Any) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            entry = self._entries.get((tool, session_id))
+            if entry is None or entry[0] != token:
+                return None
+            self._entries.move_to_end((tool, session_id))
+            return entry[1]
+
+    def putall(
+        self, tool: str, items: Iterable[tuple[str, Any, Dict[str, Any]]]
+    ) -> None:
+        """Admit a batch of ``(session_id, token, session)``, then evict to budget.
+
+        A batch rather than one call per session so the budget is read once per
+        read of a tool, not once per session in it.
+        """
+        budget = _session_cache_turn_budget()
+        with self._lock:
+            if budget <= 0:
+                # Off. Drop whatever a previous budget admitted rather than leave
+                # it resident: a process that starts at zero never fills the cache
+                # at all, so this only matters when the setting changes under a
+                # running server.
+                self._entries.clear()
+                self._turns = 0
+                return
+            for session_id, token, session in items:
+                key = (tool, session_id)
+                prior = self._entries.pop(key, None)
+                if prior is not None:
+                    self._turns -= prior[2]
+                weight = len(session.get("turns") or ())
+                self._entries[key] = (token, session, weight)
+                self._turns += weight
+            # One session over budget on its own still stays: evicting it would
+            # leave the cache permanently empty and re-merge it every request.
+            while self._turns > budget and len(self._entries) > 1:
+                _key, evicted = self._entries.popitem(last=False)
+                self._turns -= evicted[2]
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+            self._turns = 0
+
+    def stats(self) -> tuple[int, int]:
+        """``(sessions, turns)`` currently held — for tests and diagnostics."""
+        with self._lock:
+            return len(self._entries), self._turns
+
+
+_SESSION_ASSEMBLY = _SessionAssemblyCache()
+
+
+def _assembly_token(file_signatures: Iterable[Any], pricing_sig: tuple) -> tuple:
+    """Identity of the inputs behind one merged session.
+
+    The sorted file set itself rather than a hash of it: it cannot collide, and
+    being set-shaped it catches a file *disappearing* as surely as one changing.
+    Pricing rides along because assembly prices every turn, so a rate edit has to
+    invalidate what a rate edit changes.
+
+    A stored row marked missing keeps its signature and its content, so it
+    correctly does not invalidate; a row deleted outright leaves the set.
+    """
+    return (pricing_sig, tuple(sorted(file_signatures)))
+
+
+def _assemble_raw_sessions(
+    tool: str,
+    pricing_sig: tuple,
+    grouped: Dict[str, list[tuple[Any, Dict[str, Any]]]],
+) -> Dict[str, Dict[str, Any]]:
+    """Merge each session's raws, reusing the ones whose files did not change.
+
+    ``grouped`` maps a session id to ``(file_signature, raw)`` pairs in merge
+    order. The signatures are what the token is built from, so a loader only has
+    to carry the same triple it already iterates.
+    """
+    sessions: Dict[str, Dict[str, Any]] = {}
+    merged: list[tuple[str, Any, Dict[str, Any]]] = []
+    for session_id, entries in grouped.items():
+        token = _assembly_token((signature for signature, _raw in entries), pricing_sig)
+        session = _SESSION_ASSEMBLY.get(tool, session_id, token)
+        if session is None:
+            session = _merge_raw_session_sequence([raw for _signature, raw in entries])
+            merged.append((session_id, token, session))
+        sessions[session_id] = session
+    _SESSION_ASSEMBLY.putall(tool, merged)
+    return sessions
 
 
 def _file_signature(path: Path) -> tuple[str, int, int]:
@@ -1636,7 +1837,7 @@ def _parse_codex_session_file(path_str: str, _mtime_ns: int, _size: int, _pricin
 
 @_cached_session_aggregate()
 def _load_codex_sessions(signature: tuple[tuple[str, int, int], ...], pricing_sig: tuple = ()) -> Dict[str, Dict[str, Any]]:
-    sessions: Dict[str, Dict[str, Any]] = {}
+    grouped: Dict[str, list[tuple[Any, Dict[str, Any]]]] = {}
     transient_miss = False
     for path_str, mtime_ns, size in signature:
         try:
@@ -1648,12 +1849,12 @@ def _load_codex_sessions(signature: tuple[tuple[str, int, int], ...], pricing_si
             continue
         if raw and raw.get("turns"):
             raw = {key: value for key, value in raw.items() if key != "_activity"}
-            session_id = str(raw["session_id"])
-            if session_id in sessions:
-                sessions[session_id] = _merge_raw_session(sessions[session_id], raw)
-            else:
-                sessions[session_id] = raw
-    result = _drop_codex_subagent_replay_turns(sessions)
+            grouped.setdefault(str(raw["session_id"]), []).append(
+                ((path_str, mtime_ns, size), raw)
+            )
+    result = _drop_codex_subagent_replay_turns(
+        _assemble_raw_sessions("codex", pricing_sig, grouped)
+    )
     if transient_miss:
         raise _PartialSessionView(result)
     return result
@@ -1864,7 +2065,7 @@ def _parse_claude_session_file(path_str: str, _mtime_ns: int, _size: int, _prici
 
 @_cached_session_aggregate()
 def _load_claude_sessions(signature: tuple[tuple[str, int, int], ...], pricing_sig: tuple = ()) -> Dict[str, Dict[str, Any]]:
-    sessions: Dict[str, Dict[str, Any]] = {}
+    grouped: Dict[str, list[tuple[Any, Dict[str, Any]]]] = {}
     transient_miss = False
     for path_str, mtime_ns, size in signature:
         try:
@@ -1875,11 +2076,10 @@ def _load_claude_sessions(signature: tuple[tuple[str, int, int], ...], pricing_s
             transient_miss = True
             continue
         if raw:
-            session_id = str(raw["session_id"])
-            if session_id in sessions:
-                sessions[session_id] = _merge_raw_session(sessions[session_id], raw)
-            else:
-                sessions[session_id] = raw
+            grouped.setdefault(str(raw["session_id"]), []).append(
+                ((path_str, mtime_ns, size), raw)
+            )
+    sessions = _assemble_raw_sessions("claude", pricing_sig, grouped)
     if transient_miss:
         raise _PartialSessionView(sessions)
     return sessions
@@ -1910,9 +2110,20 @@ def _opencode_db_signature() -> tuple[tuple[str, int, int], ...]:
 def _load_opencode_sessions(
     signature: tuple[tuple[str, int, int], ...],
     _pricing_sig: tuple = (),
-    since_ms: Optional[int] = None,
-    until_ms: Optional[int] = None,
 ) -> Dict[str, Dict[str, Any]]:
+    """Every session in the database, unwindowed and cached on content alone.
+
+    The window used to be part of this cache key, which meant the three periods a
+    reader opens took three entries out of eight and a rate edit took all of them
+    — a memo keyed on something the reader changes constantly is not much of a
+    memo. Reading unwindowed costs about what the widest window cost anyway
+    (windowing is a scan filter here, not an index seek), and ``_summarize_session``
+    already clips turns to the window it is asked for, which is how every
+    store-backed tool has always worked.
+
+    Loading everything is also what makes the boundary events unnecessary: the
+    event just outside a window is now simply one of the turns in hand.
+    """
     if not signature:
         return {}
     db_path = Path(signature[0][0])
@@ -1920,9 +2131,9 @@ def _load_opencode_sessions(
         return {}
 
     try:
-        return _load_opencode_sessions_scalar(db_path, since_ms=since_ms, until_ms=until_ms)
+        return _load_opencode_sessions_scalar(db_path)
     except sqlite3.Error:
-        return _load_opencode_sessions_raw_json(db_path, since_ms=since_ms, until_ms=until_ms)
+        return _load_opencode_sessions_raw_json(db_path)
 
 
 def _opencode_window_clause(since_ms: Optional[int], until_ms: Optional[int]) -> tuple[str, list[int]]:
@@ -1954,11 +2165,16 @@ def _sql_boundary_event_ms(
 ) -> Dict[str, int]:
     """Nearest assistant event per session on the far side of a window edge.
 
-    These loaders window in SQL, so a session that continues across an edge would
-    otherwise lose the stretch spanning it: the first in-window event looks like
-    the start of its stream, and the last one like the end. Only the nearest
-    event outside matters — anything further away yields the same capped
+    For a caller that windows in SQL: a session continuing across an edge would
+    otherwise lose the stretch spanning it, because the first in-window event
+    looks like the start of its stream and the last one like the end. Only the
+    nearest event outside matters — anything further away yields the same capped
     interval, whose clipped part is identical either way.
+
+    The dashboard's read path no longer asks these loaders for a window (see
+    :func:`_load_opencode_sessions`), so nothing there needs a boundary event:
+    the row outside a window is simply another turn in hand. This stays for
+    callers that do pass one.
     """
     if bound_ms is None:
         return {}
@@ -2408,11 +2624,11 @@ def _load_opencode_sessions_raw_json(
     return sessions
 
 
-def _opencode_sessions(since_ms: Optional[int] = None, until_ms: Optional[int] = None) -> Dict[str, Dict[str, Any]]:
+def _opencode_sessions() -> Dict[str, Dict[str, Any]]:
     signature = _opencode_db_signature()
     if not signature:
         return {}
-    return _load_opencode_sessions(signature, _pricing_signature(), since_ms, until_ms)
+    return _load_opencode_sessions(signature, _pricing_signature())
 
 
 def _pi_session_roots() -> list[Path]:
@@ -2633,7 +2849,7 @@ def _parse_omp_session_file(path_str: str, _mtime_ns: int, _size: int, _pricing_
 
 @_cached_session_aggregate()
 def _load_pi_sessions(signature: tuple[tuple[str, int, int], ...], pricing_sig: tuple = ()) -> Dict[str, Dict[str, Any]]:
-    sessions: Dict[str, Dict[str, Any]] = {}
+    grouped: Dict[str, list[tuple[Any, Dict[str, Any]]]] = {}
     transient_miss = False
     for path_str, mtime_ns, size in signature:
         try:
@@ -2645,11 +2861,10 @@ def _load_pi_sessions(signature: tuple[tuple[str, int, int], ...], pricing_sig: 
             continue
         if not raw:
             continue
-        session_id = str(raw["session_id"])
-        if session_id in sessions:
-            sessions[session_id] = _merge_raw_session(sessions[session_id], raw)
-        else:
-            sessions[session_id] = raw
+        grouped.setdefault(str(raw["session_id"]), []).append(
+            ((path_str, mtime_ns, size), raw)
+        )
+    sessions = _assemble_raw_sessions("pi_agent", pricing_sig, grouped)
     if transient_miss:
         raise _PartialSessionView(sessions)
     return sessions
@@ -3057,7 +3272,7 @@ def _omp_session_signatures() -> tuple[tuple[str, int, int], ...]:
 
 @_cached_session_aggregate()
 def _load_omp_sessions(signature: tuple[tuple[str, int, int], ...], pricing_sig: tuple = ()) -> Dict[str, Dict[str, Any]]:
-    sessions: Dict[str, Dict[str, Any]] = {}
+    grouped: Dict[str, list[tuple[Any, Dict[str, Any]]]] = {}
     transient_miss = False
     for path_str, mtime_ns, size in signature:
         try:
@@ -3069,11 +3284,10 @@ def _load_omp_sessions(signature: tuple[tuple[str, int, int], ...], pricing_sig:
             continue
         if not raw:
             continue
-        session_id = str(raw["session_id"])
-        if session_id in sessions:
-            sessions[session_id] = _merge_raw_session(sessions[session_id], raw)
-        else:
-            sessions[session_id] = raw
+        grouped.setdefault(str(raw["session_id"]), []).append(
+            ((path_str, mtime_ns, size), raw)
+        )
+    sessions = _assemble_raw_sessions("omp", pricing_sig, grouped)
     if transient_miss:
         raise _PartialSessionView(sessions)
     return sessions
@@ -3356,7 +3570,7 @@ def _parse_kimi_session_file(path_str: str, _mtime_ns: int, _size: int, _pricing
 
 @_cached_session_aggregate()
 def _load_kimi_sessions(signature: tuple[tuple[str, int, int], ...], pricing_sig: tuple = ()) -> Dict[str, Dict[str, Any]]:
-    sessions: Dict[str, Dict[str, Any]] = {}
+    grouped: Dict[str, list[tuple[Any, Dict[str, Any]]]] = {}
     transient_miss = False
     for path_str, mtime_ns, size in signature:
         try:
@@ -3368,11 +3582,10 @@ def _load_kimi_sessions(signature: tuple[tuple[str, int, int], ...], pricing_sig
             continue
         if not raw:
             continue
-        session_id = str(raw["session_id"])
-        if session_id in sessions:
-            sessions[session_id] = _merge_raw_session(sessions[session_id], raw)
-        else:
-            sessions[session_id] = raw
+        grouped.setdefault(str(raw["session_id"]), []).append(
+            ((path_str, mtime_ns, size), raw)
+        )
+    sessions = _assemble_raw_sessions("kimi", pricing_sig, grouped)
     if transient_miss:
         raise _PartialSessionView(sessions)
     return sessions
@@ -3419,9 +3632,8 @@ def _mimo_db_signature() -> tuple[tuple[str, int, int], ...]:
 def _load_mimo_sessions(
     signature: tuple[tuple[str, int, int], ...],
     _pricing_sig: tuple = (),
-    since_ms: Optional[int] = None,
-    until_ms: Optional[int] = None,
 ) -> Dict[str, Dict[str, Any]]:
+    """Unwindowed and cached on content alone — see :func:`_load_opencode_sessions`."""
     if not signature:
         return {}
     db_path = Path(signature[0][0])
@@ -3429,9 +3641,9 @@ def _load_mimo_sessions(
         return {}
 
     try:
-        return _load_mimo_sessions_scalar(db_path, since_ms=since_ms, until_ms=until_ms)
+        return _load_mimo_sessions_scalar(db_path)
     except sqlite3.Error:
-        return _load_mimo_sessions_raw_json(db_path, since_ms=since_ms, until_ms=until_ms)
+        return _load_mimo_sessions_raw_json(db_path)
 
 
 def _load_mimo_sessions_scalar(
@@ -3625,11 +3837,11 @@ def _load_mimo_sessions_raw_json(
     return sessions
 
 
-def _mimo_sessions(since_ms: Optional[int] = None, until_ms: Optional[int] = None) -> Dict[str, Dict[str, Any]]:
+def _mimo_sessions() -> Dict[str, Dict[str, Any]]:
     signature = _mimo_db_signature()
     if not signature:
         return {}
-    return _load_mimo_sessions(signature, _pricing_signature(), since_ms, until_ms)
+    return _load_mimo_sessions(signature, _pricing_signature())
 
 
 def _kilocode_db_signature() -> tuple[tuple[str, int, int], ...]:
@@ -3647,29 +3859,57 @@ def _kilocode_db_signature() -> tuple[tuple[str, int, int], ...]:
     return tuple(signatures)
 
 
+def _kilocode_db_signatures(
+    signature: tuple[tuple[str, int, int], ...]
+) -> Dict[str, tuple[tuple[str, int, int], ...]]:
+    """Regroup a flat kilocode signature into one entry per database.
+
+    The inverse of what :func:`_kilocode_db_signature` flattened: each database
+    gets back the ``-wal`` and ``-shm`` siblings recorded alongside it. Those
+    siblings are why the signature covers them at all — a SQLite write can land
+    in the WAL and leave the main file's mtime and size untouched (measured at
+    18 of 40 appends; see ``_advance_mtime`` in the kilocode tests), so a token
+    built from the main file alone would call a changed database unchanged.
+
+    Which sessions a WAL write touched is not knowable without reading it, so
+    invalidation here is per database rather than per session. That costs
+    nothing: a session lives in exactly one channel DB.
+    """
+    grouped: Dict[str, list[tuple[str, int, int]]] = {}
+    for entry in signature:
+        path_str = entry[0]
+        for suffix in ("-wal", "-shm"):
+            if path_str.endswith(suffix):
+                path_str = path_str[: -len(suffix)]
+                break
+        grouped.setdefault(path_str, []).append(entry)
+    return {path_str: tuple(entries) for path_str, entries in grouped.items()}
+
+
 @lru_cache(maxsize=8)
 def _load_kilocode_sessions(
     signature: tuple[tuple[str, int, int], ...],
-    _pricing_sig: tuple = (),
-    since_ms: Optional[int] = None,
-    until_ms: Optional[int] = None,
+    pricing_sig: tuple = (),
 ) -> Dict[str, Dict[str, Any]]:
+    """Unwindowed and cached on content alone — see :func:`_load_opencode_sessions`.
+
+    Dropping the window is also what lets the merge reuse the assembly cache: a
+    session's raws are now fixed by the databases behind it, so the token is
+    exact. While the window was in the key, the same files could yield different
+    sessions and a cached merge would have served one window's turns to another.
+    """
     if not signature:
         return {}
     # One session lives in exactly one channel DB; the cross-DB merge is
     # defensive (dedupes turns by identity key, keeps the earlier duplicate).
-    sessions: Dict[str, Dict[str, Any]] = {}
-    for path_str, _mtime, _size in signature:
-        if path_str.endswith(("-wal", "-shm")):
-            continue
+    grouped: Dict[str, list[tuple[Any, Dict[str, Any]]]] = {}
+    for path_str, db_signature in _kilocode_db_signatures(signature).items():
         db_path = Path(path_str)
         if not db_path.exists():
             continue
         try:
             db_sessions = _load_opencode_sessions_scalar(
                 db_path,
-                since_ms=since_ms,
-                until_ms=until_ms,
                 tool="kilocode",
                 use_recorded_cost=False,
                 billing_rule="split-cache-write",
@@ -3678,8 +3918,6 @@ def _load_kilocode_sessions(
             try:
                 db_sessions = _load_opencode_sessions_raw_json(
                     db_path,
-                    since_ms=since_ms,
-                    until_ms=until_ms,
                     tool="kilocode",
                     use_recorded_cost=False,
                     billing_rule="split-cache-write",
@@ -3690,17 +3928,12 @@ def _load_kilocode_sessions(
                 )
                 continue
         for sid, raw in db_sessions.items():
-            if sid in sessions:
-                sessions[sid] = _merge_raw_session(sessions[sid], raw)
-            else:
-                sessions[sid] = raw
-    return sessions
+            grouped.setdefault(sid, []).append((db_signature, raw))
+    return _assemble_raw_sessions("kilocode", pricing_sig, grouped)
 
 
-def _kilocode_sessions(since_ms: Optional[int] = None, until_ms: Optional[int] = None) -> Dict[str, Dict[str, Any]]:
-    return _load_kilocode_sessions(
-        _kilocode_db_signature(), _pricing_signature(), since_ms, until_ms
-    )
+def _kilocode_sessions() -> Dict[str, Dict[str, Any]]:
+    return _load_kilocode_sessions(_kilocode_db_signature(), _pricing_signature())
 
 
 def _dsh_session_signatures() -> tuple[tuple[str, int, int], ...]:
@@ -3781,19 +4014,17 @@ def _parse_dsh_session_file(path_str: str, _mtime_ns: int, _size: int, _pricing_
 
 @lru_cache(maxsize=8)
 def _load_dsh_sessions(signature: tuple[tuple[str, int, int], ...], pricing_sig: tuple = ()) -> Dict[str, Dict[str, Any]]:
-    sessions: Dict[str, Dict[str, Any]] = {}
+    grouped: Dict[str, list[tuple[Any, Dict[str, Any]]]] = {}
     for path_str, mtime_ns, size in signature:
         raw = _parse_dsh_session_file(path_str, mtime_ns, size, pricing_sig)
         if not raw:
             continue
-        session_id = str(raw["session_id"])
-        if session_id in sessions:
-            # Duplicate physical files for one header id merge; the stable
-            # per-(turn, step) event keys dedup the turns.
-            sessions[session_id] = _merge_raw_session(sessions[session_id], raw)
-        else:
-            sessions[session_id] = raw
-    return sessions
+        # Duplicate physical files for one header id merge; the stable
+        # per-(turn, step) event keys dedup the turns.
+        grouped.setdefault(str(raw["session_id"]), []).append(
+            ((path_str, mtime_ns, size), raw)
+        )
+    return _assemble_raw_sessions("dsh", pricing_sig, grouped)
 
 
 def _dsh_session_parser_signature() -> dict[str, Any]:
@@ -4113,17 +4344,15 @@ def _parse_reasonix_session_file(path_str: str, _mtime_ns: int, _size: int, _pri
 
 @lru_cache(maxsize=8)
 def _load_reasonix_sessions(signature: tuple[tuple[str, int, int], ...], pricing_sig: tuple = ()) -> Dict[str, Dict[str, Any]]:
-    sessions: Dict[str, Dict[str, Any]] = {}
+    grouped: Dict[str, list[tuple[Any, Dict[str, Any]]]] = {}
     for path_str, mtime_ns, size in signature:
         raw = _parse_reasonix_session_file(path_str, mtime_ns, size, pricing_sig)
         if not raw:
             continue
-        session_id = str(raw["session_id"])
-        if session_id in sessions:
-            sessions[session_id] = _merge_raw_session(sessions[session_id], raw)
-        else:
-            sessions[session_id] = raw
-    return sessions
+        grouped.setdefault(str(raw["session_id"]), []).append(
+            ((path_str, mtime_ns, size), raw)
+        )
+    return _assemble_raw_sessions("reasonix", pricing_sig, grouped)
 
 
 def _reasonix_session_parser_signature() -> dict[str, Any]:
@@ -4251,7 +4480,7 @@ def _load_workbuddy_sessions(signature: tuple[tuple[str, int, int], ...], pricin
     """Mirror _load_claude_sessions: per-file _parse_session_file, merge per
     session_id with _merge_raw_session; transient misses raise
     _PartialSessionView so the partial view is returned but never cached."""
-    sessions: Dict[str, Dict[str, Any]] = {}
+    grouped: Dict[str, list[tuple[Any, Dict[str, Any]]]] = {}
     transient_miss = False
     for path_str, mtime_ns, size in signature:
         try:
@@ -4262,11 +4491,10 @@ def _load_workbuddy_sessions(signature: tuple[tuple[str, int, int], ...], pricin
             transient_miss = True
             continue
         if raw:
-            session_id = str(raw["session_id"])
-            if session_id in sessions:
-                sessions[session_id] = _merge_raw_session(sessions[session_id], raw)
-            else:
-                sessions[session_id] = raw
+            grouped.setdefault(str(raw["session_id"]), []).append(
+                ((path_str, mtime_ns, size), raw)
+            )
+    sessions = _assemble_raw_sessions("workbuddy", pricing_sig, grouped)
     if transient_miss:
         raise _PartialSessionView(sessions)
     return sessions
@@ -5244,15 +5472,15 @@ def _raw_sessions_for_tool(
         if key == "claude":
             return _claude_sessions()
         if key == "opencode":
-            return _opencode_sessions(since_ms=since_ms, until_ms=until_ms)
+            return _opencode_sessions()
         if key == "kilocode":
-            return _kilocode_sessions(since_ms=since_ms, until_ms=until_ms)
+            return _kilocode_sessions()
         if key == "pi_agent":
             return _pi_sessions()
         if key == "omp":
             return _omp_sessions()
         if key == "mimo":
-            return _mimo_sessions(since_ms=since_ms, until_ms=until_ms)
+            return _mimo_sessions()
         if key == "kimi":
             return _kimi_sessions()
         if key == "dsh":
@@ -5285,15 +5513,19 @@ def _raw_sessions_for_tool(
     raise ValueError(f"Unsupported session tool: {tool}")
 
 
-def _session_records_to_raw_sessions(tool: str, records: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
-    """Rebuild raw sessions from the per-file rows held in the persistent store.
+def _raw_sessions_from_records(tool: str, records: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Merge the per-file rows of each session into one raw session.
 
     Every live loader that can see one session in several files (codex, claude,
-    pi_agent, kimi) merges with _merge_raw_session, so the cached path merges the
-    same way — _merge_raw_session_sequence is that fold in one pass, not a second
-    set of rules. It is what prefers an explicit title over a fallback and dedups
-    turns by event identity; rebuilding the merge differently here is exactly how
-    a cached read starts disagreeing with a live one.
+    pi_agent, kimi) groups its raws and merges them with the same helper, so the
+    cached path is not a second set of rules. That merge is what prefers an
+    explicit title over a fallback and dedups turns by event identity; rebuilding
+    it differently here is exactly how a cached read starts disagreeing with a
+    live one.
+
+    Nothing here reads across sessions, which is what makes the result cacheable
+    a session at a time. The Codex replay dedup does read across them, so it runs
+    after this and not inside it.
     """
     grouped: Dict[str, list[Dict[str, Any]]] = {}
     for record in records:
@@ -5308,25 +5540,109 @@ def _session_records_to_raw_sessions(tool: str, records: Iterable[Dict[str, Any]
         raw["turns"] = _repriced_turns(record.get("turns") or [])
         raw["tool"] = raw.get("tool") or tool
         raw["session_id"] = session_id
-        # Rows written by older versions may carry a falsy project; _merge_raw_session
+        # Rows written by older versions may carry a falsy project; the merge
         # only defers to a sibling row's project when this one reads "unknown".
         raw["project"] = raw.get("project") or "unknown"
         grouped.setdefault(session_id, []).append(raw)
 
-    # Merge each session's rows in one pass. Folding them pairwise re-keyed and
-    # re-copied every turn already merged, which is quadratic in the number of
-    # files a session spans — see _merge_raw_session_sequence.
-    sessions: Dict[str, Dict[str, Any]] = {
-        session_id: _merge_raw_session_sequence(raws) for session_id, raws in grouped.items()
-    }
-
-    if tool == "codex":
-        # Codex-only pass; skip the keys_by_session build for every other tool.
-        sessions = _drop_codex_subagent_replay_turns(sessions)
+    sessions = _merge_grouped_raw_sessions(grouped)
     for session in sessions.values():
         session.setdefault("display_name", _fallback_display_name(session.get("session_id"), session.get("project")))
         session["is_review_session"] = bool(session.get("is_review_session", False))
     return sessions
+
+
+def _session_records_to_raw_sessions(tool: str, records: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Rebuild raw sessions from the per-file rows held in the persistent store."""
+    sessions = _raw_sessions_from_records(tool, records)
+    if tool == "codex":
+        # Codex-only pass; skip the keys_by_session build for every other tool.
+        sessions = _drop_codex_subagent_replay_turns(sessions)
+    return sessions
+
+
+def _row_touches_window(
+    started_at_ms: Optional[int],
+    last_seen_at_ms: Optional[int],
+    since_ms: Optional[int],
+    until_ms: Optional[int],
+) -> bool:
+    """The ``last_seen_at_ms >= ? AND started_at_ms < ?`` filter, in Python.
+
+    Per row, not per session: a session qualifies when *some* row of it clears
+    both bounds, which is not the same as its widest row doing so. A NULL bound
+    fails the test, matching SQL comparison against NULL.
+    """
+    if since_ms is not None and (last_seen_at_ms is None or last_seen_at_ms < since_ms):
+        return False
+    if until_ms is not None and (started_at_ms is None or started_at_ms >= until_ms):
+        return False
+    return True
+
+
+def _stored_session_assembly(
+    store: "UsageEntryStore",
+    tool: str,
+    since_ms: Optional[int],
+    until_ms: Optional[int],
+) -> tuple[Dict[str, Dict[str, Any]], Dict[str, tuple]]:
+    """Merged sessions for the window, plus the token of every session in the store.
+
+    Reads the cheap columns first and deserializes only the sessions the assembly
+    cache does not already hold at the right token. On an unchanged tool that is
+    no ``raw_json`` decode and no merge at all — which together are nearly the
+    whole cost of a stored read.
+
+    The tokens cover every session, not just the windowed ones, because the Codex
+    replay dedup reaches outside the window for fork parents and wants the same
+    cache.
+    """
+    pricing_sig = _pricing_signature()
+    file_signatures: Dict[str, list[tuple[str, str]]] = {}
+    touched: set[str] = set()
+    for session_id, file_path, signature, started_at_ms, last_seen_at_ms in store.query_session_signatures(tool):
+        if not session_id:
+            continue
+        file_signatures.setdefault(session_id, []).append((file_path, signature))
+        if session_id not in touched and _row_touches_window(
+            started_at_ms, last_seen_at_ms, since_ms, until_ms
+        ):
+            touched.add(session_id)
+
+    tokens = {
+        session_id: _assembly_token(signatures, pricing_sig)
+        for session_id, signatures in file_signatures.items()
+    }
+
+    # Ordered by the signature query, which orders rows the same way the record
+    # query does, so sessions come out in the order the uncached rebuild produced
+    # them. Cache misses hold their place until the rebuild fills them in.
+    windowed = [session_id for session_id in file_signatures if session_id in touched]
+    cached = {
+        session_id: _SESSION_ASSEMBLY.get(tool, session_id, tokens[session_id])
+        for session_id in windowed
+    }
+    stale = [session_id for session_id, session in cached.items() if session is None]
+    if stale:
+        rebuilt = _raw_sessions_from_records(
+            tool, store.query_session_records_by_ids(tool, stale)
+        )
+        admit: list[tuple[str, Any, Dict[str, Any]]] = []
+        for session_id in stale:
+            session = rebuilt.get(session_id)
+            # A session missing here held no turns in any row, or its rows went
+            # away between the two queries. Either way there is nothing to cache.
+            if session is not None:
+                admit.append((session_id, tokens[session_id], session))
+                cached[session_id] = session
+        _SESSION_ASSEMBLY.putall(tool, admit)
+
+    sessions = {
+        session_id: session
+        for session_id, session in cached.items()
+        if session is not None
+    }
+    return sessions, tokens
 
 
 _store_sync_state = threading.local()
@@ -5439,16 +5755,11 @@ def _stored_sessions_for_tool(
     else:
         raise ValueError(f"Unsupported stored session tool: {tool}")
 
-    sessions = _session_records_to_raw_sessions(
-        tool,
-        store.query_session_records(
-            tool, since_ms=since_ms, until_ms=until_ms, whole_sessions=True
-        ),
-    )
+    sessions, tokens = _stored_session_assembly(store, tool, since_ms, until_ms)
     if tool == "codex":
         sessions = _drop_codex_subagent_replay_turns(
             sessions,
-            external_parent_keys=_codex_unwindowed_parent_keys(store, sessions),
+            external_parent_keys=_codex_unwindowed_parent_keys(store, sessions, tokens),
         )
         return _apply_codex_title_map(sessions)
     if tool == "kimi":

--- a/src/tokdash/static/index.html
+++ b/src/tokdash/static/index.html
@@ -7747,6 +7747,11 @@
       return !!el && el.classList.contains('active');
     }
 
+    function isUsageReportActive() {
+      const el = document.getElementById('report-content');
+      return !!el && el.classList.contains('active');
+    }
+
     function isPricingActive() {
       const el = document.getElementById('pricing-content');
       return !!el && el.classList.contains('active');
@@ -13790,6 +13795,10 @@
       // A period or server chosen mid-flight, applied when that load lands.
       pendingPeriod: null,
       pendingServerId: null,
+      // The pending silent re-read, and the token that decides whether its answer
+      // is still wanted when it lands. See usageReportScheduleStaleReread.
+      staleTimer: null,
+      loadToken: 0,
       // Share cards. The previews double as the export source, and the token
       // stops a slow paint from landing after a newer period has rendered.
       nickname: '',
@@ -13994,6 +14003,11 @@
           if (usageReportState.versionServerId !== serverId) return;
           usageReportState.version = String((payload && payload.runtime_version) || '') || null;
           if (!usageReportState.model) return;
+          // A model still waiting on the slow two has no footer or card to stamp:
+          // this answer is fired first and is instant, so it can land between the
+          // two paints and would otherwise render the very half-empty card the
+          // partial paint exists to avoid. The full paint stamps it a moment later.
+          if (usageReportState.model.notices.pending) return;
           usageReportRenderFooter(usageReportState.model);
           // The card attribution carries the same stamp, and this answer usually
           // lands after the first paint: repaint rather than ship an em dash.
@@ -14010,6 +14024,13 @@
       if (usageReportState.loading) return;
       usageReportWire();
       usageReportState.loading = true;
+      // Every explicit load invalidates any silent re-read still queued or in
+      // flight: that one describes the window being replaced.
+      usageReportState.loadToken += 1;
+      if (usageReportState.staleTimer) {
+        clearTimeout(usageReportState.staleTimer);
+        usageReportState.staleTimer = null;
+      }
       usageReportState.error = null;
       usageReportRenderControls();
       usageReportRenderLoading();
@@ -14023,34 +14044,176 @@
       const query = `date_from=${date_from}&date_to=${date_to}`;
       const refresh = options.refresh ? '&refresh=1' : '';
       const request = (path) => fetchJsonWithRetry(server, `${path}${path.includes('?') ? '&' : '?'}${query}${refresh}`, { cache: 'no-store' });
-      const [insights, usage, activeTime] = await Promise.all([
-        request(`/api/insights?facets=${USAGE_REPORT_FACETS}`).catch((error) => ({ __error: error })),
-        request('/api/usage').catch((error) => ({ __error: error })),
-        // The scope line promises every agent session recorded on the machine,
-        // so the report pins the Codex review-session filter open instead of
-        // inheriting the server default or the Overview tab's toggle: those are
-        // a reader's choice about one card, not this report's claim.
-        request('/api/active-time?include_review_sessions=true').catch((error) => ({ __error: error })),
-      ]);
 
-      usageReportState.loading = false;
-      usageReportState.loaded = true;
-      if (insights.__error && usage.__error) {
-        usageReportState.error = { server, detail: insights.__error.message || String(insights.__error) };
+      // fetchJson resolves to null when an OK response carries no JSON body — an
+      // empty 200 from a proxy, a captive portal, a Serve hiccup. Reading `.__error`
+      // off null is a TypeError, and one thrown while `loading` is true wedges the
+      // tab for good: the guard at the top then refuses every later load, Retry
+      // included, until a page reload. Normalised here so every branch below is
+      // handed an object, whatever the network did.
+      const settle = (promise) => promise.then(
+        (payload) => (payload && typeof payload === 'object' ? payload : { __error: new Error('empty response') }),
+        (error) => ({ __error: error }),
+      );
+
+      // Sequenced, not fired as one Promise.all. All three are pure-Python
+      // computes on the server's thread pool, so they contend for the GIL rather
+      // than overlapping: fired together on a cold year window, /api/usage went
+      // from 2s alone to 13s, and the paint waited on the slowest of the three
+      // either way. /api/usage alone fills the hero, so it goes first and paints;
+      // the two slow ones start behind it and land under figures the reader is
+      // already reading. Measured cold against v2.5.3 on a year window, median of
+      // three: first number 16.4s -> 1.1s, and the FULL report 16.4s -> 12.3s. The
+      // serial request was expected to cost a couple of seconds of wall clock and
+      // does not — relieving the contention more than pays for it.
+      const notAttempted = () => ({ __error: new Error('not attempted') });
+      let usage = notAttempted();
+      let insights = notAttempted();
+      let activeTime = notAttempted();
+      try {
+        usage = await settle(request('/api/usage'));
+        if (!usage.__error) {
+          usageReportState.model = usageReportBuildModel({
+            insights: null, usage, activeTime: null,
+            period, dateFrom: date_from, dateTo: date_to,
+            // Absent, and the banner is told why: not asked for yet, not refused.
+            insightsMissing: true, usageMissing: false, activeTimeMissing: true,
+            pending: true,
+          });
+          usageReportRenderPartial(usageReportState.model);
+        }
+
+        [insights, activeTime] = await Promise.all([
+          settle(request(`/api/insights?facets=${USAGE_REPORT_FACETS}`)),
+          // The scope line promises every agent session recorded on the machine,
+          // so the report pins the Codex review-session filter open instead of
+          // inheriting the server default or the Overview tab's toggle: those are
+          // a reader's choice about one card, not this report's claim.
+          settle(request('/api/active-time?include_review_sessions=true')),
+        ]);
+
+        if (insights.__error && usage.__error) {
+          usageReportState.error = { server, detail: insights.__error.message || String(insights.__error) };
+          usageReportState.model = null;
+        } else {
+          usageReportState.model = usageReportBuildModel({
+            insights, usage, activeTime,
+            period, dateFrom: date_from, dateTo: date_to,
+            insightsMissing: !!insights.__error,
+            usageMissing: !!usage.__error,
+            activeTimeMissing: !!activeTime.__error,
+          });
+        }
+      } catch (error) {
+        // Defence in depth for the guard at the top of this function. Anything
+        // thrown between here and the finally -- a model bug, a paint bug -- would
+        // otherwise leave `loading` true forever and make the tab refuse every
+        // later load. The error panel at least offers Retry.
+        console.error('tokdash: the report failed to load', error);
+        usageReportState.error = { server, detail: (error && error.message) || String(error) };
         usageReportState.model = null;
-        usageReportRender();
-        usageReportApplyPendingChoice();
+      } finally {
+        usageReportState.loading = false;
+        usageReportState.loaded = true;
+      }
+      usageReportRender();
+      usageReportScheduleStaleReread([usage, insights, activeTime], period, server);
+      usageReportApplyPendingChoice();
+    }
+
+    // How long to leave the server's own background recompute before reading again.
+    // Sized for the slowest of the three on a year of history — the active-time
+    // merge, ~8s cold here — not the average: reading too early spends the one
+    // re-read this load allows on a value still being recomputed.
+    const USAGE_REPORT_STALE_REREAD_MS = 12000;
+
+    // Did the server answer this out of a cache entry it is already recomputing?
+    // Only routes that opt into cache metadata can say; a payload without it is
+    // treated as fresh rather than guessed at.
+    function usageReportServedStale(payload) {
+      const cache = payload && payload.response_cache;
+      return !!cache && cache.status === 'stale';
+    }
+
+    // The morning's first visit is answered out of the 00:05 warm: past its TTL the
+    // server hands the cached value over INSTANTLY and recomputes it in the
+    // background, so the figures are hours old and nothing on the page says so.
+    //
+    // Come back and read again rather than sending refresh=1, which would start a
+    // second full recompute of work the daemon is already doing.
+    //
+    // Any of the three, not just /api/usage: that one recomputes in ~2s and is
+    // reliably fresh by the time the timer fires, while the analytics scan and the
+    // active-time merge are the slow pair that carry most of the page. Keying the
+    // decision on the fastest of the three was how the hero came back current with
+    // a stale heat map, podium and agent table beneath it.
+    function usageReportScheduleStaleReread(payloads, period, server) {
+      if (!payloads.some(usageReportServedStale)) return;
+      // At most one queued at a time. The token, not this handle, is what stops a
+      // late answer from landing on a window the reader has since changed.
+      if (usageReportState.staleTimer) clearTimeout(usageReportState.staleTimer);
+      const token = usageReportState.loadToken;
+      const serverId = (server && server.id) || 'local';
+      usageReportState.staleTimer = setTimeout(() => {
+        usageReportState.staleTimer = null;
+        usageReportSilentReread(token, period, serverId);
+      }, USAGE_REPORT_STALE_REREAD_MS);
+    }
+
+    // A background re-read of the window already on screen.
+    //
+    // Deliberately NOT loadUsageReport. That function owns `loading`, installs a
+    // half-empty model for its first paint and blanks the page to placeholders —
+    // all correct for a load the reader asked for, all wrong for one they cannot
+    // see. Reusing it meant a silent refresh swallowed their clicks, replaced the
+    // live model with the pending one (which the share export could then capture),
+    // and blanked a perfectly good report if the network hiccuped.
+    //
+    // So: touch nothing until a complete, better answer is in hand.
+    async function usageReportSilentReread(token, period, serverId) {
+      if (!usageReportStillWants(token, period, serverId)) return;
+      const server = usageReportServer();
+      if (!server || server.id !== serverId) return;
+
+      const { date_from, date_to } = usageReportWindows(period);
+      const query = `date_from=${date_from}&date_to=${date_to}`;
+      const request = (path) => fetchJsonWithRetry(server, `${path}${path.includes('?') ? '&' : '?'}${query}`, { cache: 'no-store' });
+
+      let usage, insights, activeTime;
+      try {
+        // Fired together, unlike the explicit load: by now these are cache reads
+        // costing milliseconds, and a stale entry answers immediately too, so
+        // there is no cold compute here for them to contend over.
+        [usage, insights, activeTime] = await Promise.all([
+          request('/api/usage'),
+          request(`/api/insights?facets=${USAGE_REPORT_FACETS}`),
+          request('/api/active-time?include_review_sessions=true'),
+        ]);
+      } catch (_error) {
+        // Silent in, silent out. The report on screen is still the best answer this
+        // tab has; blanking it over a refresh nobody asked for is strictly worse
+        // than letting a slightly old one stand.
         return;
       }
+      if (!usage || !insights || !activeTime) return;
+      // Re-checked after the round trip: the reader had all of it to move on.
+      if (!usageReportStillWants(token, period, serverId)) return;
+
       usageReportState.model = usageReportBuildModel({
         insights, usage, activeTime,
         period, dateFrom: date_from, dateTo: date_to,
-        insightsMissing: !!insights.__error,
-        usageMissing: !!usage.__error,
-        activeTimeMissing: !!activeTime.__error,
+        insightsMissing: false, usageMissing: false, activeTimeMissing: false,
       });
       usageReportRender();
-      usageReportApplyPendingChoice();
+    }
+
+    // Is a silent answer for (token, period, serverId) still the thing on screen?
+    // An explicit load bumps the token, so anything it started outranks this.
+    function usageReportStillWants(token, period, serverId) {
+      return !usageReportState.loading
+        && usageReportState.loadToken === token
+        && usageReportState.period === period
+        && usageReportState.serverId === serverId;
     }
 
     // A control changed while a load was in flight describes data that is not on
@@ -14067,10 +14230,15 @@
       if (changedPeriod) usageReportState.period = period;
       if (changedServer) usageReportState.serverId = serverId;
       usageReportWritePrefs();
-      loadUsageReport({ refresh: true });
+      // Not a refresh. This is a queued click on a period or server the reader
+      // has not seen yet, which is an ordinary first load and wants the cache
+      // like any other. Forcing a recompute here turned "clicked while busy"
+      // into the slowest path in the tab, which is backwards: impatience was
+      // being answered with a full cold scan.
+      loadUsageReport();
     }
 
-    function usageReportBuildModel({ insights, usage, activeTime, period, dateFrom, dateTo, insightsMissing, usageMissing, activeTimeMissing }) {
+    function usageReportBuildModel({ insights, usage, activeTime, period, dateFrom, dateTo, insightsMissing, usageMissing, activeTimeMissing, pending = false }) {
       const range = (!insightsMissing && insights.range) || (!usageMissing && usage.range) || {};
       const fromKey = range.from || dateFrom;
       const toKey = range.to || dateTo;
@@ -14204,6 +14372,10 @@
           insightsMissing,
           usageMissing,
           activeTimeMissing,
+          // Not a fourth source. It marks a model built for the first paint,
+          // where the two slow requests are still outstanding rather than
+          // failed, so the banner can tell silence from refusal.
+          pending,
         },
       };
     }
@@ -14289,15 +14461,32 @@
       }));
     }
 
+    // The lines that describe the window rather than the data in it. Shared by
+    // both paints so the partial one cannot print a different range or title
+    // from the full one that replaces it.
+    function usageReportRenderHead(model) {
+      usageReportText(document.getElementById('usageReportTitle'), usageReportPeriodTitle(model));
+      usageReportText(document.getElementById('usageReportRange'),
+        `${formatShortDate(model.range.from, true)} – ${formatShortDate(model.range.to, true)}`);
+      usageReportText(document.getElementById('usageReportProgress'),
+        model.elapsed < model.periodLength ? t('usageReportInProgress', { d: model.elapsed, n: model.periodLength }) : '');
+      usageReportText(document.getElementById('usageReportScopeLine'),
+        t('usageReportScope', { machine: usageReportMachineName() }));
+    }
+
     function usageReportRenderBanner(model) {
       const banner = document.getElementById('usageReportBanner');
       const bits = [];
       // Every source that did not answer is named here, in the order a reader
       // meets its consequences: the analytics scan feeds most of the page, the
       // totals endpoint feeds the hero, active time feeds the session counts.
-      if (model.notices.insightsMissing) bits.push(t('usageReportInsightsMissing'));
+      // On the first paint the slow two have not been asked for yet, so they are
+      // absent without having failed. `pending` keeps that out of the banner,
+      // which would otherwise flash "unavailable" a moment before the data lands.
+      const pending = !!model.notices.pending;
+      if (model.notices.insightsMissing && !pending) bits.push(t('usageReportInsightsMissing'));
       if (model.notices.usageMissing) bits.push(t('usageReportTotalsFallback'));
-      if (model.notices.activeTimeMissing) bits.push(t('usageReportActiveMissing'));
+      if (model.notices.activeTimeMissing && !pending) bits.push(t('usageReportActiveMissing'));
       if (model.sourceErrors.length) {
         bits.push(t('usageReportPartial', { tools: model.sourceErrors.map(usageReportToolLabel).join(', ') }));
       }
@@ -14316,6 +14505,13 @@
     }
 
     function usageReportRenderHero(model) {
+      usageReportRenderHeroTotals(model);
+      usageReportRenderHeroActivity(model);
+    }
+
+    // The half /api/usage answers by itself, so it paints before the other two
+    // requests have even been issued.
+    function usageReportRenderHeroTotals(model) {
       const empty = model.isEmpty;
       const tokensSub = document.getElementById('usageReportKTokensSub');
       tokensSub.classList.remove('tokdash-loading-placeholder');
@@ -14333,6 +14529,12 @@
       }
       usageReportText(document.getElementById('usageReportKCost'), empty ? '—' : formatCurrency(model.cost));
       usageReportText(document.getElementById('usageReportKCostSub'), empty ? '' : t('usageReportCostShort'));
+    }
+
+    // The half that waits: runtime comes from /api/active-time, the active-day
+    // count from the insights streaks facet.
+    function usageReportRenderHeroActivity(model) {
+      const empty = model.isEmpty;
       usageReportText(document.getElementById('usageReportKActive'), empty || !model.activeMs ? '—' : formatDuration(model.activeMs));
       usageReportText(document.getElementById('usageReportKActiveSub'), empty || !model.agentMs ? '' : t('usageReportActiveSub', { agent: formatDuration(model.agentMs) }));
       const daysEl = document.getElementById('usageReportKDays');
@@ -15394,18 +15596,27 @@
       usageReportSyncShareInputs();
     }
 
+    // The first paint, off /api/usage alone: the window lines and the two hero
+    // figures that endpoint fully answers. Every section the other two requests
+    // feed keeps the placeholder usageReportRenderLoading() left on it, so the
+    // page fills in rather than showing em dashes it will have to take back. The
+    // share cards are deliberately not rendered here — they would export a
+    // half-empty report if the reader hit the button in this window.
+    function usageReportRenderPartial(model) {
+      usageReportRenderControls();
+      usageReportRenderState();
+      if (!model) return;
+      usageReportRenderHead(model);
+      usageReportRenderBanner(model);
+      usageReportRenderHeroTotals(model);
+    }
+
     function usageReportRender() {
       usageReportRenderControls();
       usageReportRenderState();
       const model = usageReportState.model;
       if (!model) return;
-      usageReportText(document.getElementById('usageReportTitle'), usageReportPeriodTitle(model));
-      usageReportText(document.getElementById('usageReportRange'),
-        `${formatShortDate(model.range.from, true)} – ${formatShortDate(model.range.to, true)}`);
-      usageReportText(document.getElementById('usageReportProgress'),
-        model.elapsed < model.periodLength ? t('usageReportInProgress', { d: model.elapsed, n: model.periodLength }) : '');
-      usageReportText(document.getElementById('usageReportScopeLine'),
-        t('usageReportScope', { machine: usageReportMachineName() }));
+      usageReportRenderHead(model);
       usageReportRenderBanner(model);
       usageReportRenderHero(model);
       usageReportRenderSentence(model);
@@ -15454,7 +15665,11 @@
           usageReportState.pendingServerId = null;
           usageReportState.serverId = select.value;
           usageReportWritePrefs();
-          loadUsageReport({ refresh: true });
+          // Each server answers out of its own cache, so switching to one is a
+          // first read of that server, not a reason to make it recompute. Only
+          // the retry button below forces one, where the reader is explicitly
+          // asking for another attempt.
+          loadUsageReport();
         });
       }
       const retry = document.getElementById('usageReportRetry');
@@ -18007,6 +18222,16 @@
       if (isQuotaActive()) {
         hideUsageRefreshReport();
         refreshQuotaViaGlobalButton();
+        return;
+      }
+      // Same shape as the Quota branch: the Report tab owns its own window and its
+      // own three requests, so the dashboard fetch below would refresh a range this
+      // tab is not showing. Without this the tab had NO user-reachable way to force
+      // a recompute -- its Retry button is revealed only by the error panel, and the
+      // period and server controls deliberately no longer force one.
+      if (isUsageReportActive()) {
+        hideUsageRefreshReport();
+        loadUsageReport({ refresh: true });
         return;
       }
       // Use current date range if set, otherwise use today

--- a/src/tokdash/usage_store.py
+++ b/src/tokdash/usage_store.py
@@ -2476,6 +2476,43 @@ class UsageEntryStore:
                         out.append(obj)
         return out
 
+    def query_session_signatures(
+        self, tool: str
+    ) -> list[tuple[str, str, str, Optional[int], Optional[int]]]:
+        """Per-row identity and time bounds for a tool, without decoding a session.
+
+        ``(session_id, file_path, signature, started_at_ms, last_seen_at_ms)`` in
+        the same order :meth:`query_session_records` returns rows, so a caller can
+        group by session and reproduce the window filter without paying the
+        ``raw_json`` decode — which is most of what a read of an unchanged tool
+        costs. The point is to learn *which* sessions changed before deciding what
+        to deserialize.
+
+        No ``missing`` filter, matching the record queries: a row kept after its
+        file disappeared still holds that file's content and still belongs to the
+        session.
+        """
+        with closing(self._connect()) as conn:
+            rows = conn.execute(
+                """
+                SELECT session_id, file_path, signature, started_at_ms, last_seen_at_ms
+                FROM session_records
+                WHERE tool = ?
+                ORDER BY file_path ASC, session_id ASC
+                """,
+                (tool,),
+            ).fetchall()
+        return [
+            (
+                str(row["session_id"]),
+                str(row["file_path"]),
+                str(row["signature"] or ""),
+                row["started_at_ms"],
+                row["last_seen_at_ms"],
+            )
+            for row in rows
+        ]
+
     def query_session_activity_records(self, tool: str) -> list[dict[str, Any]]:
         with closing(self._connect()) as conn:
             rows = conn.execute(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,24 @@ def isolated_usage_db(monkeypatch, tmp_path):
 
 
 @pytest.fixture(autouse=True)
+def empty_session_assembly_cache():
+    """Keep the process-global merged-session cache out of every other test.
+
+    ``isolated_usage_db`` gives each test its own database, but the assembly
+    cache is keyed on ``(tool, session_id)`` and a token built from file paths
+    and signatures — none of which mention the store. Two tests that reuse a
+    session id and a ``(path, mtime, size)`` triple under different tmp dirs
+    would collide, and the loser would read the other's merge. Nothing does that
+    today; this is here so nothing has to notice when something starts.
+    """
+    from tokdash.sessions import _SESSION_ASSEMBLY
+
+    _SESSION_ASSEMBLY.clear()
+    yield
+    _SESSION_ASSEMBLY.clear()
+
+
+@pytest.fixture(autouse=True)
 def no_background_warmers(monkeypatch):
     """Keep the lifespan's warm threads out of every test, on ANY code path.
 

--- a/tests/test_cold_fanout_backpressure.py
+++ b/tests/test_cold_fanout_backpressure.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import threading
 import time
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 import pytest
 
@@ -557,6 +557,148 @@ def test_a_request_after_the_daily_warm_is_served_from_cache(monkeypatch):
     assert computes == [(yesterday, yesterday)], "the request recomputed despite the warm"
 
 
+def test_the_report_tabs_three_requests_land_on_what_the_warm_filled(monkeypatch):
+    """Pin the report warm through the routes, not by re-deriving its keys.
+
+    This is the whole value of the warm, and the easiest thing to get silently
+    wrong: the tab sends no ``period``, so each key carries that route's own
+    default -- "today" for usage and active time, "year" for insights -- rather
+    than the week/month/year the reader picked. A key built from the reader's
+    period would warm three windows nobody ever asks for, and the tab would open
+    just as cold as before while every assertion about the warmer still passed.
+    """
+    from fastapi.testclient import TestClient
+
+    computes: list[tuple] = []
+
+    def fake_usage(period, date_from, date_to):
+        computes.append(("usage", date_from, date_to))
+        return {"total_tokens": 1}
+
+    def fake_insights(period, date_from, date_to, **kwargs):
+        computes.append(("insights", date_from, date_to))
+        return {"totals": {"tokens": 1}}
+
+    def fake_active_time(period, date_from, date_to, **kwargs):
+        computes.append(("active_time", date_from, date_to))
+        return {"active_ms": 1}
+
+    monkeypatch.setattr(api, "compute_usage_with_comparison", fake_usage)
+    monkeypatch.setattr(api, "compute_insights", fake_insights)
+    monkeypatch.setattr(api, "get_active_time_data", fake_active_time)
+
+    # The unfiltered target list, deliberately not _warm_report_windows(): that one
+    # drops a window collapsed to a single day, so this test would assert 6 keys on
+    # a Monday, 6 on the 1st and 0 on a Monday 1 January -- red on ~17% of dates and
+    # green on the day it was written. The skip rule has its own test below; this one
+    # is about whether a warmed key is the key the route reads.
+    api._run_warmers(api._report_warm_targets(api._local_today()))
+    warmed = list(computes)
+    # Three requests per DISTINCT window. Normally that is nine, but on a Monday
+    # that is also 1 January all three windows collapse onto the same single day,
+    # so the nine targets share three keys and the warmer rightly computes three.
+    windows = set(api._report_windows(api._local_today()))
+    assert len(warmed) == 3 * len(windows)
+
+    with TestClient(api.app) as client:
+        for date_from, date_to in api._report_windows(api._local_today()):
+            window = f"date_from={date_from}&date_to={date_to}"
+            body = client.get(f"/api/usage?{window}").json()
+            assert body["response_cache"]["status"] == "hit", (
+                f"the usage warm missed the tab's key for {date_from}..{date_to}"
+            )
+            client.get(f"/api/insights?facets={api.REPORT_FACETS}&{window}")
+            client.get(f"/api/active-time?include_review_sessions=true&{window}")
+
+    assert computes == warmed, "a Report tab request recomputed despite the warm"
+
+
+def test_a_warmed_active_time_key_holds_what_the_route_would_have_built(monkeypatch):
+    """The route used to add ``range`` inside a closure no warmer could reach.
+
+    Nothing reads that field on this endpoint today, which is exactly why the
+    divergence would have sat there until something did — and why it needs a test
+    rather than a reviewer noticing twice. Both warmers go through
+    ``_active_time_payload`` now; reinstating the closure would show up here.
+    """
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setattr(
+        api, "get_active_time_data", lambda p, f, t, **kw: {"active_ms": 1}
+    )
+    day = api._local_today()
+    date_from, date_to = api._report_windows(day)[-1]  # the year window
+
+    api._run_warmers(api._report_warm_targets(day))
+    with TestClient(api.app) as client:
+        body = client.get(
+            f"/api/active-time?include_review_sessions=true"
+            f"&date_from={date_from}&date_to={date_to}"
+        ).json()
+
+    assert body["response_cache"]["status"] == "hit", "not served from the warm"
+    assert body["range"]["from"] == date_from, "the warmed payload lost `range`"
+    assert body["range"]["to"] == date_to
+
+    # The Overview's own warmed active-time key goes through the same helper.
+    api._clear_cache()
+    api._run_warmers(api._session_warm_targets(day.isoformat()))
+    with TestClient(api.app) as client:
+        overview = client.get(
+            f"/api/active-time?date_from={day.isoformat()}&date_to={day.isoformat()}"
+        ).json()
+    assert overview["range"]["from"] == day.isoformat()
+
+
+def test_the_midnight_warm_skips_a_report_window_that_is_only_today():
+    """A week window on a Monday is today alone; so is a month window on the 1st.
+
+    Warming those at 00:05 is exactly what ``_warm_previous_day`` refuses to do
+    for the Overview, and this tab is the worse place for it: it has no
+    auto-refresh, so stale-while-revalidate would hand the reader a near-empty
+    week and keep handing it over until they loaded the tab a second time. A
+    single-day window is a second or two cold, so skipping it costs nothing.
+    """
+    monday = date(2026, 9, 7)
+    every = [key for key, _ in api._report_warm_targets(monday)]
+    midnight = [key for key, _ in api._report_warm_targets(monday, skip_single_day=True)]
+
+    assert len(every) == 9
+    assert len(midnight) == 6, "the week window's three requests are dropped"
+    assert set(midnight) < set(every)
+
+    # 1 January 2026 is a Thursday, so only the month and year windows collapse;
+    # the week still reaches back into December and is warmed as usual.
+    new_year = date(2026, 1, 1)
+    assert len(api._report_warm_targets(new_year, skip_single_day=True)) == 3
+    assert api._report_windows(new_year)[0] == ("2025-12-29", "2026-01-01")
+
+    # A 1 January that IS a Monday is the one day all three collapse together.
+    assert date(2024, 1, 1).weekday() == 0
+    assert api._report_warm_targets(date(2024, 1, 1), skip_single_day=True) == []
+    assert len(api._report_warm_targets(date(2024, 1, 1))) == 9
+
+    # An ordinary day is untouched, and the startup warm always keeps the lot:
+    # it runs when somebody started the server, not at a fixed hour, so there is
+    # no near-empty window for it to protect against.
+    assert len(api._report_warm_targets(date(2026, 9, 5), skip_single_day=True)) == 9
+
+
+def test_the_report_warm_mirrors_the_tabs_own_windows():
+    """A window off by a day is a key nobody asks for, and the tab stays cold.
+
+    The Monday week start is the one most likely to drift: JavaScript's getDay()
+    calls Sunday 0 and Python's weekday() calls Monday 0.
+    """
+    week, month, year = api._report_windows(date(2026, 9, 6))  # a Sunday
+    assert week == ("2026-08-31", "2026-09-06"), "the week runs Monday to today"
+    assert month == ("2026-09-01", "2026-09-06")
+    assert year == ("2026-01-01", "2026-09-06")
+
+    monday_week, _, _ = api._report_windows(date(2026, 9, 7))
+    assert monday_week == ("2026-09-07", "2026-09-07"), "a Monday starts its own week"
+
+
 def test_stats_is_warmed_second_behind_the_overview_usage_key(monkeypatch):
     """Composing by name must keep the dashboard's order; slicing let it drift."""
     order: list[str] = []
@@ -566,10 +708,14 @@ def test_stats_is_warmed_second_behind_the_overview_usage_key(monkeypatch):
     api._warm_caches()
 
     today = api._local_today().isoformat()
+    report = [key for key, _ in api._report_warm_targets(api._local_today())]
     assert order[0] == api._usage_warm_target(today)[0]
     assert order[1] == api._window_cache_key("stats_None", None, None)
-    assert order[2:-1] == [key for key, _ in api._session_warm_targets(today)]
-    assert order[-1] == api._day_scoped_key(api.ACTIVITY_INSIGHTS_CACHE_KEY)
+    assert order[2:-1 - len(report)] == [key for key, _ in api._session_warm_targets(today)]
+    assert order[-1 - len(report)] == api._day_scoped_key(api.ACTIVITY_INSIGHTS_CACHE_KEY)
+    # The Report tab's windows go last: they are the heaviest warm on the list and
+    # the Overview is the tab that opens first.
+    assert order[-len(report):] == report
 
 
 def test_the_daily_warm_join_is_shorter_than_the_startup_one():

--- a/tests/test_kilocode_sessions.py
+++ b/tests/test_kilocode_sessions.py
@@ -164,8 +164,21 @@ def _dt(ms):
     return datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
 
 
-def _turn_sums(raw):
-    turns = [t for s in raw.values() for t in s["turns"]]
+def _turn_sums(raw, since_ms=None, until_ms=None):
+    """Totals over the window, applied where the reader applies it.
+
+    The loader reads the whole database and caches it on content alone, so the
+    window is no longer its business — ``_summarize_session`` clips, exactly as it
+    does for every store-backed tool. These sums clip the same way so the parity
+    they assert is still parity against the parser's own SQL window.
+    """
+    turns = [
+        t
+        for s in raw.values()
+        for t in s["turns"]
+        if (since_ms is None or t["timestamp_ms"] >= since_ms)
+        and (until_ms is None or t["timestamp_ms"] < until_ms)
+    ]
     return {
         "in": sum(t["tokens_in"] for t in turns),
         "cache": sum(t["tokens_cache"] for t in turns),
@@ -293,8 +306,8 @@ def test_parity_with_usage_parser(monkeypatch, tmp_path):
                                  _dt(until_ms) if until_ms else None)
         assert len(entries) == expected_entries
         assert all(e["source"] == "kilocode" for e in entries)
-        raw = _kilocode_sessions(since_ms=since_ms, until_ms=until_ms)
-        h = _turn_sums(raw)
+        raw = _kilocode_sessions()
+        h = _turn_sums(raw, since_ms, until_ms)
         assert h["in"] == sum(e["input"] + e["cacheWrite"] for e in entries)
         assert h["cache"] == sum(e["cacheRead"] for e in entries)
         assert h["out"] == sum(e["output"] for e in entries)
@@ -306,7 +319,8 @@ def test_parity_with_usage_parser(monkeypatch, tmp_path):
             assert raw["ses_orphan"]["turns"][0]["tokens_in"] == 100 + 250
             assert raw["ses_orphan"]["project"] == "unknown"
         if since_ms is None and until_ms == BASE + 15_000:
-            assert "ses_orphan" not in raw
+            # Still loaded — it is the summary that leaves it out of the window.
+            assert sessions._summarize_session(raw["ses_orphan"], since_ms, until_ms) is None
 
     # Integration 1b: the same fix must hold through the shared loader's
     # default tool="opencode" call — there is no dedicated opencode/mimo
@@ -334,8 +348,15 @@ def test_window_half_open(monkeypatch, tmp_path):
                  _assistant(input=1, output=1, cache={"read": 0, "write": 0})),
         ],
     )
-    raw = _kilocode_sessions(since_ms=S, until_ms=U)
-    assert set(raw) == {"s_at_since"}
+    raw = _kilocode_sessions()
+    assert set(raw) == {"s_at_since", "s_at_until", "s_before"}
+    # The loader reads everything; [since, until) is applied by the summary.
+    summarized = {
+        session_id
+        for session_id, session in raw.items()
+        if sessions._summarize_session(session, S, U) is not None
+    }
+    assert summarized == {"s_at_since"}
     assert raw["s_at_since"]["turns"][0]["timestamp_ms"] == S
 
 
@@ -433,3 +454,46 @@ def test_cache_invalidates_on_write(monkeypatch, tmp_path):
     # A pricing reload also clears the session cache (turns price at load).
     reload_pricing_db()
     assert _kilocode_sessions() == second
+
+
+def test_cache_invalidates_on_a_write_that_only_moves_the_wal(monkeypatch, tmp_path):
+    """A WAL-only write must invalidate the merged session, not just the loader.
+
+    _kilocode_db_signature covers the -wal and -shm siblings precisely because a
+    SQLite write can leave the main file's mtime and size untouched (see
+    _advance_mtime). The merge cache has to be keyed on the same three files: the
+    loader would otherwise miss correctly, re-read the fresh rows, and then be
+    handed back a merge built from the old ones.
+
+    The connection stays open so the WAL is never checkpointed away, which is how
+    a running app's database actually looks on disk.
+    """
+    _patch_env(monkeypatch, tmp_path)
+    db = _kilo_root(tmp_path) / "kilo.db"
+    _make_db(db, projects=[_proj()], sess=[_sess("ses_a")],
+             messages=[_msg("m1", "ses_a", BASE,
+                            _assistant(input=1, output=1, cache={"read": 0, "write": 0}))])
+
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        assert len(_kilocode_sessions()["ses_a"]["turns"]) == 1
+        before = _kilocode_db_signature()
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data) "
+            "VALUES (?,?,?,?,?)",
+            _msg("m2", "ses_a", BASE + 1000,
+                 _assistant(input=2, output=2, cache={"read": 0, "write": 0})),
+        )
+        conn.commit()
+        after = _kilocode_db_signature()
+
+        by_path = {entry[0]: entry for entry in before}
+        moved = {entry[0] for entry in after if by_path.get(entry[0]) != entry}
+        assert moved, "the write moved nothing at all; the fixture proves nothing"
+        assert moved <= {f"{db}-wal", f"{db}-shm"}, "the main file moved; not the case under test"
+
+        assert len(_kilocode_sessions()["ses_a"]["turns"]) == 2
+    finally:
+        conn.close()

--- a/tests/test_pricing_db_editor_api.py
+++ b/tests/test_pricing_db_editor_api.py
@@ -193,6 +193,11 @@ def test_startup_warmer_populates_initial_overview_date_range(monkeypatch):
     monkeypatch.setattr(api, "get_sessions_data", fake_sessions)
     monkeypatch.setattr(api, "get_active_time_data", fake_active_time)
     monkeypatch.setattr(api, "get_codex_activity_insights", fake_activity)
+    # This test is about the Overview's slice of the startup warm, which asserts
+    # exact call lists. The Report tab's windows ride the same warm and would add
+    # to every one of them; they are pinned through their own routes in
+    # test_cold_fanout_backpressure.py.
+    monkeypatch.setattr(api, "_report_warm_targets", lambda _day: [])
 
     try:
         api._warm_caches()
@@ -242,6 +247,9 @@ def test_default_usage_request_joins_the_startup_warm(monkeypatch):
     monkeypatch.setattr(api, "get_sessions_data", lambda *_args, **_kwargs: {})
     monkeypatch.setattr(api, "get_active_time_data", lambda *_args, **_kwargs: {})
     monkeypatch.setattr(api, "get_codex_activity_insights", lambda: {"tools": []})
+    # The join being tested is for the Overview's today key; the Report tab's
+    # windows would put three more usage computes on the same warm thread.
+    monkeypatch.setattr(api, "_report_warm_targets", lambda _day: [])
     original_claim = api._claim_startup_warm_wait
 
     def claim_startup_warm_wait(key):

--- a/tests/test_provider_reported_cost.py
+++ b/tests/test_provider_reported_cost.py
@@ -245,18 +245,26 @@ def test_the_mimo_fallback_still_excludes_imported_messages(tmp_path, monkeypatc
     assert len(loaded["s1"]["turns"]) == 1, "the imported message is not Mimo's usage"
 
 
-def test_the_mimo_fallback_excludes_imported_boundary_events(tmp_path, monkeypatch):
-    """An imported row outside the window must not become the edge event either."""
+def test_the_mimo_fallback_excludes_an_imported_row_that_precedes_a_window(tmp_path, monkeypatch):
+    """An imported row must not slip in as the row before a caller's window.
+
+    It used to reach that position through a separate boundary lookup, which had
+    to re-apply the import exclusion itself. The loader reads unwindowed now, so
+    the row before a window is just the previous turn and there is no second query
+    to get it wrong — but the exclusion still has to hold there.
+    """
     db_path = _session_db(
         tmp_path / "mimo-boundary.db",
         REPORTED_COST,
         imports=True,
-        # m1 sits in the window at 1000; these two precede it, nearest first.
+        # m1 sits at 1000; these two precede it, the imported one nearest.
         extra_messages=(("imported", 800), ("m0", 700)),
     )
     _deny_json_functions(monkeypatch)
 
-    loaded = sessions._load_mimo_sessions(((str(db_path), 1, 2),), (), 900, 1_100)
+    loaded = sessions._load_mimo_sessions(((str(db_path), 1, 2),))
 
-    assert [turn["timestamp_ms"] for turn in loaded["s1"]["turns"]] == [1_000]
-    assert loaded["s1"]["_prior_event_ms"] == 700, "the imported row at 800 is not an event"
+    assert [turn["timestamp_ms"] for turn in loaded["s1"]["turns"]] == [700, 1_000]
+    assert "_prior_event_ms" not in loaded["s1"]
+    summary = sessions._summarize_session(loaded["s1"], 900, 1_100)
+    assert summary["token_events"] == 1

--- a/tests/test_session_assembly_cache.py
+++ b/tests/test_session_assembly_cache.py
@@ -1,0 +1,319 @@
+"""Assembled sessions must survive between requests, and only where they still hold.
+
+Deserializing a session's rows and merging them is the expensive half of a stored
+read, and it repeated in full on every request. The memo that would have been
+obvious — one keyed on the window — is worth nothing, because the windows a
+reader opens end today and the route's own response cache already absorbs repeats
+inside its TTL. Keying on the files behind a session instead makes one entry serve
+every window and every period at once.
+
+That only works if the token is exact. These tests pin what has to invalidate
+(a file changing, a file leaving, a rate edit) against what must not (a different
+window, a wider period, a second request), and pin the Python window filter to the
+SQL one it replaced.
+"""
+import json
+
+from tokdash import sessions as sessions_module
+from tokdash.sessions import (
+    _assembly_token,
+    _row_touches_window,
+    _session_records_to_raw_sessions,
+    _stored_session_assembly,
+    _SESSION_ASSEMBLY,
+)
+from tokdash.usage_store import UsageEntryStore
+
+DAY = 24 * 60 * 60 * 1000
+BASE = 1_800_000_000_000
+
+
+def _turn(stamp, index=1, tokens=10):
+    return {
+        "turn_index": index,
+        "timestamp_ms": stamp,
+        "model": "claude-sonnet-4.5",
+        "tokens_in": tokens,
+        "tokens_cache": 0,
+        "tokens_out": 5,
+        "tokens_reasoning": 0,
+        "tokens": tokens + 5,
+        "cost": 0.0,
+    }
+
+
+def _raw(session_id, stamps, *, name=None, project="proj"):
+    return {
+        "tool": "claude",
+        "session_id": session_id,
+        "project": project,
+        "display_name": name,
+        "turns": [_turn(stamp, index) for index, stamp in enumerate(stamps, start=1)],
+    }
+
+
+def _sync(store, contents, *, tool="claude", stamps=None):
+    """Store one row per path; ``stamps`` restamps only the paths it names."""
+    stamps = stamps or {}
+    files = tuple(
+        (path, stamps.get(path, 1), 100 + stamps.get(path, 1)) for path in sorted(contents)
+    )
+    store.sync_session_files(
+        tool,
+        files,
+        parser={"v": 1},
+        parse_file_session=lambda file_sig: contents[file_sig[0]],
+    )
+    return files
+
+
+def _store(tmp_path, contents, **kwargs):
+    store = UsageEntryStore(tmp_path / "usage.sqlite3")
+    _sync(store, contents, **kwargs)
+    return store
+
+
+def _canon(value):
+    return json.dumps(value, sort_keys=True, default=str)
+
+
+class _CountingStore:
+    """Wraps a store and counts the reads that deserialize ``raw_json``."""
+
+    def __init__(self, store):
+        self._store = store
+        self.decoded_ids = []
+
+    def query_session_signatures(self, tool):
+        return self._store.query_session_signatures(tool)
+
+    def query_session_records_by_ids(self, tool, session_ids):
+        ids = sorted(session_ids)
+        self.decoded_ids.append(ids)
+        return self._store.query_session_records_by_ids(tool, ids)
+
+    def query_session_records(self, tool, **kwargs):
+        return self._store.query_session_records(tool, **kwargs)
+
+
+def test_a_second_read_of_an_unchanged_tool_deserializes_nothing(tmp_path):
+    contents = {
+        str(tmp_path / "a.jsonl"): _raw("s1", [BASE, BASE + 1000]),
+        str(tmp_path / "b.jsonl"): _raw("s1", [BASE + 2000], name="Real"),
+        str(tmp_path / "c.jsonl"): _raw("s2", [BASE + 3000]),
+    }
+    store = _CountingStore(_store(tmp_path, contents))
+
+    first, _ = _stored_session_assembly(store, "claude", None, None)
+    assert store.decoded_ids == [["s1", "s2"]]
+
+    second, _ = _stored_session_assembly(store, "claude", None, None)
+    assert store.decoded_ids == [["s1", "s2"]]
+    # Same objects, not merely equal ones: that is what makes the read free.
+    assert second["s1"] is first["s1"]
+    assert second["s2"] is first["s2"]
+
+
+def test_a_narrower_window_reuses_what_a_wider_one_assembled(tmp_path):
+    contents = {
+        str(tmp_path / "a.jsonl"): _raw("s1", [BASE, BASE + DAY]),
+        str(tmp_path / "b.jsonl"): _raw("s2", [BASE + 2 * DAY]),
+    }
+    store = _CountingStore(_store(tmp_path, contents))
+
+    everything, _ = _stored_session_assembly(store, "claude", None, None)
+    assert store.decoded_ids == [["s1", "s2"]]
+
+    # A window that only s1 touches. Nothing is rebuilt, and the entry the
+    # unbounded read made is the one served.
+    windowed, _ = _stored_session_assembly(store, "claude", BASE, BASE + DAY)
+    assert set(windowed) == {"s1"}
+    assert store.decoded_ids == [["s1", "s2"]]
+    assert windowed["s1"] is everything["s1"]
+
+
+def test_an_appended_file_rebuilds_only_the_session_it_belongs_to(tmp_path):
+    paths = [str(tmp_path / name) for name in ("a.jsonl", "b.jsonl", "c.jsonl")]
+    contents = {
+        paths[0]: _raw("s1", [BASE]),
+        paths[1]: _raw("s1", [BASE + 1000]),
+        paths[2]: _raw("s2", [BASE + 2000]),
+    }
+    inner = _store(tmp_path, contents)
+    store = _CountingStore(inner)
+    first, _ = _stored_session_assembly(store, "claude", None, None)
+
+    contents[paths[1]] = _raw("s1", [BASE + 1000, BASE + 1500])
+    _sync(inner, contents, stamps={paths[1]: 2})
+
+    second, _ = _stored_session_assembly(store, "claude", None, None)
+    assert store.decoded_ids == [["s1", "s2"], ["s1"]]
+    assert len(second["s1"]["turns"]) == 3
+    assert second["s2"] is first["s2"]
+
+
+def test_a_file_leaving_the_session_invalidates_it(tmp_path):
+    paths = [str(tmp_path / name) for name in ("a.jsonl", "b.jsonl")]
+    contents = {paths[0]: _raw("s1", [BASE]), paths[1]: _raw("s1", [BASE + 1000])}
+    inner = _store(tmp_path, contents)
+    store = _CountingStore(inner)
+    assert len(_stored_session_assembly(store, "claude", None, None)[0]["s1"]["turns"]) == 2
+
+    # A non-durable sync deletes the row outright, leaving every surviving row's
+    # signature untouched — only the shape of the set says anything changed.
+    del contents[paths[1]]
+    inner.sync_session_files(
+        "claude",
+        ((paths[0], 1, 101),),
+        parser={"v": 1},
+        parse_file_session=lambda file_sig: contents[file_sig[0]],
+        durable=False,
+    )
+
+    second, _ = _stored_session_assembly(store, "claude", None, None)
+    assert store.decoded_ids == [["s1"], ["s1"]]
+    assert len(second["s1"]["turns"]) == 1
+
+
+def test_new_rates_invalidate_every_assembled_session(tmp_path, monkeypatch):
+    contents = {str(tmp_path / "a.jsonl"): _raw("s1", [BASE])}
+    store = _CountingStore(_store(tmp_path, contents))
+    _stored_session_assembly(store, "claude", None, None)
+
+    monkeypatch.setattr(sessions_module, "_pricing_signature", lambda: ("edited",))
+    _stored_session_assembly(store, "claude", None, None)
+    assert store.decoded_ids == [["s1"], ["s1"]]
+
+
+def test_the_cached_read_matches_the_uncached_one(tmp_path, monkeypatch):
+    contents = {
+        str(tmp_path / "a.jsonl"): _raw("s1", [BASE, BASE + DAY]),
+        str(tmp_path / "b.jsonl"): _raw("s1", [BASE + 2 * DAY], name="Titled"),
+        str(tmp_path / "c.jsonl"): _raw("s2", [BASE + 3 * DAY], project="other"),
+        str(tmp_path / "d.jsonl"): _raw("s3", [BASE - DAY]),
+    }
+    store = _store(tmp_path, contents)
+
+    windows = [
+        (None, None),
+        (BASE, BASE + 4 * DAY),
+        (BASE + DAY, BASE + 3 * DAY),
+        (None, BASE + DAY),
+        (BASE + 2 * DAY, None),
+        (BASE + 9 * DAY, BASE + 10 * DAY),
+    ]
+    for since_ms, until_ms in windows:
+        expected = _session_records_to_raw_sessions(
+            "claude",
+            store.query_session_records(
+                "claude", since_ms=since_ms, until_ms=until_ms, whole_sessions=True
+            ),
+        )
+        # Twice: the second pass reads the entries the first one left behind.
+        for _attempt in range(2):
+            assembled, _tokens = _stored_session_assembly(store, "claude", since_ms, until_ms)
+            assert list(assembled) == list(expected)
+            assert _canon(assembled) == _canon(expected)
+
+
+def test_the_python_window_filter_agrees_with_the_sql_one(tmp_path):
+    contents = {
+        str(tmp_path / f"{index}.jsonl"): _raw(f"s{index}", [BASE + index * DAY])
+        for index in range(6)
+    }
+    # One session spanning two far-apart files: its rows straddle windows that
+    # neither row alone covers, which is where a per-session predicate diverges
+    # from the per-row one SQL applies.
+    contents[str(tmp_path / "wide-a.jsonl")] = _raw("wide", [BASE])
+    contents[str(tmp_path / "wide-b.jsonl")] = _raw("wide", [BASE + 5 * DAY])
+    store = _store(tmp_path, contents)
+
+    edges = [BASE + offset * DAY for offset in range(-1, 8)]
+    for since_ms in [None, *edges]:
+        for until_ms in [None, *edges]:
+            expected = {
+                str(record["session_id"])
+                for record in store.query_session_records(
+                    "claude", since_ms=since_ms, until_ms=until_ms, whole_sessions=True
+                )
+            }
+            assembled, _tokens = _stored_session_assembly(store, "claude", since_ms, until_ms)
+            assert set(assembled) == expected, (since_ms, until_ms)
+
+
+def test_a_null_bound_fails_the_window_the_way_sql_does():
+    # SQL compares NULL to anything as NULL, which is not true, so the row is out.
+    assert _row_touches_window(None, None, None, None) is True
+    assert _row_touches_window(None, 10, 5, None) is True
+    assert _row_touches_window(None, 10, None, 20) is False
+    assert _row_touches_window(10, None, 5, None) is False
+
+
+def test_the_token_is_a_set_not_a_sequence():
+    pairs = [("b.jsonl", "sig-b"), ("a.jsonl", "sig-a")]
+    assert _assembly_token(pairs, ()) == _assembly_token(reversed(pairs), ())
+    assert _assembly_token(pairs, ()) != _assembly_token(pairs[:1], ())
+    assert _assembly_token(pairs, ()) != _assembly_token(pairs, ("rates",))
+
+
+def test_a_live_loader_reuses_the_sessions_whose_files_did_not_change(monkeypatch):
+    """The live path's own memo is keyed on the whole tool, which is too coarse.
+
+    One appended log — the session being worked in right now — changed the tool's
+    signature and re-merged every session it had. Two files per session so the
+    merge builds something new, and object identity means something.
+    """
+    contents = {
+        "/fake/a.jsonl": _raw("s1", [BASE]),
+        "/fake/b.jsonl": _raw("s1", [BASE + 1000]),
+        "/fake/c.jsonl": _raw("s2", [BASE + 2000]),
+        "/fake/d.jsonl": _raw("s2", [BASE + 3000]),
+    }
+    monkeypatch.setattr(
+        sessions_module,
+        "_parse_claude_session_file",
+        lambda path_str, *_args: contents[path_str],
+    )
+    loader = sessions_module._load_claude_sessions
+    loader.cache_clear()
+    try:
+        stamps = {path: 1 for path in contents}
+        first = loader(tuple((path, stamps[path], 100) for path in sorted(contents)), ())
+
+        contents["/fake/b.jsonl"] = _raw("s1", [BASE + 1000, BASE + 1500])
+        stamps["/fake/b.jsonl"] = 2
+        second = loader(tuple((path, stamps[path], 100) for path in sorted(contents)), ())
+
+        assert second["s2"] is first["s2"]
+        assert second["s1"] is not first["s1"]
+        assert len(second["s1"]["turns"]) == 3
+    finally:
+        loader.cache_clear()
+
+
+def test_the_turn_budget_evicts_and_can_be_switched_off(tmp_path, monkeypatch):
+    contents = {
+        str(tmp_path / "a.jsonl"): _raw("s1", [BASE + n for n in range(6)]),
+        str(tmp_path / "b.jsonl"): _raw("s2", [BASE + 100 + n for n in range(6)]),
+    }
+    store = _CountingStore(_store(tmp_path, contents))
+
+    monkeypatch.setenv("TOKDASH_SESSION_CACHE_TURNS", "0")
+    _stored_session_assembly(store, "claude", None, None)
+    _stored_session_assembly(store, "claude", None, None)
+    assert store.decoded_ids == [["s1", "s2"], ["s1", "s2"]]
+    assert _SESSION_ASSEMBLY.stats() == (0, 0)
+
+    # Room for one session of six turns, so caching both evicts the older.
+    monkeypatch.setenv("TOKDASH_SESSION_CACHE_TURNS", "6")
+    _SESSION_ASSEMBLY.clear()
+    _stored_session_assembly(store, "claude", None, None)
+    assert _SESSION_ASSEMBLY.stats() == (1, 6)
+    _stored_session_assembly(store, "claude", None, None)
+    assert store.decoded_ids[-1] == ["s1"]
+
+    # Switching it off under a running server drops what it was already holding
+    # rather than leaving it resident for the life of the process.
+    monkeypatch.setenv("TOKDASH_SESSION_CACHE_TURNS", "0")
+    _stored_session_assembly(store, "claude", None, None)
+    assert _SESSION_ASSEMBLY.stats() == (0, 0)

--- a/tests/test_session_merge_batch.py
+++ b/tests/test_session_merge_batch.py
@@ -1,16 +1,28 @@
 """The batched session merge must reproduce the pairwise fold exactly.
 
 One Claude session spans every subagent transcript it spawned, so rebuilding it
-from the store used to fold the rows pairwise and re-key every turn already
-merged — quadratic in the number of files. _merge_raw_session_sequence collapses
-that to one pass; these tests pin it to the fold it replaced, because the live
-loaders still fold pairwise and a cached read that merges differently is exactly
-how cached and live start disagreeing.
+used to fold the rows pairwise and re-key every turn already merged — quadratic
+in the number of files. _merge_raw_session_sequence collapses that to one pass;
+these tests pin it to the fold it replaced, because a read that merges
+differently is exactly how two paths over the same logs start disagreeing.
+
+Fan-out is not Claude-shaped, only Claude-sized: every loader that can attribute
+several files to one session id lands on the same K^2, and the tools that are
+never store-backed have no second cache tier to hide behind. So the loaders are
+pinned here too — both to the linear key count, and to leaving the sessions they
+merge alone afterwards, which is what makes a merged session shareable.
 """
 import json
+from pathlib import Path
+
+import pytest
 
 from tokdash import sessions
-from tokdash.sessions import _merge_raw_session, _merge_raw_session_sequence
+from tokdash.sessions import (
+    _drop_codex_subagent_replay_turns,
+    _merge_raw_session,
+    _merge_raw_session_sequence,
+)
 
 
 def _fold(raws):
@@ -139,3 +151,121 @@ def test_each_turn_is_keyed_exactly_once(monkeypatch):
     ]
     _merge_raw_session_sequence(raws)
     assert calls["n"] == files * per_file
+
+
+# Loader name paired with the module attribute its per-file parse reaches through.
+# Every one of these once folded pairwise; four of the tools (pi_agent, omp,
+# kilocode, workbuddy) are never store-backed, so nothing else caps their cost.
+LIVE_LOADERS = [
+    ("_load_codex_sessions", "_parse_codex_session_file"),
+    ("_load_claude_sessions", "_parse_claude_session_file"),
+    ("_load_pi_sessions", "_parse_pi_session_file"),
+    ("_load_omp_sessions", "_parse_omp_session_file"),
+    ("_load_kimi_sessions", "_parse_kimi_session_file"),
+    ("_load_dsh_sessions", "_parse_dsh_session_file"),
+    ("_load_reasonix_sessions", "_parse_reasonix_session_file"),
+    ("_load_workbuddy_sessions", "_parse_workbuddy_session_file"),
+]
+
+_FILES, _PER_FILE = 40, 3
+
+
+def _fan_out_raw(path_str, per_file=_PER_FILE):
+    """One session id spread over many files, the shape subagent fan-out writes."""
+    index = int(Path(path_str).stem)
+    return _raw(
+        turns=[
+            _turn(i, 1000 + index * 100 + i, event=f"e{index}-{i}")
+            for i in range(1, per_file + 1)
+        ]
+    )
+
+
+def _count_identity_keys(monkeypatch):
+    calls = {"n": 0}
+    original = sessions._turn_identity_key
+
+    def counting(turn):
+        calls["n"] += 1
+        return original(turn)
+
+    monkeypatch.setattr(sessions, "_turn_identity_key", counting)
+    return calls
+
+
+@pytest.mark.parametrize("loader_name,parser_name", LIVE_LOADERS)
+def test_a_live_loader_keys_each_turn_once(monkeypatch, loader_name, parser_name):
+    loader = getattr(sessions, loader_name)
+    loader.cache_clear()
+    monkeypatch.setattr(
+        sessions, parser_name, lambda path_str, *_args: _fan_out_raw(path_str)
+    )
+    calls = _count_identity_keys(monkeypatch)
+    signature = tuple((f"/fake/{index}.jsonl", 0, 0) for index in range(_FILES))
+    try:
+        merged = loader(signature, ())
+        assert len(merged["s1"]["turns"]) == _FILES * _PER_FILE
+        assert calls["n"] == _FILES * _PER_FILE
+    finally:
+        loader.cache_clear()
+
+
+def test_the_kilocode_loader_keys_each_turn_once(monkeypatch, tmp_path):
+    # Kilocode reads sqlite rather than transcripts, so it fakes one level up.
+    paths = []
+    for index in range(_FILES):
+        db = tmp_path / f"{index}.vscdb"
+        db.write_bytes(b"")
+        paths.append(db)
+    monkeypatch.setattr(
+        sessions,
+        "_load_opencode_sessions_scalar",
+        lambda db_path, **_kwargs: {"s1": _fan_out_raw(str(db_path))},
+    )
+    calls = _count_identity_keys(monkeypatch)
+    signature = tuple((str(path), 0, 0) for path in paths)
+    sessions._load_kilocode_sessions.cache_clear()
+    try:
+        merged = sessions._load_kilocode_sessions(signature, ())
+        assert len(merged["s1"]["turns"]) == _FILES * _PER_FILE
+        assert calls["n"] == _FILES * _PER_FILE
+    finally:
+        sessions._load_kilocode_sessions.cache_clear()
+
+
+def _fork(session_id, parent_id, events):
+    raw = _raw(session_id, turns=[_turn(i, 1000 + i, event=event) for i, event in enumerate(events, 1)])
+    raw["tool"] = "codex"
+    if parent_id:
+        raw["_subagent_parent_id"] = parent_id
+    return raw
+
+
+def test_the_codex_replay_pass_trims_a_fork_without_editing_the_input():
+    given = {"p": _fork("p", None, ["a", "b"]), "c": _fork("c", "p", ["a", "c"])}
+    before = _canon(given)
+    result = _drop_codex_subagent_replay_turns(given)
+    assert [turn["_event_key"] for turn in result["c"]["turns"]] == ["c"]
+    assert _canon(given) == before
+
+
+def test_the_codex_replay_pass_drops_an_all_replay_fork_without_editing_the_input():
+    given = {"p": _fork("p", None, ["a", "b"]), "c": _fork("c", "p", ["a", "b"])}
+    before = _canon(given)
+    result = _drop_codex_subagent_replay_turns(given)
+    assert "c" not in result and "p" in result
+    assert _canon(given) == before
+
+
+def test_the_codex_sibling_rule_keeps_the_input_intact():
+    # Parent absent, so both forks hold the same replay prefix; the later sibling
+    # gives it up. That branch also used to trim in place.
+    given = {
+        "c1": _fork("c1", "gone", ["a", "x"]),
+        "c2": _fork("c2", "gone", ["a", "y"]),
+    }
+    before = _canon(given)
+    result = _drop_codex_subagent_replay_turns(given)
+    assert [turn["_event_key"] for turn in result["c1"]["turns"]] == ["a", "x"]
+    assert [turn["_event_key"] for turn in result["c2"]["turns"]] == ["y"]
+    assert _canon(given) == before

--- a/tests/test_usage_report_frontend.py
+++ b/tests/test_usage_report_frontend.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import ast
 import json
 import re
+from datetime import date, timedelta
 import shutil
 import subprocess
 from pathlib import Path
@@ -40,7 +41,7 @@ MACHINE_KEYS = (
 
 BUILD_MODEL_SIGNATURE = (
     "function usageReportBuildModel({ insights, usage, activeTime, period, dateFrom,"
-    " dateTo, insightsMissing, usageMissing, activeTimeMissing }) {"
+    " dateTo, insightsMissing, usageMissing, activeTimeMissing, pending = false }) {"
 )
 
 HELPERS = (
@@ -407,6 +408,12 @@ process.stdout.write(JSON.stringify({
   whole: shape(build({})),
   noActiveTime: shape(build({ activeTime: { __error: 'boom' }, activeTimeMissing: true })),
   noInsights: shape(build({ insights: { __error: 'boom' }, insightsMissing: true })),
+  // The first paint: /api/usage has landed and the other two have not been
+  // issued, so the model is built over two literal nulls.
+  firstPaint: shape(build({
+    insights: null, activeTime: null,
+    insightsMissing: true, activeTimeMissing: true, pending: true,
+  })),
 }));
 """
 
@@ -442,11 +449,447 @@ def test_a_failed_active_time_leaves_no_count_rather_than_a_zero(tmp_path: Path)
     assert report["noInsights"]["sessions"] == 4
 
 
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_the_first_paint_builds_a_model_over_two_absent_sources(tmp_path: Path) -> None:
+    """The hero paints off /api/usage before the other two have been issued.
+
+    Every read of `insights` and `activeTime` in the model is guarded by its
+    Missing flag, so the first paint can pass literal nulls. Running it is the
+    point: an unguarded read is a TypeError that leaves the tab on its spinner
+    forever, which no amount of reading the source proves absent.
+    """
+    source = _source()
+    body = "\n".join(_extract_js_function(source, sig) for sig in MODEL_SIGNATURES) + MODEL_FIXTURE
+    first = json.loads(_run_node(tmp_path, "usage-report-model.js", body))["firstPaint"]
+
+    assert first["notices"]["pending"] is True, "the banner needs silence told from refusal"
+    assert first["sessions"] is None, "no active time yet is not a count of zero"
+    assert first["hasStreaks"] is False
+    assert first["activeMs"] == 0
+
+
+def test_the_server_warms_the_exact_facet_string_the_tab_asks_for() -> None:
+    """The facet string is part of the insights cache key, character for character.
+
+    These cannot be one constant -- one is Python and one is JavaScript -- so a
+    reordered or extended set on either side warms a key the tab never asks for.
+    Nothing else would notice: the warm still runs, every test that builds keys
+    from the Python constant still passes, and the tab just quietly goes back to
+    paying the cold scan it used to.
+    """
+    from tokdash import api
+
+    block = _report_block(_source())
+    match = re.search(r"const USAGE_REPORT_FACETS = '([^']+)';", block)
+    assert match, "the tab's facet constant moved or changed quoting"
+    assert match.group(1) == api.REPORT_FACETS
+
+
+LOADER_HARNESS = """
+const usageReportState = {
+  loading: false, loaded: false, error: null, model: null,
+  period: 'month', serverId: 'local', staleReread: false,
+};
+const calls = [];
+let responder = () => null;
+function usageReportWire() {}
+function usageReportRenderControls() {}
+function usageReportRenderLoading() { calls.push('renderLoading'); }
+function usageReportServer() { return { id: 'local', label: 'local' }; }
+function usageReportLoadVersion() {}
+function usageReportWindows() { return { date_from: '2026-09-01', date_to: '2026-09-05' }; }
+function usageReportBuildModel(args) { return { notices: {}, args }; }
+function usageReportRenderPartial() { calls.push('partial'); }
+function usageReportRender() { calls.push('render'); }
+function usageReportScheduleStaleReread() {}
+function usageReportApplyPendingChoice() {}
+function fetchJsonWithRetry() { return Promise.resolve(responder()); }
+const USAGE_REPORT_FACETS = 'daily';
+__LOADER__
+(async () => {
+  const out = {};
+  // An OK 200 whose body is not JSON: fetchJson resolves to null.
+  responder = () => null;
+  await loadUsageReport();
+  out.afterNull = { loading: usageReportState.loading, loaded: usageReportState.loaded };
+
+  // The tab must still accept a later load. Before the guard existed this second
+  // call was refused outright and the tab was dead until a page reload.
+  calls.length = 0;
+  responder = () => ({ total_tokens: 5 });
+  await loadUsageReport();
+  out.recovered = calls.includes('render');
+  out.loadingAtRest = usageReportState.loading;
+  process.stdout.write(JSON.stringify(out));
+})();
+"""
+
+
+WINDOWS_HARNESS = """
+let CURSOR = null;
+function usageReportToday() { return CURSOR; }
+__HELPERS__
+const out = JSON.parse(process.argv[2]).map((iso) => {
+  const [y, m, d] = iso.split('-').map(Number);
+  CURSOR = new Date(y, m - 1, d);
+  return ['week', 'month', 'year'].map((period) => {
+    const w = usageReportWindows(period);
+    return [w.date_from, w.date_to];
+  });
+});
+process.stdout.write(JSON.stringify(out));
+"""
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_the_warmers_windows_match_the_tabs_own_across_years(tmp_path: Path) -> None:
+    """The warmer builds its keys in Python; the tab builds the same windows in
+    JavaScript. A mismatch of one day warms a key nobody asks for and the tab
+    quietly stays cold -- with every Python-side test still green.
+
+    Run against the real JS rather than hardcoded expectations, over enough days to
+    cross two year boundaries and a leap day. The riskiest divergence is the week
+    start: JavaScript's getDay() calls Sunday 0, Python's weekday() calls Monday 0.
+    """
+    from tokdash import api
+
+    days = [date(2024, 1, 1) + timedelta(days=n) for n in range(900)]
+    helpers = "\n".join(
+        _extract_js_function(_source(), sig)
+        for sig in (
+            "function formatDateKey(date) {",
+            "function startOfWeekMonday(date) {",
+            "function usageReportWindows(period) {",
+        )
+    )
+    body = WINDOWS_HARNESS.replace("__HELPERS__", helpers)
+    js = json.loads(
+        _run_node(tmp_path, "usage-report-windows.js", body,
+                  json.dumps([day.isoformat() for day in days]))
+    )
+
+    mismatches = [
+        (day.isoformat(), from_js, from_py)
+        for day, from_js in zip(days, js)
+        for from_js, from_py in [([tuple(w) for w in from_js], api._report_windows(day))]
+        if from_js != from_py
+    ]
+    assert not mismatches, mismatches[:5]
+    # Guard the comparison itself: a harness that silently produced nothing would
+    # otherwise "pass" by having no mismatches to report.
+    assert len(js) == len(days)
+    assert js[0] == [["2024-01-01", "2024-01-01"]] * 3, "a Monday 1 January collapses all three"
+
+
+SCHEDULE_HARNESS = """
+const usageReportState = { staleTimer: null, loadToken: 3 };
+let nextId = 1;
+const armed = new Map();
+const cleared = [];
+setTimeout = (fn, ms) => { const id = nextId++; armed.set(id, { fn, ms }); return id; };
+clearTimeout = (id) => { cleared.push(id); armed.delete(id); };
+const reread = [];
+function usageReportSilentReread(token, period, serverId) { reread.push([token, period, serverId]); }
+const USAGE_REPORT_STALE_REREAD_MS = 12000;
+__SERVED__
+__SCHEDULE__
+const fresh = { response_cache: { status: 'hit' } };
+const stale = { response_cache: { status: 'stale' } };
+const bare = {};                       // a route that serves no cache metadata
+const server = { id: 'local' };
+const out = {};
+
+// Nothing stale: nothing armed.
+usageReportScheduleStaleReread([fresh, fresh, fresh], 'month', server);
+out.allFresh = armed.size;
+
+// A route with no metadata must not be guessed at.
+usageReportScheduleStaleReread([bare, bare, bare], 'month', server);
+out.noMetadata = armed.size;
+
+// Only the SLOW pair is stale -- usage is already fresh. This is the case that
+// keying the decision on /api/usage alone used to miss entirely.
+usageReportScheduleStaleReread([fresh, stale, fresh], 'month', server);
+out.slowPairStale = armed.size;
+const firstId = usageReportState.staleTimer;
+
+// A second schedule must retire the first timer, not stack on it.
+usageReportScheduleStaleReread([fresh, fresh, stale], 'month', server);
+out.afterSecond = { armed: armed.size, clearedFirst: cleared.includes(firstId) };
+out.delay = armed.get(usageReportState.staleTimer).ms;
+
+// Firing it hands the silent path the token captured at schedule time.
+armed.get(usageReportState.staleTimer).fn();
+out.fired = reread;
+out.handleCleared = usageReportState.staleTimer === null;
+process.stdout.write(JSON.stringify(out));
+"""
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_only_one_stale_reread_is_ever_armed(tmp_path: Path) -> None:
+    """Scheduling is where the first attempt leaked timers.
+
+    It gated on a boolean that every explicit load reset, so old timers stayed
+    armed and a reader flipping periods could fire several re-reads for the same
+    window -- multiplying request load exactly when the server is contended.
+    Executed, because a source assertion cannot see a timer that was never cleared.
+    """
+    block = _report_block(_source())
+    body = (
+        SCHEDULE_HARNESS
+        .replace("__SERVED__", _extract_js_function(
+            block, "function usageReportServedStale(payload) {"))
+        .replace("__SCHEDULE__", _extract_js_function(
+            block, "function usageReportScheduleStaleReread(payloads, period, server) {"))
+    )
+    out = json.loads(_run_node(tmp_path, "usage-report-schedule.js", body))
+
+    assert out["allFresh"] == 0, "nothing stale, nothing to re-read"
+    assert out["noMetadata"] == 0, "a route that says nothing is treated as fresh"
+    assert out["slowPairStale"] == 1, (
+        "a stale insights/active-time must arm the re-read even when usage is fresh"
+    )
+    assert out["afterSecond"] == {"armed": 1, "clearedFirst": True}, "timers stacked"
+    assert out["delay"] == 12000
+    assert out["fired"] == [[3, "month", "local"]], "the token is captured at schedule time"
+    assert out["handleCleared"] is True
+
+
+REREAD_HARNESS = """
+const usageReportState = {
+  loading: false, loaded: true, error: null, model: { tag: 'original' },
+  period: 'month', serverId: 'local', staleTimer: null, loadToken: 7,
+};
+let mode = 'ok';
+let onRequest = null;
+const renders = [];
+function usageReportServer() { return { id: 'local' }; }
+function usageReportWindows() { return { date_from: '2026-09-01', date_to: '2026-09-05' }; }
+function usageReportBuildModel() { return { tag: 'reread' }; }
+function usageReportRender() { renders.push(usageReportState.model.tag); }
+const USAGE_REPORT_FACETS = 'daily';
+function fetchJsonWithRetry() {
+  if (onRequest) onRequest();
+  if (mode === 'throw') return Promise.reject(new Error('network'));
+  if (mode === 'null') return Promise.resolve(null);
+  return Promise.resolve({ ok: true });
+}
+__REREAD__
+__WANTS__
+const snap = () => ({ model: usageReportState.model.tag, renders: renders.length, loading: usageReportState.loading });
+(async () => {
+  const out = {};
+  mode = 'throw';
+  await usageReportSilentReread(7, 'month', 'local');
+  out.afterFailure = snap();
+
+  mode = 'null';
+  await usageReportSilentReread(7, 'month', 'local');
+  out.afterNull = snap();
+
+  // The reader switches period while the round trip is in flight.
+  mode = 'ok';
+  onRequest = () => { usageReportState.period = 'year'; };
+  await usageReportSilentReread(7, 'month', 'local');
+  out.afterPeriodSwitch = snap();
+  onRequest = null;
+  usageReportState.period = 'month';
+
+  // An explicit load ran and bumped the token.
+  await usageReportSilentReread(6, 'month', 'local');
+  out.afterStaleToken = snap();
+
+  // Nothing changed: it commits.
+  await usageReportSilentReread(7, 'month', 'local');
+  out.afterSuccess = snap();
+  process.stdout.write(JSON.stringify(out));
+})();
+"""
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_a_silent_reread_never_damages_the_report_on_screen(tmp_path: Path) -> None:
+    """The re-read is invisible, so every way it can go wrong is silent too.
+
+    Executed rather than asserted against the source: the first attempt at this
+    reused `loadUsageReport`, and every one of these cases passed its
+    source-string tests while blanking the page, swallowing clicks or leaving a
+    half-empty model in state for the share export to capture.
+    """
+    block = _report_block(_source())
+    body = (
+        REREAD_HARNESS
+        .replace("__REREAD__", _extract_js_function(
+            block, "async function usageReportSilentReread(token, period, serverId) {"))
+        .replace("__WANTS__", _extract_js_function(
+            block, "function usageReportStillWants(token, period, serverId) {"))
+    )
+    out = json.loads(_run_node(tmp_path, "usage-report-reread.js", body))
+
+    for case in ("afterFailure", "afterNull", "afterPeriodSwitch", "afterStaleToken"):
+        assert out[case]["model"] == "original", f"{case} overwrote a good report"
+        assert out[case]["renders"] == 0, f"{case} repainted the page"
+
+    assert out["afterSuccess"]["model"] == "reread", "a clean re-read must commit"
+    assert out["afterSuccess"]["renders"] == 1
+
+    # It must never take the loading flag: that is what swallowed period clicks and
+    # made Retry a no-op during a refresh the reader could not see.
+    for case in out.values():
+        assert case["loading"] is False
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_an_empty_200_does_not_wedge_the_report_tab(tmp_path: Path) -> None:
+    """`fetchJson` resolves to null when an OK response carries no JSON body.
+
+    Sequencing moved the first dereference of that value inside the window where
+    `loading` is true, so the TypeError left the flag set and the guard at the top
+    of `loadUsageReport` then refused every later load -- period buttons, server
+    switch and Retry alike -- until a page reload. Executed rather than asserted
+    against the source, because the bug is control flow, not a string.
+    """
+    block = _report_block(_source())
+    loader = _extract_js_function(block, "async function loadUsageReport(options = {}) {")
+    body = LOADER_HARNESS.replace("__LOADER__", loader)
+    out = json.loads(_run_node(tmp_path, "usage-report-loader.js", body))
+
+    assert out["afterNull"]["loading"] is False, "an empty 200 left the tab wedged"
+    assert out["afterNull"]["loaded"] is True
+    assert out["recovered"] is True, "the tab refused every load after the first failure"
+    assert out["loadingAtRest"] is False
+
+
+def test_a_report_served_from_a_stale_entry_reads_again_once() -> None:
+    """The morning's first visit is answered out of the 00:05 warm.
+
+    Past its TTL the server hands the cached value over instantly AND recomputes
+    it in the background, so the figures are hours old and nothing on the page
+    says so. The tab reads again once when it sees that status -- and must not
+    send refresh=1, which would start a second full recompute of the work the
+    daemon is already doing.
+    """
+    block = _report_block(_source())
+    schedule = _extract_js_function(
+        block, "function usageReportScheduleStaleReread(payloads, period, server) {"
+    )
+    reread = _extract_js_function(
+        block, "async function usageReportSilentReread(token, period, serverId) {"
+    )
+    loader = _extract_js_function(block, "async function loadUsageReport(options = {}) {")
+
+    # Any of the three, not just the fastest one.
+    assert "payloads.some(usageReportServedStale)" in schedule
+    assert "usageReportScheduleStaleReread([usage, insights, activeTime], period, server)" in loader
+
+    # The server is already recomputing these keys; forcing doubles the work.
+    assert "refresh=1" not in reread
+    assert "loadUsageReport" not in reread, (
+        "the silent path must not reuse the loader: that one owns `loading`, the "
+        "partial model and the blanking paint"
+    )
+
+    # A queued re-read describes the window an explicit load is replacing.
+    assert "clearTimeout(usageReportState.staleTimer)" in schedule
+    assert "clearTimeout(usageReportState.staleTimer)" in loader
+    assert "usageReportState.loadToken += 1" in loader
+
+    # Guarded on both sides of the round trip.
+    assert reread.count("usageReportStillWants(token, period, serverId)") == 2
+    # A failed re-read must leave the report on screen alone.
+    assert "return;" in reread.split("catch (_error) {")[1]
+
+
+def test_the_version_stamp_waits_for_the_full_paint() -> None:
+    """/api/version is fired first and answers instantly, so it can land between
+    the two paints. Stamping the partial model would render the footer and the
+    share cards off a half-empty report -- the one thing the partial paint is
+    careful not to do."""
+    block = _report_block(_source())
+    version = _extract_js_function(block, "function usageReportLoadVersion() {")
+    # The whole statement, not the condition and the ordering: asserting those two
+    # separately passes for `if (...notices.pending) { }`, which guards nothing.
+    assert "if (usageReportState.model.notices.pending) return;" in version
+    assert version.index("notices.pending") < version.index("usageReportRenderShare")
+
+
+def test_a_source_not_asked_for_yet_is_not_reported_as_unavailable() -> None:
+    """`pending` is the difference between "not here yet" and "refused".
+
+    Without it the first paint flashes "analytics unavailable" a moment before
+    the analytics land, which is a false claim about the server.
+    """
+    block = _report_block(_source())
+    banner = _extract_js_function(block, "function usageReportRenderBanner(model) {")
+    assert "const pending = !!model.notices.pending;" in banner
+    assert "model.notices.insightsMissing && !pending" in banner
+    assert "model.notices.activeTimeMissing && !pending" in banner
+    # Usage is the request the first paint is made of: by then it has either
+    # landed or failed, so its notice is never suppressed.
+    assert "model.notices.usageMissing && !pending" not in banner
+
+
+def test_the_report_paints_the_hero_before_asking_for_the_slow_two() -> None:
+    """The three requests contend for the server's GIL instead of overlapping.
+
+    Fired as one Promise.all, a 2s /api/usage became a 13s one and the paint
+    waited on the slowest of the set either way. Usage alone fills the hero, so
+    it is awaited and painted before the other two are issued.
+    """
+    block = _report_block(_source())
+    loader = _extract_js_function(block, "async function loadUsageReport(options = {}) {")
+    usage_at = loader.index("await settle(request('/api/usage'))")
+    paint_at = loader.index("usageReportRenderPartial(")
+    insights_at = loader.index("/api/insights?facets=")
+    active_at = loader.index("/api/active-time?include_review_sessions=true")
+    assert usage_at < paint_at < insights_at, "the hero must paint before the slow two start"
+    assert usage_at < paint_at < active_at
+    # The slow two still overlap each other -- sequencing them as well would add
+    # their times rather than trading a little wall clock for a much earlier paint.
+    assert loader.count("await Promise.all([") == 1
+
+
+def test_the_first_paint_renders_only_what_usage_answers() -> None:
+    """Anything else would print an em dash it has to take back a moment later.
+
+    The sections the other two requests feed keep the placeholder
+    usageReportRenderLoading() left on them, so the page fills in instead.
+    """
+    block = _report_block(_source())
+    partial = _extract_js_function(block, "function usageReportRenderPartial(model) {")
+    full = _extract_js_function(block, "function usageReportRender() {")
+    hero = _extract_js_function(block, "function usageReportRenderHero(model) {")
+    assert "usageReportRenderHeroTotals(model)" in partial
+    # The activity half is reached through the whole-hero wrapper, which only the
+    # full paint calls.
+    assert "usageReportRenderHeroActivity(model)" not in partial
+    assert "usageReportRenderHeroActivity(model)" in hero
+    assert "usageReportRenderHero(model)" in full
+    for absent in (
+        "usageReportRenderSentence",
+        "usageReportRenderHeat",
+        "usageReportRenderPodium",
+        "usageReportRenderWhen",
+        "usageReportRenderAgents",
+        "usageReportRenderFooter",
+        "usageReportRenderShare",  # would export a half-empty card
+    ):
+        assert absent not in partial, f"{absent} has no data on the first paint"
+        assert absent in full, f"{absent} must still run once everything has landed"
+    # Both paints take the window lines from one place, so the partial one cannot
+    # print a different range or title from the full one that replaces it.
+    assert "usageReportRenderHead(model)" in partial
+    assert "usageReportRenderHead(model)" in full
+
+
 def test_an_unknown_count_prints_a_dash_everywhere_it_is_read() -> None:
     """`model.sessions` and `model.streaks` are read in four places. A single
     formatNumber(null) among them puts "0 sessions" back on the page."""
     block = _report_block(_source())
-    hero = _extract_js_function(block, "function usageReportRenderHero(model) {")
+    # The activity half of the hero: split out so the first paint can render the
+    # totals half from /api/usage alone, without these two tiles.
+    hero = _extract_js_function(block, "function usageReportRenderHeroActivity(model) {")
     assert "empty || !model.streaks" in hero
     assert "String(model.streaks.active_days)" in hero, "the zero fallback is gone"
     sentence = _extract_js_function(block, "function usageReportRenderSentence(model) {")
@@ -562,8 +1005,13 @@ def test_report_asks_for_the_facets_the_new_sections_need() -> None:
     served = facets_line.split("'")[1].split(",")
     for facet in ("hourly", "weekday", "tools", "models", "projects"):
         assert facet in served, facet
-    # One request for all of them: the server folds every facet out of one scan.
-    assert block.count("/api/insights?facets=") == 1
+    # One request for all of them: the server folds every facet out of one scan, so
+    # asking twice costs the machine the scan again for nothing. Both callers -- the
+    # explicit load and the silent re-read -- must therefore ask for the WHOLE set.
+    # What must never appear is an insights request for a subset.
+    asked = re.findall(r"/api/insights\?facets=\$\{(\w+)\}", block)
+    assert asked, "no insights request found"
+    assert set(asked) == {"USAGE_REPORT_FACETS"}, asked
 
 
 def test_the_day_map_notice_names_only_the_facets_it_is_missing() -> None:
@@ -1171,12 +1619,22 @@ def test_a_control_changed_mid_flight_is_applied_late_not_dropped() -> None:
     block = _report_block(_source())
     loader = _extract_js_function(block, "async function loadUsageReport(options = {}) {")
     wire = _extract_js_function(block, "function usageReportWire() {")
-    assert loader.count("usageReportApplyPendingChoice()") == 2, "both exits of a load settle the queue"
+    # One exit, not two. The load used to return early on a total failure and had to
+    # remember to settle the queue on both paths; the try/finally collapsed them, so
+    # "every exit settles the queue" is now structurally true rather than duplicated.
+    assert loader.count("usageReportApplyPendingChoice()") == 1
+    assert loader.count("return;") == 1, "only the re-entrancy guard at the top may return early"
     assert "usageReportState.pendingPeriod = button.dataset.period" in wire
     assert "usageReportState.pendingServerId = select.value" in wire
     assert "select.value = usageReportState.serverId" in wire, "the box names the server actually on screen"
     applied = _extract_js_function(block, "function usageReportApplyPendingChoice() {")
-    assert "loadUsageReport({ refresh: true })" in applied
+    # A plain load, not a forced one. The queued choice is a period or server the
+    # reader has not seen yet, so it wants the cache like any other first load;
+    # forcing a recompute made clicking during a load the slowest path in the tab.
+    assert "loadUsageReport()" in applied
+    assert "loadUsageReport({ refresh: true })" not in applied, (
+        "a queued choice is a first read, not a refresh"
+    )
     assert "usageReportWritePrefs()" in applied, "a queued choice that lands is the stored choice"
 
 

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -3312,20 +3312,23 @@ def _add_mimo_external_import(db_path: Path, message_ids: list[str]) -> tuple[tu
     return ((str(db_path), stat.st_mtime_ns, stat.st_size),)
 
 
-def test_opencode_session_loaders_use_sql_window_and_match_raw_json_fallback(tmp_path):
+def test_opencode_session_loaders_read_every_row_and_match_the_raw_json_fallback(tmp_path):
+    """The loader takes no window, so the two backends must agree on the lot.
+
+    Windowing moved out of the cache key and into ``_summarize_session``, which is
+    where every store-backed tool has always applied it — the loader's result is
+    now determined by the database alone and reusable for any period.
+    """
     db_path = tmp_path / "opencode.db"
     signature = _create_opencode_session_db(db_path)
 
     sessions_module._load_opencode_sessions.cache_clear()
-    scalar = sessions_module._load_opencode_sessions(signature, (), 1000, 2000)
-    raw = sessions_module._load_opencode_sessions_raw_json(db_path, since_ms=1000, until_ms=2000)
-    all_rows = sessions_module._load_opencode_sessions_raw_json(db_path)
+    scalar = sessions_module._load_opencode_sessions(signature, ())
+    raw = sessions_module._load_opencode_sessions_raw_json(db_path)
 
     assert scalar == raw
     assert set(scalar) == {"s1", "s2"}
-    assert len(all_rows["s1"]["turns"]) == 4
-    assert len(scalar["s1"]["turns"]) == 2
-    assert [turn["timestamp_ms"] for turn in scalar["s1"]["turns"]] == [1000, 1500]
+    assert [turn["timestamp_ms"] for turn in scalar["s1"]["turns"]] == [900, 1000, 1500, 2000]
     turn = next(turn for turn in scalar["s1"]["turns"] if turn["timestamp_ms"] == 1500)
     assert scalar["s1"]["project"] == "tokdash"
     assert scalar["s1"]["display_name"] == "OpenCode title"
@@ -3338,6 +3341,20 @@ def test_opencode_session_loaders_use_sql_window_and_match_raw_json_fallback(tmp
     assert turn["tokens"] == 28
 
 
+def test_an_opencode_window_is_applied_where_the_session_is_summarized(tmp_path):
+    db_path = tmp_path / "opencode.db"
+    signature = _create_opencode_session_db(db_path)
+
+    sessions_module._load_opencode_sessions.cache_clear()
+    loaded = sessions_module._load_opencode_sessions(signature, ())
+
+    # Half-open [1000, 2000): the row at 900 and the one at 2000 are both out.
+    summary = sessions_module._summarize_session(loaded["s1"], 1000, 2000)
+    assert summary["token_events"] == 2
+    assert summary["started_at"] == sessions_module._ms_to_iso(1000)
+    assert summary["last_seen_at"] == sessions_module._ms_to_iso(1500)
+
+
 def test_opencode_loader_falls_back_to_raw_json_when_scalar_query_fails(monkeypatch, tmp_path):
     db_path = tmp_path / "opencode.db"
     signature = _create_opencode_session_db(db_path)
@@ -3348,28 +3365,32 @@ def test_opencode_loader_falls_back_to_raw_json_when_scalar_query_fails(monkeypa
     monkeypatch.setattr(sessions_module, "_load_opencode_sessions_scalar", fail_scalar)
     sessions_module._load_opencode_sessions.cache_clear()
 
-    result = sessions_module._load_opencode_sessions(signature, (), 1000, 2000)
+    result = sessions_module._load_opencode_sessions(signature, ())
 
     assert set(result) == {"s1", "s2"}
-    assert [turn["timestamp_ms"] for turn in result["s1"]["turns"]] == [1000, 1500]
+    assert [turn["timestamp_ms"] for turn in result["s1"]["turns"]] == [900, 1000, 1500, 2000]
     assert len(result["s2"]["turns"]) == 1
 
 
-def test_get_sessions_data_passes_period_window_to_opencode_loader(monkeypatch):
-    captured = {}
+def _windowless_loader(tool, calls):
+    """A loader that takes no window and returns one in-period turn and one older.
 
-    def fake_opencode_sessions(*, since_ms=None, until_ms=None):
-        captured["since_ms"] = since_ms
-        captured["until_ms"] = until_ms
+    Taking no arguments is half the assertion: a caller still passing a window
+    would raise here rather than quietly cache one period's rows under another's.
+    """
+    since_ms, _until_ms = sessions_module._window_bounds("today")
+
+    def load():
+        calls.append(tool)
         return {
             "s1": {
-                "tool": "opencode",
+                "tool": tool,
                 "session_id": "s1",
                 "project": "tokdash",
                 "turns": [
                     sessions_module._build_turn(
-                        turn_index=1,
-                        timestamp_ms=int(since_ms or 0),
+                        turn_index=index,
+                        timestamp_ms=stamp,
                         model="model",
                         tokens_in=1,
                         tokens_cache=0,
@@ -3377,54 +3398,41 @@ def test_get_sessions_data_passes_period_window_to_opencode_loader(monkeypatch):
                         tokens_reasoning=0,
                         bill=sessions_module._billing_record("model", "fresh-input"),
                     )
+                    for index, stamp in enumerate(
+                        (int(since_ms) - 90 * 24 * 60 * 60 * 1000, int(since_ms)), start=1
+                    )
                 ],
             }
         }
 
-    monkeypatch.setattr(sessions_module, "_opencode_sessions", fake_opencode_sessions)
+    return load
+
+
+def test_get_sessions_data_windows_the_opencode_loaders_whole_database(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(
+        sessions_module, "_opencode_sessions", _windowless_loader("opencode", calls)
+    )
 
     result = sessions_module.get_sessions_data("opencode", "today")
 
-    assert captured["since_ms"] is not None
-    assert captured["until_ms"] is not None
-    assert captured["since_ms"] < captured["until_ms"]
+    assert calls == ["opencode"]
     assert result["summary"]["session_count"] == 1
+    # Two turns loaded, one inside today: the period is applied on the way out.
+    assert result["sessions"][0]["token_events"] == 1
 
 
-def test_get_sessions_data_passes_period_window_to_mimo_loader(monkeypatch):
-    captured = {}
-
-    def fake_mimo_sessions(*, since_ms=None, until_ms=None):
-        captured["since_ms"] = since_ms
-        captured["until_ms"] = until_ms
-        return {
-            "s1": {
-                "tool": "mimo",
-                "session_id": "s1",
-                "project": "tokdash",
-                "turns": [
-                    sessions_module._build_turn(
-                        turn_index=1,
-                        timestamp_ms=int(since_ms or 0),
-                        model="model",
-                        tokens_in=1,
-                        tokens_cache=0,
-                        tokens_out=1,
-                        tokens_reasoning=0,
-                        bill=sessions_module._billing_record("model", "fresh-input"),
-                    )
-                ],
-            }
-        }
-
-    monkeypatch.setattr(sessions_module, "_mimo_sessions", fake_mimo_sessions)
+def test_get_sessions_data_windows_the_mimo_loaders_whole_database(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(
+        sessions_module, "_mimo_sessions", _windowless_loader("mimo", calls)
+    )
 
     result = sessions_module.get_sessions_data("mimo", "today")
 
-    assert captured["since_ms"] is not None
-    assert captured["until_ms"] is not None
-    assert captured["since_ms"] < captured["until_ms"]
+    assert calls == ["mimo"]
     assert result["summary"]["session_count"] == 1
+    assert result["sessions"][0]["token_events"] == 1
 
 
 def test_opencode_signatures_include_wal_and_shm(monkeypatch, tmp_path):
@@ -3473,20 +3481,21 @@ def test_mimo_signatures_include_wal_and_shm(monkeypatch, tmp_path):
     }
 
 
-def test_mimo_session_loader_uses_sql_window_and_project_worktree(tmp_path):
+def test_mimo_session_loader_reads_every_row_and_the_project_worktree(tmp_path):
     db_path = tmp_path / "mimocode.db"
     signature = _create_opencode_session_db(db_path)
 
     sessions_module._load_mimo_sessions.cache_clear()
-    result = sessions_module._load_mimo_sessions(signature, (), 1000, 2000)
+    result = sessions_module._load_mimo_sessions(signature, ())
 
     assert set(result) == {"s1", "s2"}
-    assert len(result["s1"]["turns"]) == 2
-    assert [turn["timestamp_ms"] for turn in result["s1"]["turns"]] == [1000, 1500]
+    assert [turn["timestamp_ms"] for turn in result["s1"]["turns"]] == [900, 1000, 1500, 2000]
     assert result["s1"]["project"] == "tokdash"
     assert result["s1"]["display_name"] == "OpenCode title"
     assert result["s2"]["project"] == "other"
     assert result["s2"]["display_name"] == "other-slug"
+    # The window is the summary's job now, and it still bounds both ends.
+    assert sessions_module._summarize_session(result["s1"], 1000, 2000)["token_events"] == 2
 
 
 def test_mimo_session_loaders_exclude_external_import_messages(tmp_path):
@@ -3495,13 +3504,13 @@ def test_mimo_session_loaders_exclude_external_import_messages(tmp_path):
     signature = _add_mimo_external_import(db_path, ["at_since", "inside"])
 
     sessions_module._load_mimo_sessions.cache_clear()
-    result = sessions_module._load_mimo_sessions(signature, (), 1000, 2000)
-    raw = sessions_module._load_mimo_sessions_raw_json(db_path, since_ms=1000, until_ms=2000)
+    result = sessions_module._load_mimo_sessions(signature, ())
+    raw = sessions_module._load_mimo_sessions_raw_json(db_path)
 
     assert result == raw
-    assert set(result) == {"s2"}
+    # The two imported messages are gone from s1; the rows Mimo owns remain.
+    assert [turn["timestamp_ms"] for turn in result["s1"]["turns"]] == [900, 2000]
     assert [turn["timestamp_ms"] for turn in result["s2"]["turns"]] == [1500]
-    assert len(result["s2"]["turns"]) == 1
 
 
 def test_mimo_parser_collect_uses_sql_window(monkeypatch, tmp_path):


### PR DESCRIPTION
The Report tab's three requests re-did the same work on every read. Session assembly — deserializing a session's per-file rows and merging them — ran in full every time, because nothing above it was keyed on content.

## What changed

**One merge, not nine.** Nine live loaders folded their per-session raws pairwise, rebuilding the whole accumulated session on every file: O(K²) in the number of files a session spans, which is what subagent fan-out produces. They now group per session id and merge once through `_merge_raw_session_sequence`, the one-pass fold the store path already used. Claude and Codex reach that fold through the store, but **pi_agent, omp, kilocode and workbuddy are never store-backed**, so the quadratic was live for them, waiting on a session large enough to show it.

**A per-session assembly cache, shared by both paths.** Keyed on `(tool, session_id)`, with a token built from the set of files behind the session plus the pricing signature. The key carries no dates, so week, month and year share one merged object instead of assembling three; a window-keyed memo could not, since the windows a reader opens end today and are already absorbed by the route cache TTL. Being set-shaped, the token catches a file leaving as surely as one changing. A new `query_session_signatures` reads the cheap columns, so a read learns which sessions changed before deciding what to deserialize.

**Window out of the cache keys.** opencode, mimo and kilocode carried the window in their key, where three periods took three of eight entries and a rate edit took all of them. They load unwindowed now and `_summarize_session` clips, as it has always done for store-backed tools. zcode and qoder keep theirs — they precompute activity intervals from the window, so they are genuinely window-dependent rather than merely clipped.

**Two correctness prerequisites.** `_drop_codex_subagent_replay_turns` no longer trims in place — cached sessions are shared by reference, and trimming one would strip turns from every later read of a different window. And kilocode's token covers each database's `-wal`/`-shm` siblings: a SQLite write can land in the WAL and leave the main file's mtime and size untouched, so a token built from the main file alone would call a changed database unchanged.

## Measurements

v2.5.3 vs this branch, real 986 MB database, all three Report requests, min of three reps with the arms alternating and a fresh DB copy per measurement. Windows end *yesterday*, so neither arm answered a moving question.

| year window | v2.5.3 | this branch | |
|---|---|---|---|
| `/api/active-time`, warm process | 10.50s | 2.28s | −78% |
| all three requests, warm process | 14.92s | 7.07s | −53% |
| all three requests, cold process | 19.65s | 17.89s | −9% |

The cold-process gain is small because the cache starts empty; the tab's own windows are warmed at startup. Payloads are byte-identical between arms apart from the `response_cache` metadata block this branch adds.

Attribution, same build with the cache toggled: `/api/active-time` warm 8.78s → 1.60s, while `/api/insights` is 2.72s either way — the win is where it was aimed.

Peak RSS is unchanged (1291 MB → 1289 MB): holding merged sessions costs less than decoding every row at once. Retained memory does grow — the year run holds 2,417 sessions / 379,934 turns. `TOKDASH_SESSION_CACHE_TURNS` bounds it (default 500,000 turns; `0` disables the cache).

## Tests

2159 passed, 6 skipped. New: 11 tests for the assembly cache (including a 90-window sweep asserting the Python window filter agrees with the SQL one it replaced, and a parity test that the cached read matches the uncached one), a WAL-only-write regression test for kilocode, and ten pinning `_turn_identity_key` call counts so a return to the pairwise fold fails.
