### PR TITLE
fix(pricing): claude-3.5-sonnet is 2x published price ($6/$30 vs $3/$15)

### DIFF
--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - OpenCode, MiMo and Kilo Code no longer key their session cache on the requested window, where three periods took three of the eight slots and a single pricing edit took all of them. They read unwindowed and the window is applied where every other tool applies it. (#74)
 - `TOKDASH_SESSION_CACHE_TURNS` bounds what the new session cache retains, in turns rather than sessions, since one long-running session can outweigh a thousand short ones. The default is 500,000 turns; `0` disables the cache. (#74)
 
+### Fixed
+
+- `claude-3.5-sonnet` prices at $3 / $15 per MTok with cache reads at $0.30 and cache writes at $3.75, the published Anthropic rate, instead of double it. `claude-3-5-sonnet-20241022` and `-20240620` both normalize to that entry, so every 3.5 Sonnet session, Claude Code's default model from Oct 2024 to early Feb 2025, showed twice its real cost in Overview, Stats and Sessions. The bundled database is 2.0.24; stored rows reprice on read through the pricing content signature. (#75, thanks @roy-tong)
+
 ## 2.5.3 - 2026-09-05
 
 ### Added

--- a/src/tokdash/pricing_db.json
+++ b/src/tokdash/pricing_db.json
@@ -1216,10 +1216,10 @@
     },
     "claude-3.5-sonnet": {
       "provider": "anthropic",
-      "input": 6,
-      "output": 30,
-      "cache_read": 0.6,
-      "cache_write": 7.5,
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3,
+      "cache_write": 3.75,
       "unit": "per_million_tokens",
       "source": "openrouter.ai/anthropic/claude-3.5-sonnet"
     },

--- a/src/tokdash/pricing_db.json
+++ b/src/tokdash/pricing_db.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.0.23",
-  "lastUpdated": "2026-09-05T00:00:00Z",
+  "version": "2.0.24",
+  "lastUpdated": "2026-09-07T11:04:33Z",
   "note": "Comprehensive pricing database with all Moonshot, MiniMax, GLM, and OpenAI models from OpenRouter. Cache pricing estimated at 10% of input for cache_read, 100% of input for cache_write.",
   "aliases": {
     "Qwen/Qwen3.8-Flash-Next": "qwen3.8-flash",


### PR DESCRIPTION
**Version / commit:** main @ 8191e59 (src/tokdash/pricing_db.json line 1217)

**What happened**

The packaged pricing database prices claude-3.5-sonnet at input $6 / output $30
(cache_read $0.6 / cache_write $7.5) per million tokens, citing
openrouter.ai/anthropic/claude-3.5-sonnet as the source. Both Anthropic's
official pricing and that OpenRouter page list $3 / $15 (cache 0.3 / 3.75).
Even Bedrock's higher regional price is only $3.6/$18, so $6/$30 doesn't match
any listing — it looks like a scrape artifact from the 2026-09-03 model scan
(#67).

Neighboring entries (claude-3.7-sonnet, claude-sonnet-4, both $3/$15) are
correct, which makes this the odd one out.

**Reproduction (against the packaged module, commit 8191e59):**

```python
from tokdash.pricing import PricingDatabase
db = PricingDatabase()
db.get_cost("claude-3-5-sonnet-20241022", 1_000_000, 1_000_000, 0, 0)
# -> 36.0   (expected 18.0)
db.get_cost("claude-3-7-sonnet-20250219", 1_000_000, 1_000_000, 0, 0)
# -> 18.0   (correct neighbor for comparison)
```

Both claude-3-5-sonnet-20241022 and -20240620 normalize to this entry
(model_normalization.py maps "claude-3-5-sonnet" -> "claude-3.5-sonnet"), so
every 3.5 Sonnet session — the default Claude Code model from Oct 2024 to early
Feb 2025 — shows double its real cost in Sessions/Overview/Stats.

**Expected behavior**

input 3, output 15, cache_read 0.3, cache_write 3.75.

**Minimal fix**

Four numbers in pricing_db.json:

```diff
     "claude-3.5-sonnet": {
       "provider": "anthropic",
-      "input": 6,
-      "output": 30,
-      "cache_read": 0.6,
-      "cache_write": 7.5,
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3,
+      "cache_write": 3.75,
       "unit": "per_million_tokens",
       "source": "openrouter.ai/anthropic/claude-3.5-sonnet"
```

Verified locally: with the change, 1M in + 1M out prices at $18.00 and
1M cache_read + 1M cache_write at $4.05; no test asserts the old values.
Since the pricing content identity changes, the usage cache should reprice
stored rows automatically via the existing content_signature mechanism.
```