### PR TITLE
Bill Claude turns on the completed usage snapshot

### DIFF
--- a/src/tokdash/sessions.py
+++ b/src/tokdash/sessions.py
@@ -37,6 +37,7 @@ from .sources.coding_tools import (
     WorkBuddyParser,
     ZCodeSnapshotError,
     antigravity_db_signatures,
+    claude_usage_supersedes,
     cline_message_file_signatures,
     codex_fork_ancestry,
     codex_replay_key_session_id,
@@ -100,7 +101,10 @@ _SESSION_FILE_PARSER_VERSIONS = {
     #    replay dedup; stored v1 keys/rows predate both.
     "_parse_codex_session_file": 2,
     # 2: turns carry _stream_id so subagents are timed separately from the main agent.
-    "_parse_claude_session_file": 2,
+    # 3: streaming snapshots collapse per claude_usage_supersedes rather than
+    #    keeping the first write, for role-bearing rows too; stored v2 turns
+    #    kept the partial, and its cache split.
+    "_parse_claude_session_file": 3,
     # 2: turns carry _stream_id so concurrent agents are timed separately.
     "_parse_kimi_session_file": 2,
     "_parse_dsh_session_file": 1,
@@ -1941,8 +1945,12 @@ def _parse_claude_session_file(path_str: str, _mtime_ns: int, _size: int, _prici
     ai_title = ""
     agent_name = ""
     turns = []
-    seen_message_ids = set()
-    snapshot_turns_by_message_id: Dict[str, Dict[str, Any]] = {}
+    # One assistant turn is rewritten once per streamed content block, every
+    # write sharing the message id and carrying cumulative usage. Which write is
+    # authoritative is claude_usage_supersedes' call, shared with
+    # ClaudeParser._parse_all so the two cannot disagree; `message.role` says
+    # nothing about whether more writes follow.
+    best_turns_by_message_id: dict[str, tuple[int, tuple[int, int, int, int], Dict[str, Any]]] = {}
 
     try:
         handle = session_path.open("r", encoding="utf-8")
@@ -1999,10 +2007,15 @@ def _parse_claude_session_file(path_str: str, _mtime_ns: int, _size: int, _prici
             if total_tokens == 0:
                 continue
 
-            # Legacy role-bearing logs repeat the same message id; skip the
-            # duplicates before pricing the turn.
-            if message_id and not is_top_level_assistant and message_id in seen_message_ids:
-                continue
+            # A write that cannot supersede this id's best is not worth pricing,
+            # so bail before building the turn.
+            buckets = (fresh_input, output_tokens, cache_read, cache_write)
+            if message_id:
+                best = best_turns_by_message_id.get(message_id)
+                if best is not None and not claude_usage_supersedes(
+                    total_tokens, buckets, best[0], best[1]
+                ):
+                    continue
 
             turn = _build_turn(
                 turn_index=0,
@@ -2030,23 +2043,9 @@ def _parse_claude_session_file(path_str: str, _mtime_ns: int, _size: int, _prici
                 turns.append(turn)
                 continue
 
-            if is_top_level_assistant:
-                # Newer Claude Code builds log assistant turns as role-less
-                # streaming snapshots sharing one id; keep the latest snapshot.
-                existing = snapshot_turns_by_message_id.get(message_id)
-                if existing is None or timestamp_ms >= int(existing.get("timestamp_ms", 0) or 0):
-                    snapshot_turns_by_message_id[message_id] = turn
-                continue
+            best_turns_by_message_id[message_id] = (total_tokens, buckets, turn)
 
-            # First non-zero occurrence of this legacy id.
-            seen_message_ids.add(message_id)
-            turns.append(turn)
-
-    turns.extend(
-        turn
-        for message_id, turn in snapshot_turns_by_message_id.items()
-        if message_id not in seen_message_ids
-    )
+    turns.extend(turn for _, _, turn in best_turns_by_message_id.values())
     turns.sort(key=lambda item: int(item.get("timestamp_ms", 0) or 0))
     for turn_index, turn in enumerate(turns, start=1):
         turn["turn_index"] = turn_index

--- a/src/tokdash/sources/coding_tools.py
+++ b/src/tokdash/sources/coding_tools.py
@@ -1265,6 +1265,39 @@ class CodexParser(BaseParser):
         return out
 
 
+ClaudeUsageBuckets = Tuple[int, int, int, int]  # (input, output, cache_read, cache_write)
+
+
+def claude_usage_supersedes(
+    total: int,
+    buckets: ClaudeUsageBuckets,
+    best_total: int,
+    best_buckets: ClaudeUsageBuckets,
+) -> bool:
+    """Does this streamed usage write replace the best one kept for its id?
+
+    Claude Code rewrites one assistant turn once per streamed content block,
+    every write sharing the message id, and streamed usage counts are
+    cumulative -- so a larger total is a later, more complete write.
+
+    An equal total with a *different* split is a reclassification: the server
+    resolved the prompt against its cache and moved fresh input into cache-read
+    or cache-write. The later split is the accurate one, and keeping the earlier
+    one would price cached tokens at the fresh-input rate.
+
+    An equal total with an identical split is a genuine duplicate write, so the
+    first wins and a double-written turn keeps its earlier timestamp rather than
+    migrating into a later reporting window.
+
+    Shared by ClaudeParser._parse_all and sessions._parse_claude_session_file:
+    the two must agree on which write is authoritative, and a bug that lost ~20%
+    of all output tokens came from those sites disagreeing.
+    """
+    if total != best_total:
+        return total > best_total
+    return buckets != best_buckets
+
+
 class ClaudeParser(BaseParser):
     source_name = "claude"
     sync_capability = SourceSyncCapability(
@@ -1274,7 +1307,13 @@ class ClaudeParser(BaseParser):
     )
     # 1: assistant usage rows keyed on message id, streaming snapshots
     #    collapsed to the latest, cache writes billed at the input rate.
-    persistent_parser_version = 1
+    # 2: snapshots collapse per claude_usage_supersedes -- fullest total wins,
+    #    an equal total with a changed split takes the later split -- for
+    #    role-bearing rows too. v1 kept the first non-zero write of a
+    #    role-bearing id, which on endpoints that stamp both `type` and
+    #    `message.role` was the partial that carries the whole prompt and no
+    #    output yet -- dropping ~20% of all output tokens.
+    persistent_parser_version = 2
 
     def __init__(self, pricing_db: PricingDatabase):
         super().__init__(pricing_db)
@@ -1304,8 +1343,16 @@ class ClaudeParser(BaseParser):
 
     def _parse_all(self) -> List[Dict[str, Any]]:
         out: List[Dict[str, Any]] = []
-        seen_message_ids = set()
-        snapshot_entries_by_message_id: Dict[str, Dict[str, Any]] = {}
+        # Claude Code rewrites one assistant turn once per streamed content
+        # block, every write sharing the message id, and streamed usage counts
+        # are cumulative -- so the write with the largest total is the finished
+        # turn. Keep that one per id. The first write is usually a partial that
+        # already carries the whole prompt but no output yet, and it is not
+        # distinguishable by shape: whether the row also carries `message.role`
+        # says nothing about whether more writes follow.
+        #
+        # See claude_usage_supersedes for the tie rules.
+        best_by_message_id: Dict[str, Tuple[int, ClaudeUsageBuckets, Dict[str, Any]]] = {}
 
         for path_str, _, _ in self._file_signatures():
             session_file = Path(path_str)
@@ -1336,14 +1383,20 @@ class ClaudeParser(BaseParser):
                     output_t = self._i(usage.get("output_tokens", usage.get("output")))
                     cache_r = self._i(usage.get("cache_read_input_tokens", usage.get("cache_read_tokens")))
                     cache_w = self._i(usage.get("cache_creation_input_tokens", usage.get("cache_write_tokens")))
-                    if input_t + output_t + cache_r + cache_w == 0:
+                    buckets: ClaudeUsageBuckets = (input_t, output_t, cache_r, cache_w)
+                    total_t = sum(buckets)
+                    if total_t == 0:
                         continue
 
                     msg_id = str(msg.get("id") or obj.get("uuid") or "")
-                    # Legacy role-bearing logs write the same message id many
-                    # times; skip the duplicates before building/pricing the entry.
-                    if msg_id and not is_top_level_assistant and msg_id in seen_message_ids:
-                        continue
+                    # A write that cannot supersede this id's best is not worth
+                    # pricing, so bail before building the entry.
+                    if msg_id:
+                        best = best_by_message_id.get(msg_id)
+                        if best is not None and not claude_usage_supersedes(
+                            total_t, buckets, best[0], best[1]
+                        ):
+                            continue
 
                     model = str(msg.get("model") or "unknown")
                     entry = {
@@ -1370,27 +1423,11 @@ class ClaudeParser(BaseParser):
                         out.append(entry)
                         continue
 
-                    if is_top_level_assistant:
-                        # Newer Claude Code builds (so far seen via OpenAI-compatible
-                        # endpoints) log assistant turns as role-less streaming
-                        # snapshots sharing one id; keep the latest, which carries
-                        # the most complete usage.
-                        existing = snapshot_entries_by_message_id.get(msg_id)
-                        if existing is None or entry["timestamp"] >= existing["timestamp"]:
-                            snapshot_entries_by_message_id[msg_id] = entry
-                        continue
-
-                    # First non-zero occurrence of this legacy id.
-                    seen_message_ids.add(msg_id)
-                    out.append(entry)
+                    best_by_message_id[msg_id] = (total_t, buckets, entry)
             except Exception:
                 continue
 
-        out.extend(
-            entry
-            for msg_id, entry in snapshot_entries_by_message_id.items()
-            if msg_id not in seen_message_ids
-        )
+        out.extend(entry for _, _, entry in best_by_message_id.values())
         out.sort(key=lambda entry: int(entry.get("timestamp", 0) or 0))
         return out
 

--- a/tests/test_claude_multi_dir.py
+++ b/tests/test_claude_multi_dir.py
@@ -110,7 +110,12 @@ def test_claude_session_drilldown_keeps_real_entry_when_zero_token_placeholder_s
     assert raw["sess-mi"]["turns"][0]["tokens_in"] == 42
 
 
-def test_legacy_claude_records_keep_first_nonzero_snapshot(monkeypatch, tmp_path):
+def test_legacy_claude_records_keep_fullest_snapshot(monkeypatch, tmp_path):
+    """Role-bearing rows are streaming snapshots too, so the fullest wins.
+
+    Streamed usage is cumulative, so the last write of a message id is the
+    finished turn. Keeping the first write instead billed the partial.
+    """
     session_dir = tmp_path / ".claude" / "projects" / "project"
     session_dir.mkdir(parents=True)
     session_file = session_dir / "sess-legacy.jsonl"
@@ -135,9 +140,158 @@ def test_legacy_claude_records_keep_first_nonzero_snapshot(monkeypatch, tmp_path
     raw = sessions._claude_sessions()
 
     assert len(entries) == 1
-    assert entries[0]["output"] == 5
+    assert entries[0]["output"] == 9
     assert len(raw["sess-legacy"]["turns"]) == 1
-    assert raw["sess-legacy"]["turns"][0]["tokens_out"] == 5
+    assert raw["sess-legacy"]["turns"][0]["tokens_out"] == 9
+
+
+def test_claude_records_with_both_type_and_role_keep_completed_usage(monkeypatch, tmp_path):
+    """The shape that lost ~98% of one endpoint's output tokens.
+
+    An Anthropic-compatible endpoint stamps BOTH top-level ``type`` and
+    ``message.role``, so the role-less snapshot branch never fired and the
+    zero-output first content block won on the strength of its input tokens.
+    """
+    session_dir = tmp_path / ".claude-open" / "projects" / "project"
+    session_dir.mkdir(parents=True)
+
+    def _block(output_tokens: int, timestamp: str, cache_read: int = 0) -> str:
+        return (
+            '{"type":"assistant","sessionId":"sess-both","cwd":"/work/project",'
+            f'"timestamp":"{timestamp}",'
+            '"message":{"role":"assistant","id":"chatcmpl-both",'
+            '"model":"qwen3.8-flash-next",'
+            f'"usage":{{"input_tokens":14475,"cache_read_input_tokens":{cache_read},'
+            f'"output_tokens":{output_tokens}}}}}}}\n'
+        )
+
+    (session_dir / "sess-both.jsonl").write_text(
+        _block(0, "2026-09-08T01:59:29Z") + _block(111, "2026-09-08T01:59:33Z"),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _sig_cache.clear()
+    BaseParser._entry_cache.clear()
+    sessions._parse_claude_session_file.cache_clear()
+    sessions._load_claude_sessions.cache_clear()
+
+    entries = ClaudeParser(PricingDatabase()).collect(None, None)
+    raw = sessions._claude_sessions()
+
+    assert len(entries) == 1
+    assert entries[0]["input"] == 14475
+    assert entries[0]["output"] == 111
+    assert len(raw["sess-both"]["turns"]) == 1
+    assert raw["sess-both"]["turns"][0]["tokens_out"] == 111
+
+
+def _write_claude_reclassified_session(root: Path, roleless: bool) -> None:
+    """A turn whose completed write moves fresh input into cache-read.
+
+    The total is identical across both writes -- 10,000 fresh becomes 1,000
+    fresh plus 9,000 cache-read -- so only the split distinguishes them.
+    """
+    session_dir = root / "projects" / "project"
+    session_dir.mkdir(parents=True)
+
+    def _block(fresh: int, cache_read: int, timestamp: str) -> str:
+        role = "" if roleless else '"role":"assistant",'
+        type_field = '"type":"assistant",' if roleless else ""
+        return (
+            "{"
+            f"{type_field}"
+            '"sessionId":"sess-recl","cwd":"/work/project",'
+            f'"timestamp":"{timestamp}",'
+            "\"message\":{"
+            f"{role}"
+            '"id":"msg-recl","model":"claude-sonnet-5",'
+            f'"usage":{{"input_tokens":{fresh},'
+            f'"cache_read_input_tokens":{cache_read},"output_tokens":10}}'
+            "}}\n"
+        )
+
+    (session_dir / "sess-recl.jsonl").write_text(
+        _block(10000, 0, "2026-06-12T12:00:00Z") + _block(1000, 9000, "2026-06-12T12:00:01Z"),
+        encoding="utf-8",
+    )
+
+
+def test_claude_parser_equal_total_reclassification_keeps_the_later_split(monkeypatch, tmp_path):
+    """An equal total with a changed split is a cache reclassification.
+
+    Selecting on total alone would tie and keep the first write, pricing 9,000
+    cached tokens at the fresh-input rate.
+    """
+    _write_claude_reclassified_session(tmp_path / ".claude-open", roleless=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _sig_cache.clear()
+    BaseParser._entry_cache.clear()
+
+    entries = ClaudeParser(PricingDatabase()).collect(None, None)
+
+    assert len(entries) == 1
+    assert entries[0]["input"] == 1000
+    assert entries[0]["cacheRead"] == 9000
+
+
+def test_claude_session_drilldown_equal_total_reclassification_keeps_the_later_split(
+    monkeypatch, tmp_path
+):
+    _write_claude_reclassified_session(tmp_path / ".claude-open", roleless=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    sessions._parse_claude_session_file.cache_clear()
+    sessions._load_claude_sessions.cache_clear()
+
+    raw = sessions._claude_sessions()
+
+    assert len(raw["sess-recl"]["turns"]) == 1
+    assert raw["sess-recl"]["turns"][0]["tokens_in"] == 1000
+    assert raw["sess-recl"]["turns"][0]["tokens_cache"] == 9000
+
+
+def test_claude_role_bearing_equal_total_reclassification_keeps_the_later_split(
+    monkeypatch, tmp_path
+):
+    """The same rule applies to rows that carry ``message.role``."""
+    _write_claude_reclassified_session(tmp_path / ".claude", roleless=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _sig_cache.clear()
+    BaseParser._entry_cache.clear()
+    sessions._parse_claude_session_file.cache_clear()
+    sessions._load_claude_sessions.cache_clear()
+
+    entries = ClaudeParser(PricingDatabase()).collect(None, None)
+    raw = sessions._claude_sessions()
+
+    assert len(entries) == 1
+    assert entries[0]["input"] == 1000
+    assert entries[0]["cacheRead"] == 9000
+    assert raw["sess-recl"]["turns"][0]["tokens_in"] == 1000
+    assert raw["sess-recl"]["turns"][0]["tokens_cache"] == 9000
+
+
+def test_claude_identical_duplicate_writes_keep_the_earlier_timestamp(monkeypatch, tmp_path):
+    """Ties keep the first write, so a real double-write does not move later."""
+    session_dir = tmp_path / ".claude" / "projects" / "project"
+    session_dir.mkdir(parents=True)
+    row = (
+        '{{"sessionId":"sess-dup","cwd":"/work/project","timestamp":"{ts}",'
+        '"message":{{"role":"assistant","id":"msg-dup","model":"claude-sonnet-4.5",'
+        '"usage":{{"input_tokens":42,"output_tokens":9}}}}}}\n'
+    )
+    (session_dir / "sess-dup.jsonl").write_text(
+        row.format(ts="2026-06-12T23:59:59Z") + row.format(ts="2026-06-13T00:00:02Z"),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _sig_cache.clear()
+    BaseParser._entry_cache.clear()
+
+    entries = ClaudeParser(PricingDatabase()).collect(None, None)
+
+    assert len(entries) == 1
+    assert entries[0]["output"] == 9
+    assert entries[0]["timestamp"] == 1781308799000  # 2026-06-12T23:59:59Z
 
 
 def _write_claude_open_streaming_session(root: Path) -> None:
@@ -168,7 +322,7 @@ def _write_claude_open_streaming_session(root: Path) -> None:
     )
 
 
-def test_claude_parser_reads_top_level_assistant_and_keeps_latest_snapshot(monkeypatch, tmp_path):
+def test_claude_parser_reads_top_level_assistant_and_keeps_fullest_snapshot(monkeypatch, tmp_path):
     _write_claude_open_streaming_session(tmp_path / ".claude-open")
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     _sig_cache.clear()
@@ -181,7 +335,7 @@ def test_claude_parser_reads_top_level_assistant_and_keeps_latest_snapshot(monke
     assert entries[0]["output"] == 9
 
 
-def test_claude_session_drilldown_reads_top_level_assistant_and_keeps_latest_snapshot(
+def test_claude_session_drilldown_reads_top_level_assistant_and_keeps_fullest_snapshot(
     monkeypatch, tmp_path
 ):
     _write_claude_open_streaming_session(tmp_path / ".claude-open")


### PR DESCRIPTION
## The bug

Claude Code rewrites one assistant turn once per streamed content block, every write sharing a single `message.id` and carrying cumulative usage. Only the last write is complete; the earlier ones already carry the whole prompt but little or no output yet.

Both Claude parse sites collapsed those writes to one row, but the branch that kept the fullest was gated on `message.role` being **absent**:

```python
is_top_level_assistant = role is None and obj.get("type") == "assistant"
```

Rows that carry both a top-level `type` and a `message.role` — what Anthropic-compatible endpoints in front of a local server emit — fail that gate and fall through to the legacy branch, which keeps the **first** non-zero write of an id. The partial passes the non-zero check on its input tokens alone, so the turn bills with `output_tokens: 0` and the completed write is discarded:

```
apiBlockIndex 0  usage: {"input_tokens":14475,"output_tokens":0}      <- billed
apiBlockIndex 1  usage: {"input_tokens":14475,"output_tokens":111}    <- dropped
```

The natural control is in the same corpus: `Qwen/Qwen3.6-27B-FP8` logs role-*less* snapshots, hits the fullest branch, and loses nothing.

## Impact

Measured over a 7.6 GB corpus of 187k message ids — **32.4M output tokens recovered, 20% of all output.** Not specific to third-party endpoints:

| Model | output before | after |
|---|---|---|
| `claude-sonnet-5` | 362,954 | 3,590,317 (90% was missing) |
| `claude-haiku-4-5` | 464,609 | 1,971,495 (76%) |
| `claude-opus-4-8` | 46,324,007 | 58,486,474 |
| `claude-opus-5` | 40,206,238 | 48,932,043 |
| **total** | **125,559,848** | **157,921,756** |

Cost was under-reported by about 2.6%. A turn's input attribution is also corrected where the endpoint reports caching: `Qwen/Qwen3.8-27B-FP8` input drops 7,489,757 → 1,206,557 as the partial's cold-input claim gives way to the completed write's cache split.

## The fix

`message.role` says nothing about whether more writes follow, so both shapes now share one rule. Selection moved into `claude_usage_supersedes()`, shared by both parse sites rather than written twice — two sites disagreeing about which write is authoritative is what produced this bug.

- Larger total wins.
- **Equal total with a different split** is a cache reclassification (10,000 fresh input becoming 1,000 fresh + 9,000 cache-read at the same total) and takes the later split; keeping the earlier one prices cached tokens at the fresh-input rate.
- **Equal total with an identical split** keeps the first write, so a genuine duplicate neither double-counts nor migrates into a later reporting window.

Keeping the fullest record whole means a turn stamps at its completion rather than its first block. Of those 187k ids, 82 cross an hour boundary and 5 cross a day, so no reporting window moves materially, and it avoids splicing a timestamp onto another write's usage.

The comparison runs before the entry is built, so a superseded write is never priced. Parse time over the same corpus is unchanged at ~24s; the pass is I/O bound.

Both persistent versions move, or stored rows keep their old totals: `ClaudeParser.persistent_parser_version` 1 → 2, and the separate `_SESSION_FILE_PARSER_VERSIONS["_parse_claude_session_file"]` 2 → 3.

## Tests

`2170 passed, 6 skipped`.

Rewrote `test_legacy_claude_records_keep_first_nonzero_snapshot`, which pinned the old rule, and renamed the two `keeps_latest_snapshot` tests to `keeps_fullest_snapshot` to match. Added coverage for the `type`+`role` shape and, in both parsers, for equal-total reclassification and for an identical duplicate write straddling midnight keeping the earlier timestamp. Each new test was checked against the pre-fix source to confirm it fails there.

No changelog entry here — per `RELEASING.md`, entries are written at release time from the merged PR list.