### PR TITLE
Serve `/static/**` when tokdash is installed with symlinked static assets

### DIFF
--- a/src/tokdash/api.py
+++ b/src/tokdash/api.py
@@ -618,7 +618,11 @@ async def _lifespan(_app: "FastAPI"):
 
 
 app = FastAPI(title="Tokdash", lifespan=_lifespan)
-app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+# follow_symlink=True: pipx/uv installs the packaged static assets as symlinks into
+# the uv cache. Starlette defaults to follow_symlink=False, where lookup_path()
+# realpath-resolves each request out of STATIC_DIR, fails the commonpath guard, and
+# 404s every /static/** asset. Traversal ("..") is still rejected via abspath.
+app.mount("/static", StaticFiles(directory=str(STATIC_DIR), follow_symlink=True), name="static")
 app.add_middleware(NoCacheMiddleware)
 
 

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -241,6 +241,50 @@ def test_api_endpoints_and_dashboard_smoke(synthetic_api_data):
     assert "no-store" in _static_middleware_cache_control("/static/icons/icon-192.png")
 
 
+def _static_mount():
+    return next(route for route in api.app.routes if getattr(route, "name", None) == "static")
+
+
+def test_static_mount_follows_symlinks():
+    """pipx/uv installs the packaged assets as symlinks into the uv cache.
+
+    With Starlette's default follow_symlink=False, lookup_path() realpath-resolves
+    each request out of STATIC_DIR, fails the commonpath guard, and 404s every
+    /static/** asset. Pin the mount option so it cannot silently regress.
+    """
+    assert _static_mount().app.follow_symlink is True
+
+
+@pytest.mark.skipif(os.name == "nt", reason="creating symlinks needs developer mode on Windows")
+def test_static_serves_symlinked_assets(tmp_path):
+    """End-to-end version of the check above: serve a packaged file that is itself a
+    symlink. Reuses the real mount's follow_symlink setting, so this test fails if
+    api.py ever drops it again instead of only asserting the flag.
+    """
+    from fastapi import FastAPI
+    from fastapi.staticfiles import StaticFiles
+    from fastapi.testclient import TestClient
+
+    follow_symlink = _static_mount().app.follow_symlink
+
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "themes.css").write_text("body {}", encoding="utf-8")
+
+    linked = tmp_path / "static"
+    linked.mkdir()
+    (linked / "themes.css").symlink_to(real / "themes.css")
+
+    app = FastAPI()
+    app.mount(
+        "/static",
+        StaticFiles(directory=str(linked), follow_symlink=follow_symlink),
+        name="static",
+    )
+
+    assert TestClient(app).get("/static/themes.css").status_code == 200
+
+
 def test_public_base_path_rendering():
     assert api._normalize_public_base_path("tokdash/") == "/tokdash"
     assert api._normalize_public_base_path("/") == ""

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -257,13 +257,13 @@ def test_static_mount_follows_symlinks():
 
 @pytest.mark.skipif(os.name == "nt", reason="creating symlinks needs developer mode on Windows")
 def test_static_serves_symlinked_assets(tmp_path):
-    """End-to-end version of the check above: serve a packaged file that is itself a
-    symlink. Reuses the real mount's follow_symlink setting, so this test fails if
-    api.py ever drops it again instead of only asserting the flag.
+    """Resolve a packaged file that is itself a symlink.
+
+    Reuse the real mount's setting so dropping follow_symlink in api.py makes the
+    lookup fail. Avoid TestClient here because synchronous handlers can deadlock
+    with this repository's FastAPI/AnyIO test stack.
     """
-    from fastapi import FastAPI
     from fastapi.staticfiles import StaticFiles
-    from fastapi.testclient import TestClient
 
     follow_symlink = _static_mount().app.follow_symlink
 
@@ -275,14 +275,11 @@ def test_static_serves_symlinked_assets(tmp_path):
     linked.mkdir()
     (linked / "themes.css").symlink_to(real / "themes.css")
 
-    app = FastAPI()
-    app.mount(
-        "/static",
-        StaticFiles(directory=str(linked), follow_symlink=follow_symlink),
-        name="static",
-    )
+    static_files = StaticFiles(directory=str(linked), follow_symlink=follow_symlink)
+    full_path, stat_result = static_files.lookup_path("themes.css")
 
-    assert TestClient(app).get("/static/themes.css").status_code == 200
+    assert full_path == str(linked / "themes.css")
+    assert stat_result is not None
 
 
 def test_public_base_path_rendering():


### PR DESCRIPTION
## Summary

When tokdash is installed in a layout where the files under `tokdash/static/` are **symlinks**, every request under `/static/**` returns `404`. The dashboard shell itself loads fine — its HTML/JS are inlined in `index.html` — so the page renders and only the theme, logo, agent icons and PWA icons are missing. It reads like a cosmetic front-end bug rather than what it is: an install-layout problem in the static mount.

One-line fix: let the `/static` mount follow symlinks.

## Root cause

`src/tokdash/api.py`:

```python
app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
```

Starlette's `StaticFiles` defaults to `follow_symlink=False`. In that mode `lookup_path()` resolves every request with `os.path.realpath()` and then requires the resolved path to stay inside the mount directory:

```python
full_path = os.path.realpath(joined_path)      # -> ~/.cache/uv/archive-v0/<hash>/tokdash/static/themes.css
directory = os.path.realpath(directory)        # -> <site-packages>/tokdash/static
if os.path.commonpath([full_path, directory]) != str(directory):
    continue                                   # out of bounds -> MISS -> 404
```

When the packaged assets are symlinks into the uv cache, `realpath()` resolves the request *out of* `STATIC_DIR`, the `commonpath` guard fails, and **every** file is treated as out of bounds. Hence a blanket 404 under `/static/**`.

Why only `/static/**` is affected: `index.html`, `manifest.webmanifest` and `sw.js` are served by their own routes using `Path.read_bytes()`, which follows symlinks.

Why CI did not catch it: CI installs editable (`pip install -e .`), where the files are real, and the existing static tests only assert `icon_path.exists()`, the middleware's `cache-control` header and the output of `_render_manifest()` — they never issue an HTTP request to `/static/**`.

## Fix

```python
app.mount("/static", StaticFiles(directory=str(STATIC_DIR), follow_symlink=True), name="static")
```

### Why `follow_symlink=True` is the right fix, not a blanket workaround

- Starlette's default is a conservative boundary for directories that may contain **untrusted** symlinks (user uploads, third-party content). tokdash's `static/` ships inside tokdash's own wheel and is served to `127.0.0.1` only, so there is no untrusted symlink source here. `follow_symlink=False` is a mis-fit for this mount, not a security boundary worth keeping.
- Path traversal is still rejected: with `follow_symlink=True` Starlette switches to `os.path.abspath()` and keeps the same `commonpath` guard, so `..` still fails the bounds check.
- Only the symlink layout is affected at all: `clone`/`hardlink`/`copy` all place **real** files in `site-packages`, whose `realpath()` does not escape. Covering the symlink layout therefore costs nothing for the other install modes.
- `follow_symlink` requires starlette >= 0.30, which `fastapi>=0.115.0` already guarantees.

Note: `STATIC_DIR.resolve()` does **not** help. The `static/` directory itself is a real directory; only the files inside it are symlinks, so `.resolve()` changes nothing.

## Tests

```python
def test_static_mount_follows_symlinks():
    assert _static_mount().app.follow_symlink is True


@pytest.mark.skipif(os.name == "nt", reason="creating symlinks needs developer mode on Windows")
def test_static_serves_symlinked_assets(tmp_path):
    # builds a static/ dir whose file is a symlink and reuses the real mount's
    # follow_symlink setting, so it fails if api.py drops it again
    ...
```

The first pins the mount option so it cannot silently regress. The second reproduces the layout end-to-end and reuses the real mount's `follow_symlink` value (rather than hardcoding `True`), so reverting `api.py` makes it fail with a 404 instead of passing vacuously. It is skipped on Windows, where creating symlinks needs developer mode / elevation.

Verified locally: `pytest tests/test_api_smoke.py -q` → 11 passed, 1 skipped (baseline 9 passed, 1 skipped). With `follow_symlink` temporarily reset to the Starlette default, both new tests fail.

## Reproduction

The layout comes from uv's `symlink` link mode (`link-mode = "symlink"` in `uv.toml`, or `UV_LINK_MODE=symlink`), with pipx installed against the uv backend:

```bash
# 1. install: the packaged assets are linked into site-packages instead of copied
pipx install tokdash

# 2. confirm the layout: the asset is a symlink into the uv cache
SP=$(python -c 'import os, tokdash; print(os.path.dirname(tokdash.__file__))')
ls -l "$SP/static/themes.css"        # -> ~/.cache/uv/archive-v0/<hash>/tokdash/static/themes.css

# 3. start tokdash and hit an asset
tokdash serve &
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:55423/static/themes.css   # 404 (before the fix)
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:55423/                    # 200
```

Symlink mode is not an accident or a typo: it avoids keeping two real copies of every package on disk (the uv cache and the environment), which some users care about — for whole-disk backups in particular, real copies double up where symlinks do not. It is one of uv's four supported link modes, so this is a legitimate layout to be installed with, not a broken one.

Directly against the app (`127.0.0.1:55423`) and through a reverse proxy (`location /tokdash/` → `127.0.0.1:55423/`) behave identically, so the proxy is not involved.

## Alternatives considered

Replacing `StaticFiles` with a custom handler that does `Path.read_bytes()` (the way the `manifest.webmanifest` / `sw.js` routes already work). Rejected as the default path: it means re-implementing MIME types, `Range` and `ETag`/`304` by hand for no benefit over a single supported keyword argument.
